### PR TITLE
fix(tui): guard hive render widths

### DIFF
--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { defineTool } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import type { AgentType, HiveState, ReviewVerdictLevel } from "../core/types";
 import {
@@ -26,8 +26,22 @@ type ToolRenderOptions = { isPartial?: boolean; expanded?: boolean };
 // Structural Component shape. Avoid importing pi-tui's `Component` type: its
 // barrel re-exports it with a `.ts` specifier that tsc (moduleResolution
 // "Bundler") cannot resolve, so `import { type Component }` fails to typecheck.
-function emptyToolRender(): { render: (width: number) => string[]; invalidate: () => void } {
+type ToolRenderComponent = { render: (width: number) => string[]; invalidate: () => void };
+
+function emptyToolRender(): ToolRenderComponent {
   return { render: () => [], invalidate() {} };
+}
+
+function boundedToolRender(lines: string[] | (() => string[]), ellipsis: string): ToolRenderComponent {
+  return {
+    invalidate() {},
+    render(width: number): string[] {
+      const safeWidth = Math.max(0, width - 2);
+      if (safeWidth <= 0) return [];
+      const rendered = typeof lines === "function" ? lines() : lines;
+      return rendered.map((line) => truncateToWidth(line, safeWidth, ellipsis));
+    },
+  };
 }
 
 // Builds pi-hive's five custom tools as plain, reusable ToolDefinition objects
@@ -146,8 +160,11 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
     },
     renderCall(args: unknown, theme: any) {
       const agent = (args as any).agent || "?";
-      const task = String((args as any).task || "");
-      return new Text(theme.fg("toolTitle", theme.bold("delegate_agent ")) + agentColored(agent, theme) + theme.fg("dim", ` — ${task.slice(0, 80)}`), 0, 0);
+      const task = truncateMiddle(String((args as any).task || ""), 500);
+      const line = theme.fg("toolTitle", theme.bold("delegate_agent ")) +
+        agentColored(agent, theme) +
+        theme.fg("dim", task ? ` — ${task}` : "");
+      return boundedToolRender([line], theme.fg("dim", "…"));
     },
     renderResult(result: any, options: ToolRenderOptions, theme: any) {
       const details = result.details as any;
@@ -159,8 +176,11 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
       if (options.isPartial || details?.status === "running") return emptyToolRender();
       const ok = details?.status === "done";
       const header = theme.fg(ok ? "success" : "error", `${ok ? "✓" : "✗"} `) + agentColored(agent, theme) + theme.fg("dim", ` ${Math.round((details?.elapsed || 0) / 1000)}s`);
-      if (options.expanded && details?.outputPreview) return new Text(`${header}\n${theme.fg("muted", truncateMiddle(details.outputPreview, 4000))}`, 0, 0);
-      return new Text(header, 0, 0);
+      if (options.expanded && details?.outputPreview) {
+        const preview = theme.fg("muted", truncateMiddle(details.outputPreview, 4000));
+        return boundedToolRender([header, preview], theme.fg("dim", "…"));
+      }
+      return boundedToolRender([header], theme.fg("dim", "…"));
     },
   }),
 

--- a/src/ui/tui/activity.ts
+++ b/src/ui/tui/activity.ts
@@ -75,7 +75,12 @@ function padToWidth(line: string, width: number): string {
 }
 
 function renderCompactBox(body: string[], width: number, theme: any): string[] {
-  const boxWidth = Math.max(20, Math.min(width, MAX_BOX_WIDTH));
+  // Pi places extension widgets inside an already-indented content region. Keep
+  // a small safety margin so our decorative border never collides with the
+  // terminal edge or draws through the editor/footer on narrow layouts.
+  const safeWidth = Math.max(0, width - 2);
+  if (safeWidth < 8) return [];
+  const boxWidth = Math.min(Math.max(20, safeWidth), MAX_BOX_WIDTH);
   const contentWidth = Math.max(0, boxWidth - 4);
   const title = ` Hive activity `;
   const topPlain = `╭─${title}${"─".repeat(Math.max(0, boxWidth - title.length - 3))}╮`;


### PR DESCRIPTION
## Summary
- make delegate_agent call/result rendering width-aware with a small safety margin
- keep the Hive activity widget box inside the available TUI width

## Verification
- just verify