### PR TITLE
fix(plan): align review approval gate verdicts

### DIFF
--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -57,5 +57,6 @@ ${leadRoster}
 ${routingGuidance}
 - If the user says "plan", "plan first", "spec", "approach", or "don't implement yet", switch to plan mode (or delegate to the planning lead) first and stop for user confirmation before execution.
 - For cross-cutting work, delegate to multiple leads (up to the parallel limit) and let each fan out within its team.
+- Use team_status when deciding whether to resume a lead's existing session or call delegate_agent with fresh=true; context around 75% means consider fresh when continuity is not needed, and around 85% means prefer fresh unless continuity is essential.
 - Synthesize the leads' results into one answer with evidence, risks, and next steps.`;
 }

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -44,6 +44,36 @@ function boundedToolRender(lines: string[] | (() => string[]), ellipsis: string)
   };
 }
 
+function formatTokens(count: number): string {
+  if (!Number.isFinite(count) || count < 0) return "?";
+  if (count < 1000) return Math.round(count).toString();
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1000000) return `${Math.round(count / 1000)}k`;
+  if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
+  return `${Math.round(count / 1000000)}M`;
+}
+
+function formatContextFill(row: { contextPct?: number; contextTokens?: number; contextWindow?: number }): string {
+  const pct = Number(row.contextPct);
+  const pctText = Number.isFinite(pct) ? `${pct.toFixed(1)}%` : "?";
+  const tokens = Number(row.contextTokens);
+  const window = Number(row.contextWindow);
+  const tokenText = Number.isFinite(tokens) && Number.isFinite(window) && window > 0
+    ? ` (${formatTokens(tokens)}/${formatTokens(window)})`
+    : Number.isFinite(window) && window > 0
+      ? ` (of ${formatTokens(window)})`
+      : "";
+  return `${pctText}${tokenText}`;
+}
+
+function contextAdvice(contextPct?: number): "resume-ok" | "consider-fresh" | "fresh-recommended" {
+  const pct = Number(contextPct);
+  if (!Number.isFinite(pct)) return "resume-ok";
+  if (pct >= 85) return "fresh-recommended";
+  if (pct >= 75) return "consider-fresh";
+  return "resume-ok";
+}
+
 // Builds pi-hive's five custom tools as plain, reusable ToolDefinition objects
 // (defineTool() does no registration — it's a pure identity/typing wrapper).
 // The SAME definitions are used for the orchestrator's own pi.registerTool()
@@ -89,7 +119,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
   defineTool({
     name: "team_status",
     label: "Team Status",
-    description: "Return the current hive session, log path, active workers, and per-agent state.",
+    description: "Return the current hive session, log path, active workers, per-agent state, and context-window fill so leads can decide whether to resume or use fresh=true.",
     parameters: Type.Object({}),
     async execute() {
       const rows = Array.from(state.runtimes.values()).map((runtime) => ({
@@ -102,6 +132,10 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         lastWork: runtime.lastWork,
         costUsd: runtime.costUsd,
         tokens: runtime.inputTokens + runtime.outputTokens,
+        contextPct: runtime.contextPct,
+        contextTokens: runtime.contextTokens,
+        contextWindow: runtime.contextWindow,
+        contextAdvice: contextAdvice(runtime.contextPct),
       }));
       const verdicts = Array.from((state.latestVerdicts || new Map()).values());
       const verdictLines = verdicts.length
@@ -112,7 +146,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         `conversation: ${state.session?.conversationLog || "n/a"}`,
         `active_runs: ${state.activeRuns}`,
         "",
-        ...rows.map((row) => `- ${row.agent} [${row.group}] ${row.status}, runs=${row.runs}, tokens=${row.tokens}, cost=$${row.costUsd.toFixed(3)}${row.task ? ` — ${row.task.slice(0, 120)}` : ""}`),
+        ...rows.map((row) => `- ${row.agent} [${row.group}] ${row.status}, runs=${row.runs}, ctx=${formatContextFill(row)} ${row.contextAdvice}, tokens=${row.tokens}, cost=$${row.costUsd.toFixed(3)}${row.task ? ` — ${row.task.slice(0, 120)}` : ""}`),
         ...verdictLines,
       ].join("\n");
       return { content: [{ type: "text", text }], details: { session: state.session, activeRuns: state.activeRuns, agents: rows, verdicts } };
@@ -294,7 +328,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
     typeScopedTools.push(defineTool({
       name: "submit_review_verdict",
       label: "Submit Review Verdict",
-      description: "Submit your FINAL structured review verdict (red/yellow/green). green = clean approval; yellow = approve with non-blocking concerns (proceed, surface them); red = blocked, list blockers. This is how a reviewer reports its conclusion — do not put the verdict only in chat text.",
+      description: "Submit your FINAL structured review verdict (red/yellow/green). green = clean approval; yellow = approve with non-blocking concerns (proceed, surface them); red = blocked, list blockers. Reviewers MUST call this before their final answer; do not put the verdict only in chat text.",
       parameters: Type.Object({
         verdict: Type.Union([Type.Literal("red"), Type.Literal("yellow"), Type.Literal("green")], { description: "red = blocked (populate blockers); yellow = approve with non-blocking concerns; green = clean approval." }),
         summary: Type.String({ description: "One- or two-sentence summary of the review conclusion." }),
@@ -302,7 +336,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         concerns: Type.Optional(Type.Array(Type.String(), { description: "Yellow: non-blocking follow-ups to surface to the human." })),
         blockers: Type.Optional(Type.Array(Type.String(), { description: "Red: must-fix items before proceeding." })),
         changeId: Type.Optional(Type.String({ description: "The change-id under review. Defaults to the active change if one is set." })),
-        artifact: Type.Optional(Type.String({ description: "The OpenSpec artifact under review, e.g. proposal.md, design.md, specs/**/*.md, or tasks.md." })),
+        artifact: Type.Optional(Type.String({ description: "The OpenSpec artifact under review, e.g. proposal.md, design.md, specs/**/*.md, or tasks.md. Required for OpenSpec plan-review gates." })),
       }),
       async execute(_toolCallId: string, params: unknown, _signal: AbortSignal | undefined, _onUpdate: ToolUpdate | undefined, ctx: ExtensionContext) {
         const p = params as { verdict: ReviewVerdictLevel; summary: string; evidence?: string[]; concerns?: string[]; blockers?: string[]; changeId?: string; artifact?: string };

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -128,7 +128,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
       task: Type.String({ description: "Focused task for that agent. Include the exact question and expected output." }),
       fresh: Type.Optional(Type.Boolean({ description: "Start the agent from a clean session, discarding its prior memory. Default false (resume). Use when the previous session is irrelevant or should not influence this task." })),
     }),
-    async execute(_toolCallId: string, params: unknown, _signal: AbortSignal | undefined, onUpdate: ToolUpdate | undefined, ctx: ExtensionContext) {
+    async execute(_toolCallId: string, params: unknown, signal: AbortSignal | undefined, onUpdate: ToolUpdate | undefined, ctx: ExtensionContext) {
       const p = (params || {}) as { agent?: string; task?: string; fresh?: boolean };
       const agent = String(p.agent || "").trim();
       const task = String(p.task || "").trim();
@@ -142,7 +142,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         };
       }
       onUpdate?.({ content: [{ type: "text", text: `Delegating to ${agent}${fresh ? " (fresh session)" : ""}...` }], details: { agent, task, status: "running" } });
-      const result = await dispatchAgent(state, agent, task, ctx, Boolean(fresh));
+      const result = await dispatchAgent(state, agent, task, ctx, Boolean(fresh), undefined, signal);
       // Fire-and-forget memory distillation on success. Non-blocking: the
       // worker's answer returns immediately; the distiller reads a snapshot, so
       // re-delegating the same agent never races it.

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -32,6 +32,11 @@ import { isExecutionGateOpen, isAwaitingHumanApproval, setAgentReviewVerdict, ty
 import { agentRoster, resolveRuntime } from "./agent-lookup";
 import { addHiveActivity } from "../ui/tui/activity";
 
+// Dashboard activity should show reviewer/worker conclusions without confusing
+// middle elision in normal cases. Keep a high hard cap to avoid unbounded shared
+// telemetry rows if an agent accidentally returns a huge dump.
+const DELEGATION_EVENT_MESSAGE_LIMIT = 64_000;
+
 function resolveModel(ctx: ExtensionContext, modelString: string): any {
   const [provider, ...idParts] = modelString.split("/");
   return (ctx as any).modelRegistry?.find(provider, idParts.join("/"));
@@ -97,13 +102,20 @@ export function isPendingArtifactRevisionTask(task: string, pending: ArtifactId)
   return ARTIFACT_TARGET_MARKERS[pending].test(task);
 }
 
+export function inferChangeIdFromReviewTask(task: string): string | null {
+  const pathMatch = task.match(/openspec\/changes\/([a-z0-9]+(?:-[a-z0-9]+)*)\//i);
+  if (pathMatch) return pathMatch[1];
+  const quotedMatch = task.match(/OpenSpec change [`"]([a-z0-9]+(?:-[a-z0-9]+)*)[`"]|change [`"]([a-z0-9]+(?:-[a-z0-9]+)*)[`"]|change\s+([a-z0-9]+(?:-[a-z0-9]+)*)\b/i);
+  return quotedMatch?.[1] || quotedMatch?.[2] || quotedMatch?.[3] || null;
+}
+
 export function inferArtifactFromReviewTask(task: string): ArtifactId | null {
   // Prefer the explicit review target. Review prompts often contain negative
   // scope clauses like "Do not consider design/specs/tasks"; a plain keyword
   // scan would otherwise tag a proposal review as tasks/specs/design.
   if (/\breview\s+only\s+the\s+requirements\s+gate\b/i.test(task)) return null;
   const explicit = task.match(/\breview\s+only\s+the\s+(proposal|design|specs?|tasks)\s+gate\b/i);
-  if (explicit) return explicit[1].toLowerCase().replace(/s$/, "s") as ArtifactId;
+  if (explicit) return explicit[1].toLowerCase().startsWith("spec") ? "specs" : (explicit[1].toLowerCase() as ArtifactId);
 
   const pathMatch = task.match(/openspec\/changes\/[^\s`'"]+\/((?:proposal|design|tasks)\.md|specs\/[^\s`'"]+|specs\/\*\*\/\*\.md)/i);
   if (pathMatch) return pathMatch[1].startsWith("specs/") ? "specs" : (pathMatch[1].replace(/\.md$/i, "") as ArtifactId);
@@ -249,6 +261,7 @@ export async function dispatchAgent(
   const skillPaths = resolveWorkerSkillPaths(ctx.cwd, runtime.config.skills as unknown[]);
 
   const chunks: string[] = [];
+  let streamedSnapshot = "";
   const sessionManager = SessionManager.open(runtime.sessionFile);
 
   const { session } = await createSession({
@@ -348,10 +361,18 @@ export async function dispatchAgent(
   const unsubscribe = session.subscribe((event: any) => {
     if (event.type === "message_update") {
       const delta = event.assistantMessageEvent;
-      const text = delta?.delta || delta?.text || "";
-      if (delta?.type === "text_delta" && text) {
-        chunks.push(text);
-        const last = chunks.join("").split("\n").filter((line: string) => line.trim()).pop();
+      if (delta?.type === "text_delta") {
+        // The documented SDK contract exposes incremental text on `delta`. Some
+        // event shapes also carry `text`/`message` as the full accumulated
+        // snapshot; appending that snapshot duplicates every prefix in the final
+        // worker result (e.g. "P", "Pl", "Ple" as separate lines in the TUI).
+        // Keep snapshots only for live status/fallback output, never as chunks.
+        const deltaText = typeof delta.delta === "string" ? delta.delta : "";
+        if (deltaText) chunks.push(deltaText);
+        const snapshot = textFromMessage(event.message) || (typeof delta.text === "string" ? delta.text : "");
+        if (snapshot) streamedSnapshot = snapshot;
+        const live = chunks.length ? chunks.join("") : streamedSnapshot;
+        const last = live.split("\n").filter((line: string) => line.trim()).pop();
         if (last) runtime.lastWork = last;
       }
     } else if (event.type === "tool_execution_start") {
@@ -469,7 +490,7 @@ export async function dispatchAgent(
       const last = [...messages].reverse().find((message: any) => message.role === "assistant");
       // Keep the chunks fallback for output text; the usage-add block that used
       // to live here is deleted (double-count fix, Decision 1).
-      if (last && !chunks.length) chunks.push(textFromMessage(last));
+      if (last && !chunks.length && !streamedSnapshot) chunks.push(textFromMessage(last));
     }
     publishRuntimeUpdate(state);
     writeHiveStateSnapshot(state);
@@ -570,12 +591,13 @@ export async function dispatchAgent(
   session.dispose();
   runtime.session = undefined;
 
-  const output = chunks.join("").trim() || errorMessage || "[no output]";
+  const output = chunks.join("").trim() || streamedSnapshot.trim() || errorMessage || "[no output]";
   runtime.lastWork = output.split("\n").filter((line) => line.trim()).pop() || runtime.status;
-  // The shared log keeps only a bounded summary of the result — the full
-  // output is returned to the caller and persisted in this agent's own
-  // transcript (agents/<slug>.jsonl). Logging the whole thing here is what
-  // turned the shared log into a multi-hundred-KB-per-line firehose.
+  // The shared log keeps a bounded copy of the result for the dashboard. The
+  // cap is intentionally high enough that normal review verdicts are not
+  // middle-elided in the web UI, while still protecting the shared telemetry log
+  // from accidental multi-hundred-KB rows.
+  const completionMessage = truncateMiddle(output, DELEGATION_EVENT_MESSAGE_LIMIT);
   const completion = {
     from: runtime.config.name,
     // The real delegation parent: the ALS caller (A6). For top-level
@@ -583,7 +605,7 @@ export async function dispatchAgent(
     // delegations now record the truthful parent instead of a hardcoded root.
     to: caller,
     type: runtime.status,
-    message: truncateMiddle(output, 2_000),
+    message: completionMessage,
     costUsd: runtime.costUsd,
     inputTokens: runtime.inputTokens,
     outputTokens: runtime.outputTokens,
@@ -607,8 +629,13 @@ export async function dispatchAgent(
     reasoningTokens: nonneg(runtime.reasoningTokens - (runtime.runStartReasoningTokens ?? 0)),
     costUsd: nonneg(runtime.costUsd - (runtime.runStartCostUsd ?? 0)),
   };
-  if (state.mode === "plan" && runtime.config.agentType === "reviewer") {
-    const changeId = currentChangeId() || state.activeChangeId || "";
+  if (runtime.config.agentType === "reviewer") {
+    // Persist per-artifact reviewer clearance whenever a review prompt is
+    // explicit enough to identify its target. Some dashboard-triggered review
+    // turns can run without plan-mode ambient state after a session restore; in
+    // that case, derive the change id from the OpenSpec paths in the task so the
+    // Plans UI does not reject a freshly PASSed artifact as "not ready".
+    const changeId = currentChangeId() || state.activeChangeId || inferChangeIdFromReviewTask(task) || "";
     const artifact = inferArtifactFromReviewTask(task);
     const verdict = inferReviewVerdict(output);
     if (changeId && artifact && verdict) setAgentReviewVerdict(ctx.cwd, changeId, artifact, verdict, runtime.config.name);
@@ -616,7 +643,7 @@ export async function dispatchAgent(
 
   emitHiveEvent(state, "delegation_end", {
     ...completion,
-    truncated: output.length > 2_000,
+    truncated: output.length > DELEGATION_EVENT_MESSAGE_LIMIT,
     exitCode,
     stopReason: lastStopReason,
     errorMessage: errorMessage ? truncateMiddle(errorMessage, 500) : undefined,
@@ -678,12 +705,17 @@ export async function runDistillerProcess(state: HiveState, ctx: ExtensionContex
   });
 
   const chunks: string[] = [];
+  let streamedSnapshot = "";
   session.subscribe((event: any) => {
     if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
-      chunks.push(event.assistantMessageEvent.delta || event.assistantMessageEvent.text || "");
+      const delta = event.assistantMessageEvent;
+      const deltaText = typeof delta.delta === "string" ? delta.delta : "";
+      if (deltaText) chunks.push(deltaText);
+      const snapshot = textFromMessage(event.message) || (typeof delta.text === "string" ? delta.text : "");
+      if (snapshot) streamedSnapshot = snapshot;
     } else if (event.type === "agent_end") {
       const last = [...(event.messages || [])].reverse().find((m: any) => m.role === "assistant");
-      if (last && !chunks.length) chunks.push(textFromMessage(last));
+      if (last && !chunks.length && !streamedSnapshot) chunks.push(textFromMessage(last));
     }
   });
 
@@ -694,7 +726,7 @@ export async function runDistillerProcess(state: HiveState, ctx: ExtensionContex
   } finally {
     session.dispose();
   }
-  return chunks.join("").trim();
+  return chunks.join("").trim() || streamedSnapshot.trim();
 }
 
 export async function distillMentalModel(state: HiveState, ctx: ExtensionContext, runtime: AgentRuntime): Promise<void> {

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -97,11 +97,27 @@ export function isPendingArtifactRevisionTask(task: string, pending: ArtifactId)
   return ARTIFACT_TARGET_MARKERS[pending].test(task);
 }
 
-function inferArtifactFromReviewTask(task: string): ArtifactId | null {
-  for (const id of ["tasks", "specs", "design", "proposal"] as const) {
-    if (ARTIFACT_TARGET_MARKERS[id].test(task)) return id;
+export function inferArtifactFromReviewTask(task: string): ArtifactId | null {
+  // Prefer the explicit review target. Review prompts often contain negative
+  // scope clauses like "Do not consider design/specs/tasks"; a plain keyword
+  // scan would otherwise tag a proposal review as tasks/specs/design.
+  if (/\breview\s+only\s+the\s+requirements\s+gate\b/i.test(task)) return null;
+  const explicit = task.match(/\breview\s+only\s+the\s+(proposal|design|specs?|tasks)\s+gate\b/i);
+  if (explicit) return explicit[1].toLowerCase().replace(/s$/, "s") as ArtifactId;
+
+  const pathMatch = task.match(/openspec\/changes\/[^\s`'"]+\/((?:proposal|design|tasks)\.md|specs\/[^\s`'"]+|specs\/\*\*\/\*\.md)/i);
+  if (pathMatch) return pathMatch[1].startsWith("specs/") ? "specs" : (pathMatch[1].replace(/\.md$/i, "") as ArtifactId);
+
+  const positiveText = task
+    .split(/(?<=[.!?])\s+|\n+/)
+    .filter((sentence) => !/\bdo not\b|\bdon't\b|\bno\s+(?:design|specs|tasks|proposal)\b/i.test(sentence))
+    .join("\n");
+  let best: { id: ArtifactId; index: number } | null = null;
+  for (const id of ["proposal", "design", "specs", "tasks"] as const) {
+    const match = positiveText.match(ARTIFACT_TARGET_MARKERS[id]);
+    if (match?.index != null && (!best || match.index < best.index)) best = { id, index: match.index };
   }
-  return null;
+  return best?.id ?? null;
 }
 
 function inferReviewVerdict(output: string): Exclude<AgentReviewVerdict, null> | null {

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -133,6 +133,7 @@ function inferReviewVerdict(output: string): Exclude<AgentReviewVerdict, null> |
 export async function dispatchAgent(
   state: HiveState, agentName: string, task: string, ctx: ExtensionContext, fresh = false,
   createSession: CreateAgentSession = createAgentSession,
+  abortSignal?: AbortSignal,
 ): Promise<{ output: string; exitCode: number; elapsed: number }> {
   if (!state.config || !state.session) throw new Error("hive is not initialized");
   const caller = currentAgentName();
@@ -261,6 +262,16 @@ export async function dispatchAgent(
     resourceLoader: workerResourceLoader(state, ctx.cwd, runtime.config.name, skillPaths),
   });
   runtime.session = session;
+
+  let abortedByParent = false;
+  const abortWorker = (): void => {
+    abortedByParent = true;
+    runtime.lastWork = "cancelling";
+    addHiveActivity(state, { kind: "delegation_end", parent: caller, agent: runtime.config.name, status: "error", text: "cancel requested" });
+    void session.abort?.().catch((): undefined => undefined);
+  };
+  if (abortSignal?.aborted) abortWorker();
+  else abortSignal?.addEventListener("abort", abortWorker, { once: true });
 
   // Authoritative per-model thinking levels for this worker's effective model.
   // This is the SDK's own answer — no ModelRegistry plumbing needed (A10).
@@ -483,8 +494,9 @@ export async function dispatchAgent(
     // unless a more specific one is set. state.activeChangeId is the persistent
     // selection; currentChangeId() carries an already-scoped value into nesting.
     const scopedChangeId = currentChangeId() ?? state.activeChangeId;
+    if (abortedByParent) throw new Error("aborted");
     await runAsAgent(runtime.config.name, () => runWithChange(scopedChangeId, () => session.prompt(task)));
-    errorMessage = session.state.errorMessage;
+    errorMessage = abortedByParent ? "aborted" : session.state.errorMessage;
     // The 1s timer polls this too, but relying on it alone can miss the final,
     // most accurate reading if the last tick landed moments before completion.
     // Refresh the raw tokens/window alongside the percent (Phase 4.7) so the
@@ -548,6 +560,7 @@ export async function dispatchAgent(
     }
   } catch { /* keep incremental values if stats is unavailable */ }
 
+  abortSignal?.removeEventListener("abort", abortWorker);
   unsubscribe();
   if (runtime.timer) clearInterval(runtime.timer);
   runtime.elapsedMs = runtime.startedAt ? Date.now() - runtime.startedAt : runtime.elapsedMs;

--- a/src/engine/prompts.ts
+++ b/src/engine/prompts.ts
@@ -25,7 +25,7 @@ export function buildOperatingContract(runtime: AgentRuntime): string {
       lines.push("You are a **tester**. You write tests, not production code. You do not write spec files or issue verdicts.");
       break;
     case "reviewer":
-      lines.push("You are a **reviewer**. You are read-only: you may run inspection and test commands but must not modify files. Submit your final verdict with `submit_review_verdict` (red/yellow/green) and include the reviewed artifact when known (for example `tasks.md`, `design.md`, or `specs/**/*.md`) — not as chat text. A red verdict unlocks same-artifact revision; green/yellow marks it ready for human UI review.");
+      lines.push("You are a **reviewer**. You are read-only: you may run inspection and test commands but must not modify files. Before your final answer, you MUST call `submit_review_verdict` with your red/yellow/green verdict and include the reviewed OpenSpec artifact when known (for example `proposal.md`, `design.md`, `specs/**/*.md`, or `tasks.md`). Do not rely on chat text like PASS/FAIL as the gate signal. A red verdict unlocks same-artifact revision; green/yellow marks it ready for human UI review.");
       break;
     case "lead": {
       lines.push("You are a **lead**. You delegate and coordinate; you do not modify files (all edits go through your coder/tester reports).");
@@ -58,7 +58,7 @@ export function buildWorkerPrompt(state: HiveState, ctx: ExtensionContext, runti
   // Only leads (agents with reports) get delegation guidance; a leaf worker has
   // no reports and needs no paragraph about them.
   const delegationScope = reports.length
-    ? `\nNested delegation: You lead a team. Your direct reports are: ${reports.join(", ")}. When a task should reach them (e.g. it asks you to fan work out, propagate something downstream, or it needs their specialist judgment), you MUST actually call delegate_agent for each relevant report and wait for their real answers — do NOT describe, assume, or fabricate what they would say. Only answer directly for work that is genuinely yours alone and does not involve your reports. Then synthesize their actual responses into your final answer.`
+    ? `\nNested delegation: You lead a team. Your direct reports are: ${reports.join(", ")}. When a task should reach them (e.g. it asks you to fan work out, propagate something downstream, or it needs their specialist judgment), you MUST actually call delegate_agent for each relevant report and wait for their real answers — do NOT describe, assume, or fabricate what they would say. Only answer directly for work that is genuinely yours alone and does not involve your reports. Then synthesize their actual responses into your final answer. Before reusing a busy or long-lived report, call team_status and check its ctx percentage: resume by default for continuity, consider fresh=true around 75%+ when old context is not needed, and prefer fresh=true around 85%+ unless continuity is essential.`
     : "";
   const knowledgeContext = renderKnowledgeRefs(ctx, "Context and mental model", runtime.config.context);
   const domain = renderDomainScopes(runtime.config.domain);

--- a/src/observability/server/plan-routes.ts
+++ b/src/observability/server/plan-routes.ts
@@ -47,15 +47,17 @@ export interface PlanDetail {
   verdicts: ReturnType<typeof listVerdicts>;
 }
 
-// The reviewer AGENT's standing verdict for a change (its most recent non-"ui"
-// verdict). Change-level, but with the per-artifact hard stop only one artifact
-// is under review at a time, so a standing agent green means "the agent has
-// cleared the artifact currently up for human review".
-function agentClearedChange(cwd: string, changeId: string): boolean {
+// The reviewer AGENT's standing verdict for an artifact. The sidecar is the
+// source of truth for new reviews because it is keyed by artifact and readable
+// by the core dispatch gate. Fall back to old change-level SQLite verdicts only
+// when no sidecar agent-review state exists at all (legacy sessions).
+function agentClearedArtifact(cwd: string, changeId: string, artifact: string): boolean {
+  const sidecarVerdict = openspec.agentReviewVerdict(cwd, changeId, artifact);
+  if (sidecarVerdict) return sidecarVerdict === "green" || sidecarVerdict === "yellow";
+  if (Object.keys(openspec.readAgentReviewLedger(cwd, changeId)).length > 0) return false;
+
   const verdicts = listVerdicts(changeId, cwd).filter((v) => v.reviewer !== "ui");
   if (!verdicts.length) return false;
-  // listVerdicts is newest-first; the latest agent verdict must be green/yellow
-  // (not red) to count as cleared.
   return verdicts[0].verdict === "green" || verdicts[0].verdict === "yellow";
 }
 
@@ -64,14 +66,14 @@ export function planDetail(cwd: string, changeId: string): PlanDetail | null {
   const detail = openspec.changeDetail(cwd, changeId);
   if (!detail) return null;
   const validation = openspec.validate(cwd, changeId);
-  const agentCleared = agentClearedChange(cwd, changeId);
   const artifactReview: ArtifactReview[] = detail.artifacts.map((a) => {
     const authored = a.status === "done";
     const humanVerdict = openspec.artifactVerdict(cwd, changeId, a.id);
+    const agentCleared = authored && agentClearedArtifact(cwd, changeId, a.id);
     return {
       id: a.id,
       authored,
-      agentCleared: authored && agentCleared,
+      agentCleared,
       humanVerdict,
       humanReviewReady: authored && agentCleared && humanVerdict !== "green",
     };

--- a/src/observability/server/review-wiring.ts
+++ b/src/observability/server/review-wiring.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { handleReviewSurface, registerReviewSurface, renderReviewInput, type ReviewContext, type ReviewInput, type ReviewSurface } from "../../engine/review";
 import { parseRid } from "../../engine/review";
 import * as openspec from "../../engine/openspec";
-import { insertPlanVerdict } from "./db";
+import { insertPlanVerdict, listVerdicts } from "./db";
 import { enqueueDashboardAction, resolveProjectCwd } from "./plan-bridge";
 
 // Bun-side wiring for the self-hosted Plannotator plan-review surface. Builds the
@@ -28,6 +28,22 @@ function recordVerdict(ctx: ReviewContext, verdict: "green" | "red", feedback: s
   });
 }
 
+function latestAgentVerdict(ctx: ReviewContext): openspec.AgentReviewVerdict {
+  const sidecarVerdict = openspec.agentReviewVerdict(ctx.cwd, ctx.change, ctx.artifact);
+  if (sidecarVerdict) return sidecarVerdict;
+
+  // If any structured per-artifact review state exists, absence for THIS
+  // artifact is meaningful: do not fall back to a change-level SQLite verdict
+  // from another artifact. That mismatch is what made proposal approval look
+  // available and then reject in the live session.
+  if (Object.keys(openspec.readAgentReviewLedger(ctx.cwd, ctx.change)).length > 0) return null;
+
+  // Older reviewer flows may have only persisted a change-level SQLite verdict.
+  // Use it only for fully legacy changes with no sidecar agent-review state.
+  const verdict = listVerdicts(ctx.change, ctx.cwd).find((v) => v.reviewer !== "ui")?.verdict;
+  return verdict === "green" || verdict === "yellow" || verdict === "red" ? verdict : null;
+}
+
 const surface: ReviewSurface | null = registerReviewSurface({
   mountPath: PLAN_REVIEW_MOUNT,
   hooks: {
@@ -40,18 +56,20 @@ const surface: ReviewSurface | null = registerReviewSurface({
     },
     onApprove(ctx, input) {
       const feedback = renderReviewInput(input);
-      const agentVerdict = openspec.agentReviewVerdict(ctx.cwd, ctx.change, ctx.artifact);
+      const agentVerdict = latestAgentVerdict(ctx);
       if (agentVerdict !== "green" && agentVerdict !== "yellow") {
         const gateFeedback = agentVerdict === "red"
           ? "Automated plan reviewer marked this artifact RED. Revise it before human approval."
           : "Automated plan reviewer has not marked this artifact ready for human approval yet.";
-        recordVerdict(ctx, "red", gateFeedback);
+        // This is NOT a human rejection of the artifact; it is an invalid/early
+        // approve attempt. Do not persist a red UI verdict and do not route it as
+        // planner revision feedback, or the live session falsely says the human
+        // rejected the plan.
         enqueueDashboardAction(ctx.cwd, {
-          type: "plan_review_denied",
+          type: "plan_review_not_ready",
           changeId: ctx.change,
           artifact: ctx.artifact,
           feedback: gateFeedback,
-          annotationCount: 0,
         });
         return;
       }

--- a/src/ui/tui/widget.ts
+++ b/src/ui/tui/widget.ts
@@ -88,6 +88,8 @@ function startDashboardActionPoller(state: HiveState, ctx: ExtensionContext) {
           state.pi.sendUserMessage(action.feedback ? `${next}\n\nReviewer note:\n${action.feedback}` : next);
         } else if (action.type === "plan_review_denied" && action.changeId) {
           state.pi.sendUserMessage(`The plan-review UI rejected the ${action.artifact || "artifact"} for change "${action.changeId}":\n\n${action.feedback || "(no feedback given)"}\n\nRevise that artifact with the planning team, then re-submit it for review before continuing.`);
+        } else if (action.type === "plan_review_not_ready" && action.changeId) {
+          state.pi.sendUserMessage(`The plan-review UI could not approve the ${action.artifact || "artifact"} for change "${action.changeId}" yet:\n\n${action.feedback || "Automated plan reviewer has not marked this artifact ready for human approval yet."}\n\nRun or wait for the automated reviewer to clear this artifact before approving it.`);
         } else if (action.type === "question" && action.question) {
           // WS-D: a delegated planner promoted a clarifying question to the main
           // session. Surface it to the human (inline dialog when we have a UI),

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { dispatchAgent, inferArtifactFromReviewTask, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, type CreateAgentSession } from "../src/engine/dispatch.ts";
+import { dispatchAgent, inferArtifactFromReviewTask, inferChangeIdFromReviewTask, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, type CreateAgentSession } from "../src/engine/dispatch.ts";
 import { restoreRuntimeCounters } from "../src/engine/session.ts";
 import type { AgentRuntime, HiveState } from "../src/core/types.ts";
 
@@ -35,8 +35,15 @@ test("pending artifact revision tasks may bypass the human-review authoring hold
 
 test("review artifact inference ignores negative scope clauses", () => {
   assert.equal(inferArtifactFromReviewTask("Review ONLY the proposal gate. Do not consider design/specs/tasks."), "proposal");
+  assert.equal(inferArtifactFromReviewTask("Review ONLY the specs gate for OpenSpec change `integrate-front-window-registration-workspace-frontend`."), "specs");
+  assert.equal(inferArtifactFromReviewTask("Review ONLY the spec gate for OpenSpec change `integrate-front-window-registration-workspace-frontend`."), "specs");
   assert.equal(inferArtifactFromReviewTask("Review ONLY the requirements gate before design. Do not modify files."), null);
   assert.equal(inferArtifactFromReviewTask("Audit `openspec/changes/add-auth/proposal.md` for readiness. Do not consider design/specs/tasks."), "proposal");
+});
+
+test("review change inference uses explicit OpenSpec change references", () => {
+  assert.equal(inferChangeIdFromReviewTask("Review ONLY the specs gate for OpenSpec change `integrate-front-window-registration-workspace-frontend`."), "integrate-front-window-registration-workspace-frontend");
+  assert.equal(inferChangeIdFromReviewTask("Inputs: `openspec/changes/add-auth/specs/auth/spec.md`"), "add-auth");
 });
 
 test("resolveWorkerSkillPaths flattens skill refs so delegate setup never passes objects to path.resolve", () => {
@@ -82,6 +89,49 @@ function scriptedSession(opts: {
     dispose() { /* noop */ },
   };
 }
+
+test("dispatchAgent treats message_update.text as snapshot, not appended delta", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-snapshot-"));
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  const state: HiveState = {
+    pi: {} as any,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md" },
+      agents: [worker.config],
+      sharedContext: [],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 2, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    } as any,
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: join(dir, "e.jsonl") },
+    runtimes: new Map([["builder", worker]]),
+    widgetCtx: null, activeRuns: 0, mode: "hive", normalToolNames: [],
+    sddStatus: null, obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: () => ({ provider: "test", id: "model" }) } } as any;
+  let handler: ((e: any) => void) | undefined;
+  const create: CreateAgentSession = (async () => ({ session: {
+    subscribe(cb: (e: any) => void): () => void { handler = cb; return () => { handler = undefined; }; },
+    getAvailableThinkingLevels(): string[] { return ["off"]; },
+    getContextUsage(): { percent: number } { return { percent: 0 }; },
+    getSessionStats(): any { return { tokens: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 }, cost: { total: 0 } }; },
+    state: { errorMessage: undefined },
+    async prompt(): Promise<void> {
+      for (const text of ["- P", "- Pl", "- Please approve"]) {
+        handler?.({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", text },
+          message: { role: "assistant", content: [{ type: "text", text }] },
+        });
+      }
+      handler?.({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "- Please approve" }] }] });
+    },
+    dispose(): void { /* noop */ },
+  } } as any)) as any;
+
+  const result = await dispatchAgent(state, "Builder", "review", ctx, false, create);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output, "- Please approve");
+});
 
 test("dispatchAgent abort signal cancels the worker session", async () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-hive-abort-"));

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -83,6 +83,48 @@ function scriptedSession(opts: {
   };
 }
 
+test("dispatchAgent abort signal cancels the worker session", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-abort-"));
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  const state: HiveState = {
+    pi: {} as any,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md" },
+      agents: [worker.config],
+      sharedContext: [],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 2, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    } as any,
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: join(dir, "e.jsonl") },
+    runtimes: new Map([["builder", worker]]),
+    widgetCtx: null, activeRuns: 0, mode: "hive", normalToolNames: [],
+    sddStatus: null, obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: () => ({ provider: "test", modelId: "model" }) } } as any;
+  const controller = new AbortController();
+  let abortCalled = false;
+  let releasePrompt: (() => void) | undefined;
+  const create: CreateAgentSession = (async () => ({ session: {
+    subscribe(): () => void { return () => undefined; },
+    getAvailableThinkingLevels(): string[] { return ["off"]; },
+    getContextUsage(): { percent: number } { return { percent: 0 }; },
+    getSessionStats(): any { return { tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, cost: { total: 0 } }; },
+    state: { errorMessage: undefined },
+    async prompt(): Promise<void> { await new Promise<void>((resolve) => { releasePrompt = resolve; }); },
+    async abort(): Promise<void> { abortCalled = true; releasePrompt?.(); },
+    dispose(): void { /* noop */ },
+  } } as any)) as any;
+
+  const resultPromise = dispatchAgent(state, "Builder", "build slowly", ctx, false, create, controller.signal);
+  await new Promise((resolve) => setImmediate(resolve));
+  controller.abort();
+  const result = await resultPromise;
+
+  assert.equal(abortCalled, true);
+  assert.equal(result.exitCode, 1);
+  assert.match(result.output, /aborted/);
+  assert.equal(state.activeRuns, 0);
+});
+
 test("dispatchAgent totals equal getSessionStats exactly — no message_end/agent_end double-count (L1)", async () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-hive-dispatch-"));
   const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { dispatchAgent, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, type CreateAgentSession } from "../src/engine/dispatch.ts";
+import { dispatchAgent, inferArtifactFromReviewTask, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, type CreateAgentSession } from "../src/engine/dispatch.ts";
 import { restoreRuntimeCounters } from "../src/engine/session.ts";
 import type { AgentRuntime, HiveState } from "../src/core/types.ts";
 
@@ -31,6 +31,12 @@ test("pending artifact revision tasks may bypass the human-review authoring hold
   assert.equal(isPendingArtifactRevisionTask("Author the next artifact (tasks) with the planning team", "tasks"), false);
   assert.equal(isPendingArtifactRevisionTask("Continue planning after human approval", "tasks"), false);
   assert.equal(isPendingArtifactRevisionTask("Spec reviewer failed. Revise specs/front-window/spec.md", "specs"), true);
+});
+
+test("review artifact inference ignores negative scope clauses", () => {
+  assert.equal(inferArtifactFromReviewTask("Review ONLY the proposal gate. Do not consider design/specs/tasks."), "proposal");
+  assert.equal(inferArtifactFromReviewTask("Review ONLY the requirements gate before design. Do not modify files."), null);
+  assert.equal(inferArtifactFromReviewTask("Audit `openspec/changes/add-auth/proposal.md` for readiness. Do not consider design/specs/tasks."), "proposal");
 });
 
 test("resolveWorkerSkillPaths flattens skill refs so delegate setup never passes objects to path.resolve", () => {

--- a/tests/plan-server.spec.ts
+++ b/tests/plan-server.spec.ts
@@ -3,7 +3,7 @@
 // Run: bun test ./tests/plan-server.spec.ts
 import { expect, test, beforeAll } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -22,6 +22,9 @@ function osx(args: string[]) {
 
 let routes: typeof import("../src/observability/server/plan-routes");
 let bridge: typeof import("../src/observability/server/plan-bridge");
+let review: typeof import("../src/observability/server/review-wiring");
+let db: typeof import("../src/observability/server/db");
+let openspec: typeof import("../src/engine/openspec");
 
 beforeAll(async () => {
   if (OSX) {
@@ -37,6 +40,9 @@ beforeAll(async () => {
   }
   routes = await import("../src/observability/server/plan-routes");
   bridge = await import("../src/observability/server/plan-bridge");
+  review = await import("../src/observability/server/review-wiring");
+  db = await import("../src/observability/server/db");
+  openspec = await import("../src/engine/openspec");
 });
 
 test.if(OSX)("listPlans returns OpenSpec change summaries", () => {
@@ -70,4 +76,96 @@ test("resolveProjectCwd rejects an unknown cwd and echoes a known one", () => {
   const fallback = bridge.resolveProjectCwd(null);
   expect(typeof fallback).toBe("string");
   expect(bridge.resolveProjectCwd(fallback)).toBe(fallback);
+});
+
+async function approveProposal(changeId: string, activeProject: string) {
+  const rid = encodeURIComponent(`${changeId}#proposal.md`);
+  const cwd = encodeURIComponent(activeProject);
+  const req = new Request("http://127.0.0.1:43191/api/approve", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      referer: `http://127.0.0.1:43191/pl-review/?rid=${rid}&cwd=${cwd}`,
+    },
+    body: JSON.stringify({ feedback: "looks good" }),
+  });
+  return review.handlePlanReview(req, new URL(req.url));
+}
+
+test("review approval honors legacy SQLite-only agent verdicts", async () => {
+  const activeProject = bridge.resolveProjectCwd(null)!;
+  const changeId = "legacy-agent-green";
+  const dir = join(activeProject, "openspec", "changes", changeId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "proposal.md"), "# Legacy agent green\n\nReady.\n");
+  db.insertPlanVerdict({
+    id: "legacy-agent-green-verdict",
+    changeId,
+    reviewer: "Plan Reviewer",
+    verdict: "green",
+    summary: "ready for human review",
+    cwd: activeProject,
+    createdAt: new Date().toISOString(),
+  });
+
+  try {
+    const res = await approveProposal(changeId, activeProject);
+    expect(res?.status).toBe(200);
+    expect(openspec.artifactVerdict(activeProject, changeId, "proposal.md")).toBe("green");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("review approval does not borrow SQLite verdicts when sidecar targets another artifact", async () => {
+  const activeProject = bridge.resolveProjectCwd(null)!;
+  const changeId = "sidecar-mismatch";
+  const dir = join(activeProject, "openspec", "changes", changeId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "proposal.md"), "# Sidecar mismatch\n\nReady.\n");
+  db.insertPlanVerdict({
+    id: "sidecar-mismatch-green-verdict",
+    changeId,
+    reviewer: "Plan Reviewer",
+    verdict: "green",
+    summary: "change-level green should not clear proposal when sidecar exists for tasks",
+    cwd: activeProject,
+    createdAt: new Date().toISOString(),
+  });
+  openspec.setAgentReviewVerdict(activeProject, changeId, "tasks", "green", "Plan Reviewer");
+
+  try {
+    const res = await approveProposal(changeId, activeProject);
+    expect(res?.status).toBe(200);
+    expect(openspec.artifactVerdict(activeProject, changeId, "proposal.md")).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test.if(OSX)("planDetail does not show review-now for artifacts missing sidecar verdicts", () => {
+  const changeId = "sidecar-mismatch-detail";
+  osx(["new", "change", changeId]);
+  const dir = join(PROJECT, "openspec", "changes", changeId);
+  writeFileSync(join(dir, "proposal.md"), "# Sidecar mismatch detail\n\nReady.\n");
+  db.insertPlanVerdict({
+    id: "sidecar-mismatch-detail-green-verdict",
+    changeId,
+    reviewer: "Plan Reviewer",
+    verdict: "green",
+    summary: "legacy change-level green",
+    cwd: PROJECT,
+    createdAt: new Date().toISOString(),
+  });
+  openspec.setAgentReviewVerdict(PROJECT, changeId, "tasks", "green", "Plan Reviewer");
+
+  try {
+    const detail = routes.planDetail(PROJECT, changeId)!;
+    const proposal = detail.artifactReview.find((a) => a.id === "proposal")!;
+    expect(proposal.authored).toBe(true);
+    expect(proposal.agentCleared).toBe(false);
+    expect(proposal.humanReviewReady).toBe(false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/verdicts.test.ts
+++ b/tests/verdicts.test.ts
@@ -97,3 +97,20 @@ test("team_status surfaces the latest verdict", async () => {
   assert.match(res.content[0].text, /latest verdicts:/);
   assert.match(res.content[0].text, /add-auth: GREEN by Rev/);
 });
+
+test("team_status surfaces context fill and fresh/resume advice", async () => {
+  const builder = runtime("Builder", { agentType: "coder" });
+  builder.contextPct = 86.25;
+  builder.contextTokens = 172_500;
+  builder.contextWindow = 200_000;
+  const state = stateWith([builder]);
+
+  const status = buildHiveTools(state, "Orchestrator").find((t) => t.name === "team_status")!;
+  const res = await (status.execute as any)("id", {});
+
+  assert.match(res.content[0].text, /ctx=86\.3% \(173k\/200k\) fresh-recommended/);
+  assert.equal(res.details.agents[0].contextPct, 86.25);
+  assert.equal(res.details.agents[0].contextTokens, 172_500);
+  assert.equal(res.details.agents[0].contextWindow, 200_000);
+  assert.equal(res.details.agents[0].contextAdvice, "fresh-recommended");
+});


### PR DESCRIPTION
## Summary
- infer automated review artifact targets from explicit review prompts before scanning generic artifact keywords
- avoid treating unsupported requirements-gate reviews as design/spec/task verdicts
- let approval honor legacy SQLite-only agent verdicts when per-artifact sidecar state is missing

## Verification
- just verify