### PR TITLE
ci: publish to npm on GitHub Release (not tag push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Release
 
-# Publishes to npm when a version tag (v*) is pushed. Cut a release with:
-#   npm version <patch|minor|major> && git push --follow-tags
-# The tag must match the package.json version, or the job fails before publishing.
+# Publishes to npm when a GitHub Release is published. Cut a release with:
+#   gh release create v0.1.0 --generate-notes
+# The release tag must match the package.json version, or the job fails before
+# publishing.
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -44,12 +46,14 @@ jobs:
           curl --proto '=https' --tlsv1.2 -LsSf https://just.systems/install.sh | bash -s -- --to "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Verify tag matches package.json version
+      - name: Verify release tag matches package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${RELEASE_TAG#v}"
           PKG="$(node -p "require('./package.json').version")"
           if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Tag v$TAG does not match package.json version $PKG"
+            echo "::error::Release tag $RELEASE_TAG does not match package.json version $PKG"
             exit 1
           fi
           echo "Releasing v$PKG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,23 +94,29 @@ editing.
 [pi.dev package gallery](https://pi.dev/packages) (the gallery indexes npm packages
 carrying the `pi-package` keyword — there is no separate submission step).
 
-Releases are **tag-triggered**: pushing a `v*` tag runs
-[`.github/workflows/release.yml`](.github/workflows/release.yml), which re-runs
-`just ci` and then `npm publish --provenance`.
+Releases are triggered by **publishing a GitHub Release**. That runs
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which checks out
+the release tag, re-runs `just ci`, and then `npm publish --provenance`.
 
 ```sh
-npm version <patch|minor|major>   # bumps package.json + creates the matching git tag
-git push --follow-tags            # pushes the commit and the tag → triggers Release
+# 1. Bump the version and push the commit (no tag yet):
+npm version <patch|minor|major> --no-git-tag-version
+git commit -am "chore: release vX.Y.Z" && git push
+
+# 2. Publish a GitHub Release whose tag matches the new version:
+gh release create vX.Y.Z --generate-notes
 ```
 
-The workflow fails before publishing if the tag doesn't match `package.json`'s
-version, and `just ci` must pass, so a broken or mistagged build cannot ship. The
-published tarball ships only the `files` allowlist (runtime code + the prebuilt
-`ui/web/dist/`); dependency folders never ship.
+The release tag (e.g. `v0.1.0`) must match `package.json`'s version, and `just ci`
+must pass, or the workflow fails before publishing — so a broken or mistagged build
+cannot ship. The published tarball ships only the `files` allowlist (runtime code +
+the prebuilt `ui/web/dist/`); dependency folders never ship.
 
-**One-time setup:** add an npm **automation** access token as the `NPM_TOKEN`
-repository secret (Settings → Secrets and variables → Actions). Publishing to npm
-is what makes the package appear in the gallery.
+**One-time setup:** add an npm access token that can publish in CI — a **granular**
+token with "bypass 2FA" enabled, or a classic **automation** token — as the
+`NPM_TOKEN` repository secret (Settings → Secrets and variables → Actions). A plain
+publish token fails with a 403 when the account has 2FA-on-publish enabled.
+Publishing to npm is what makes the package appear in the gallery.
 
 ## Security
 


### PR DESCRIPTION
Switches the release trigger from tag-push to **GitHub Release published**, per the plan to drive releases through the Releases UI (with notes) and to retrigger the v0.1.0 publish after fixing the npm token.

## Changes
- `on: push: tags: ['v*']` → `on: release: types: [published]`.
- Checkout now uses `ref: github.event.release.tag_name` so it builds the released tag's code.
- Version guard reads `github.event.release.tag_name` and still fails before publishing if it doesn't match `package.json`.
- CONTRIBUTING: documented the `gh release create vX.Y.Z --generate-notes` flow and clarified the token requirement (granular "bypass 2FA" or classic automation token — a plain publish token 403s under 2FA-on-publish, which is exactly what the first run hit).

## Why
The initial tag-triggered run passed everything (guard, `just ci`, provenance) and failed only at `npm publish` with `403 — Two-factor authentication or granular access token with bypass 2fa enabled is required`. That's a token-type issue, fixed by swapping the secret's token. This PR also moves to the nicer Release-driven flow so the retrigger is a real GitHub Release.

## After merge
1. Ensure the `NPM_TOKEN` secret holds a bypass-2FA/automation token.
2. `gh release create v0.1.0 --generate-notes` (tag `v0.1.0` already exists) → triggers the publish.