### PR TITLE
fix: correct maintainer contact email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ it. Reports of ways to bypass that boundary are taken seriously.
 **Please do not open a public issue for security reports.**
 
 - Preferred: open a private [GitHub security advisory](https://github.com/demetere/pi-hive/security/advisories/new).
-- Alternatively, email **demetre@pleiful.ai** with a description, affected version/commit, and a minimal reproduction.
+- Alternatively, email **demetredzmanashvili@gmail.com** with a description, affected version/commit, and a minimal reproduction.
 
 Please allow a reasonable window for a fix before any public disclosure. There is no
 bug-bounty program; acknowledgement in the release notes is offered for valid reports

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Hierarchical multi-agent orchestration extension for the Pi coding agent, with a live Solid + Vite telemetry dashboard.",
   "type": "module",
-  "author": "Demetre Dzmanashvili <demetre@pleiful.ai>",
+  "author": "Demetre Dzmanashvili <demetredzmanashvili@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/demetere/pi-hive.git"


### PR DESCRIPTION
Corrects the maintainer contact email to `demetredzmanashvili@gmail.com` in the two places it appears:

- `SECURITY.md` — the vulnerability-reporting email
- `package.json` — the `author` field

No functional change. `just verify-package` passes.