### PR TITLE
docs: make the extension pi-installable (valid pi install specs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,26 @@ opposite: **it's config-first, and you own the whole tree.** Nothing runs until
 
 ## Install location & activation
 
-Install from GitHub (recommended):
+Install from GitHub with `pi install` (recommended):
 
 ```sh
-pi install github:demetere/pi-hive
+pi install git:github.com/demetere/pi-hive          # latest main
+pi install git:github.com/demetere/pi-hive@v0.1.0   # pin a tag/commit
 ```
 
-Or install from a local checkout by path:
+`pi install` also accepts the full HTTPS or SSH URL, e.g.
+`pi install https://github.com/demetere/pi-hive` or
+`pi install ssh://git@github.com/demetere/pi-hive`. Pi runs `npm install` for the
+package, so the extension's runtime dependency
+([OpenSpec](https://github.com/Fission-AI/OpenSpec)) is fetched automatically; the
+Pi host packages are declared as peer dependencies and provided by Pi at load time.
 
-```sh
-pi install /path/to/pi-hive
+You can also add it declaratively in Pi's `settings.json`:
+
+```json
+{
+  "packages": ["git:github.com/demetere/pi-hive"]
+}
 ```
 
 For local development, load a checkout temporarily without installing:
@@ -76,7 +86,7 @@ For local development, load a checkout temporarily without installing:
 pi -e .        # from the repository root
 ```
 
-When installed globally, Pi auto-discovers the package for **every** project.
+When installed, Pi auto-discovers the package for **every** project.
 
 For repository-first development, use `just` as the command source of truth:
 


### PR DESCRIPTION
Makes the install instructions actually work with `pi install`, per the [authoritative Pi packages doc](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md).

## The bug
The README told users to run `pi install github:demetere/pi-hive`. Pi does **not** accept the `github:owner/repo` shorthand — that command fails.

## Fix
- Use the valid `git:` spec: `pi install git:github.com/demetere/pi-hive` (with `@v0.1.0` tag/commit pinning).
- Document the accepted HTTPS/SSH URL forms.
- Add a `settings.json` `packages` example for declarative installs.
- Clarify the dependency model: Pi runs `npm install`, so OpenSpec (the sole runtime `dependency`) is fetched automatically; the Pi host packages are `peerDependencies` and injected by Pi at load time.

## No manifest change needed
Verified the package is already installable against the authoritative doc:
- `pi.extensions` declared ✓
- `pi-package` keyword present (gallery-discoverable) ✓
- host packages (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `typebox`) as `peerDependencies` with `"*"` — not bundled ✓
- `@fission-ai/openspec` in `dependencies`; its `.bin/openspec` resolves after a production install (verified by packing + `npm install --omit=dev` in a temp dir) ✓
- `@plannotator/pi-extension` stays a devDependency (only used at build time to vendor `plannotator.html`, which is committed) ✓

Docs-only change.