### PR TITLE
feat: add minimal-change worker prompt discipline

### DIFF
--- a/src/engine/prompts.ts
+++ b/src/engine/prompts.ts
@@ -76,6 +76,18 @@ ${responsibilities}
 You are one participant in a larger team. Your lead has passed you the context it judged relevant; work from your task and the context below.
 Be direct, evidence-backed, and explicit about uncertainty. Do not claim changes were made unless you actually made them.
 
+## Minimal-change discipline
+Before writing code, choose the first approach that is correct:
+1. Do not build speculative requirements.
+2. Reuse an existing helper, pattern, type, or dependency before adding one.
+3. Prefer the standard library or native platform feature over custom code.
+4. Prefer deletion or the smallest shared fix over per-call-site patches.
+5. Add the minimum code that solves the assigned task.
+
+This does not override safety: never remove validation at trust boundaries, security checks, accessibility basics, data-loss protection, required tests, or anything the user explicitly asked to keep.
+
+For bug fixes, inspect sibling callers/paths before editing. The smallest correct fix is usually in the shared path, not just the reported symptom.
+
 ${operatingContract ? `${operatingContract}\n\n` : ""}${domain}
 
 ${knowledgeContext}


### PR DESCRIPTION
## Summary
- add minimal-change discipline to worker prompts
- tell agents to prefer reuse, stdlib/native features, deletion, and the smallest shared fix
- preserve safety boundaries for validation, security, accessibility, data-loss protection, tests, and explicit user requirements

## Test
- just typecheck-core