### PR TITLE
ci: publish to npm on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+# Publishes to npm when a version tag (v*) is pushed. Cut a release with:
+#   npm version <patch|minor|major> && git push --follow-tags
+# The tag must match the package.json version, or the job fails before publishing.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install dashboard dependencies
+        run: cd ui/web && npm ci
+
+      - name: Install just
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl --proto '=https' --tlsv1.2 -LsSf https://just.systems/install.sh | bash -s -- --to "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG"
+            exit 1
+          fi
+          echo "Releasing v$PKG"
+
+      - name: Run release gates
+        run: just ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,19 +94,23 @@ editing.
 [pi.dev package gallery](https://pi.dev/packages) (the gallery indexes npm packages
 carrying the `pi-package` keyword — there is no separate submission step).
 
-To cut a release:
+Releases are **tag-triggered**: pushing a `v*` tag runs
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which re-runs
+`just ci` and then `npm publish --provenance`.
 
 ```sh
-just ci                      # all gates must be green
-npm version <patch|minor>    # bumps package.json + creates a git tag
-git push && git push --tags  # publish the tag (enables git:...@vX.Y.Z pinning)
-npm publish                  # prepublishOnly runs `just prepublish` first
+npm version <patch|minor|major>   # bumps package.json + creates the matching git tag
+git push --follow-tags            # pushes the commit and the tag → triggers Release
 ```
 
-`npm publish` is gated by `prepublishOnly` (`just prepublish`: tests, dashboard
-freshness, and package-manifest verification), so a broken or stale build cannot
-ship. The published tarball ships only the `files` allowlist (runtime code + the
-prebuilt `ui/web/dist/`); dependency folders never ship.
+The workflow fails before publishing if the tag doesn't match `package.json`'s
+version, and `just ci` must pass, so a broken or mistagged build cannot ship. The
+published tarball ships only the `files` allowlist (runtime code + the prebuilt
+`ui/web/dist/`); dependency folders never ship.
+
+**One-time setup:** add an npm **automation** access token as the `NPM_TOKEN`
+repository secret (Settings → Secrets and variables → Actions). Publishing to npm
+is what makes the package appear in the gallery.
 
 ## Security
 


### PR DESCRIPTION
Adds a **tag-triggered** npm release workflow so publishing (and therefore the [pi.dev gallery](https://pi.dev/packages) listing) happens on demand, not on every code change.

## How it works
`.github/workflows/release.yml` fires only on a pushed `v*` tag. It:
1. Sets up Node 24 + Bun + `just` (same as CI).
2. **Guards** that the tag matches `package.json`'s version — fails before publishing on a mismatch.
3. Runs `just ci` (full gate: typecheck, tests, dashboard freshness, package-manifest, pack dry-run).
4. `npm publish --provenance --access public`.

## Cutting a release
```sh
npm version <patch|minor|major>   # bumps package.json + creates the matching tag
git push --follow-tags            # triggers Release
```

## Why tag-triggered (not publish-on-push)
npm versions are immutable — auto-publishing on every merge to `main` would burn versions on doc/test changes and ship unreviewed releases. Tag-triggered keeps you in control of when and what version ships.

## One-time setup (maintainer, not in this PR)
Add an npm **automation** token as the `NPM_TOKEN` repo secret (Settings → Secrets and variables → Actions). Documented in CONTRIBUTING.

## Note on overlap with #4
Both this and #4 add a "Releasing" section to CONTRIBUTING. This PR's version is the complete one (covers the workflow); expect a small merge conflict on that block if #4 lands first — resolve by keeping this PR's section.