### PR TITLE
fix: recognize sprint-plan OpenSpec tasks

### DIFF
--- a/src/engine/openspec.ts
+++ b/src/engine/openspec.ts
@@ -291,13 +291,20 @@ export function validate(cwd: string, name?: string): ValidateResult {
 // Execution readiness gate
 // ---------------------------------------------------------------------------
 
-// tasks.md exists and contains at least one checkbox item. Accept both common
-// Markdown task-list bullets (`- [ ]`) and ordered task lists (`1. [ ]`), since
-// OpenSpec plans may use sprint-numbered checkboxes.
+// tasks.md exists and is materially authored. Prefer checkbox/task-list items
+// when present, but accept execution-ready sprint plans too: the planning gate
+// may produce dependency-ordered sprint sections with acceptance criteria rather
+// than Markdown checkboxes, and /hive-execute should not report that such a file
+// is missing.
 export function hasTasks(cwd: string, name: string): boolean {
   if (!isSafeChangeId(name)) return false;
   const raw = readIfSmall(join(cwd, "openspec", "changes", name, "tasks.md"), MAX_ARTIFACT_BYTES);
-  return /^\s*(?:[-*]|\d+\.)\s*\[[ xX]\]/m.test(raw);
+  if (!raw.trim()) return false;
+  if (/^\s*(?:[-*]|\d+\.)\s*\[[ xX]\]/m.test(raw)) return true;
+  const hasTasksHeading = /^#\s+Tasks\b/im.test(raw);
+  const sprintSections = raw.match(/^##\s+\d+\.\s+Sprint\b/gim)?.length ?? 0;
+  const hasAcceptanceCriteria = /\*\*Acceptance criteria:\*\*/i.test(raw);
+  return hasTasksHeading && sprintSections > 0 && hasAcceptanceCriteria;
 }
 
 // Artifact-side readiness: the artifacts are materially complete (tasks

--- a/src/engine/prompts.ts
+++ b/src/engine/prompts.ts
@@ -14,7 +14,7 @@ export function buildOperatingContract(runtime: AgentRuntime): string {
   const lines: string[] = ["## Operating contract (agent type)"];
   switch (type) {
     case "planner": {
-      lines.push("You are a **planner**. You write only OpenSpec proposal/design/specs/tasks artifacts (under `openspec/changes/<change-id>/`, plus docs). Spec deltas belong at `specs/<capability>/spec.md` using a capability slug, not the change-id repeated; do not create bare `spec.md` or `specs/spec.md`. You must not modify production or test code — those edits are blocked at the tool layer.");
+      lines.push("You are a **planner**. You write only OpenSpec proposal/design/specs/tasks artifacts (under `openspec/changes/<change-id>/`, plus docs). Spec deltas belong at `specs/<capability>/spec.md` using a capability slug, not the change-id repeated; do not create bare `spec.md` or `specs/spec.md`. For `tasks.md`, include concrete Markdown task-list checkboxes (`- [ ] ...`) even when organizing work into sprints, so execution readiness and human review have explicit actionable units. You must not modify production or test code — those edits are blocked at the tool layer.");
       if (runtime.config.stages?.length) lines.push(`You own these planning gates: ${runtime.config.stages.join(", ")}. You may write only those gate artifacts.`);
       break;
     }

--- a/tests/openspec.test.ts
+++ b/tests/openspec.test.ts
@@ -43,13 +43,15 @@ test("resolveArtifact blocks traversal outside the change dir", () => {
   assert.ok(ok && ok.endsWith("/openspec/changes/add-auth/proposal.md"));
 });
 
-test("hasTasks detects checkbox items only", () => {
+test("hasTasks detects checklist and sprint-plan tasks", () => {
   const cwd = scratch();
   const dir = join(cwd, "openspec", "changes", "add-auth");
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "tasks.md"), "# Tasks\n\nno checkboxes here\n");
+  writeFileSync(join(dir, "tasks.md"), "# Tasks\n\nno checkboxes or sprint sections here\n");
   assert.equal(openspec.hasTasks(cwd, "add-auth"), false);
   writeFileSync(join(dir, "tasks.md"), "# Tasks\n\n- [ ] one\n- [x] two\n");
+  assert.equal(openspec.hasTasks(cwd, "add-auth"), true);
+  writeFileSync(join(dir, "tasks.md"), "# Tasks: add-auth\n\n## 1. Sprint 1 — Foundation\n\n**Acceptance criteria:**\n\n- Foundation is reviewer-testable.\n");
   assert.equal(openspec.hasTasks(cwd, "add-auth"), true);
 });
 


### PR DESCRIPTION
## Summary
- accept authored sprint-plan tasks.md files with sprint sections and acceptance criteria as execution-ready
- keep checkbox task lists as the preferred/fast path
- tell planner agents to include Markdown task-list checkboxes in tasks.md when organizing work into sprints
- add coverage for checklist and sprint-plan task detection

## Test
- just typecheck-core