### PR TITLE
chore: prepare package for npm publish + pi.dev gallery listing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,26 @@ editing.
 - Prefer complete, production-ready changes: no TODO placeholders, no debug logging,
   no unexplained temporary behavior.
 
+## Releasing (maintainers)
+
+`pi-hive` is distributed two ways, and publishing to npm is what lists it in the
+[pi.dev package gallery](https://pi.dev/packages) (the gallery indexes npm packages
+carrying the `pi-package` keyword — there is no separate submission step).
+
+To cut a release:
+
+```sh
+just ci                      # all gates must be green
+npm version <patch|minor>    # bumps package.json + creates a git tag
+git push && git push --tags  # publish the tag (enables git:...@vX.Y.Z pinning)
+npm publish                  # prepublishOnly runs `just prepublish` first
+```
+
+`npm publish` is gated by `prepublishOnly` (`just prepublish`: tests, dashboard
+freshness, and package-manifest verification), so a broken or stale build cannot
+ship. The published tarball ships only the `files` allowlist (runtime code + the
+prebuilt `ui/web/dist/`); dependency folders never ship.
+
 ## Security
 
 Do not report vulnerabilities in public issues or PRs. See

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     ".": "./index.ts"
   },
   "pi": {
-    "extensions": ["./index.ts"]
+    "extensions": ["./index.ts"],
+    "image": "https://raw.githubusercontent.com/demetere/pi-hive/main/docs/assets/dashboard-overview.png"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Preps `pi-hive` to be published to npm, which is what lists it in the [pi.dev package gallery](https://pi.dev/packages) — the gallery indexes npm packages carrying the `pi-package` keyword (already present), with no separate submission step.

## Changes
- **`pi.image`** gallery preview → the committed dashboard screenshot (raw GitHub URL). The gallery renders `pi.image` (PNG/JPEG/GIF/WebP) as the package card preview; a `pi.video` (MP4) can be added later.
- **`publishConfig.access: "public"`** — explicit public publish.
- **CONTRIBUTING**: documented the maintainer release flow (`npm version` → push tag → `npm publish`), noting `prepublishOnly` (`just prepublish`) gates the publish.

## Notes
- The name **`pi-hive` is available on npm** (unscoped), so `pi install npm:pi-hive` will work — no scoping needed.
- No runtime/dependency changes. Host packages stay `peerDependencies` (`*`); OpenSpec stays the sole runtime `dependency`. `just verify-package` passes.
- Actual `npm publish` is intentionally **not** run here — it's a maintainer action tied to the npm account, done after this lands (and after tagging).

Depends conceptually on #3 (valid `pi install` specs) but touches different lines; no conflict.