### PR TITLE
fix: worker session correctness — reload() domain enforcement + context injection

### DIFF
--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -195,6 +195,12 @@ export async function dispatchAgent(
   const model = modelFrom(ctx, runtime.config.model);
   const tools = normalizeWorkerTools(runtime.config.tools, state.config.settings.defaultTools);
   const thinking = runtime.config.thinking!;
+  // Fix #3: capture whether a prior transcript exists BEFORE the archive step.
+  // This determines whether this dispatch is a new session (no prior transcript)
+  // or a resume (existing transcript the SDK will replay on prompt()). The value
+  // is used below to decide which input to pass to session.prompt(): the full
+  // assembled worker context (new/fresh) or the lean task alone (resume).
+  const sessionFileExisted = existsSync(runtime.sessionFile);
   // fresh=true starts this agent's conversation clean. Rather than DELETE the
   // prior session (which would lose the transcript of earlier runs while their
   // token/cost still count), ARCHIVE it to a numbered run file so the dashboard
@@ -526,7 +532,16 @@ export async function dispatchAgent(
     // selection; currentChangeId() carries an already-scoped value into nesting.
     const scopedChangeId = currentChangeId() ?? state.activeChangeId;
     if (abortedByParent) throw new Error("aborted");
-    await runAsAgent(runtime.config.name, () => runWithChange(scopedChangeId, () => session.prompt(task)));
+    // Fix #3: inject the assembled worker context on new/fresh session starts.
+    // fresh=true always starts clean (prior transcript archived above, if any).
+    // A first-ever session for this agent (no prior transcript file) also needs
+    // the full context so shared_context and the domain boundary reach the worker.
+    // Resumed sessions (fresh=false, existing transcript) receive the lean task
+    // only — pi-hive's native transcript persistence already carries the context
+    // forward, so re-injecting would duplicate it on every resumed delegation.
+    // Deliberate non-goal: distiller re-injection into resumed workers (P4).
+    const isNewSession = fresh || !sessionFileExisted;
+    await runAsAgent(runtime.config.name, () => runWithChange(scopedChangeId, () => session.prompt(isNewSession ? prompt : task)));
     errorMessage = abortedByParent ? "aborted" : session.state.errorMessage;
     // The 1s timer polls this too, but relying on it alone can miss the final,
     // most accurate reading if the last tick landed moments before completion.

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -264,6 +264,16 @@ export async function dispatchAgent(
   let streamedSnapshot = "";
   const sessionManager = SessionManager.open(runtime.sessionFile);
 
+  // createAgentSession only calls reload() when it creates its own resource
+  // loader (sdk.js). When a loader is supplied by the caller, the SDK skips
+  // reload, leaving extensionsResult empty (constructor default). Without
+  // reload the extensionFactories never run, runner.hasHandlers("tool_call")
+  // is false, beforeToolCall short-circuits, and domain enforcement is silently
+  // bypassed for every worker tool call. Call reload() here so the factory
+  // registers the tool_call handler before the session starts.
+  const workerLoader = workerResourceLoader(state, ctx.cwd, runtime.config.name, skillPaths);
+  await workerLoader.reload();
+
   const { session } = await createSession({
     cwd: ctx.cwd,
     model: resolvedModel,
@@ -272,7 +282,7 @@ export async function dispatchAgent(
     tools: toolNames,
     customTools: hiveTools,
     sessionManager,
-    resourceLoader: workerResourceLoader(state, ctx.cwd, runtime.config.name, skillPaths),
+    resourceLoader: workerLoader,
   });
   runtime.session = session;
 

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -535,3 +535,93 @@ test("first-run delegation_start carries thinkingLevels + effective model (J4/M8
   // The effective model is present (not undefined) on the very first run.
   assert.equal(first.payload.model, "test/model");
 });
+
+// Fix #3 regression: the assembled worker context built by buildWorkerPrompt must
+// be passed to session.prompt() on new/fresh session starts. On resumed sessions
+// (fresh=false, existing transcript) only the lean task must be passed — the
+// transcript already carries the context via pi-hive's native persistence.
+
+// Helper: scripted session that captures the argument passed to prompt().
+// Fires no events (output is "[no output]", exitCode 0) — the test cares only
+// about what reached prompt(), not the session's output.
+function capturePromptSession(): { session: any; getPromptArg: () => string | undefined } {
+  let captured: string | undefined;
+  const session = {
+    subscribe(_cb: (e: any) => void): () => void { return () => undefined; },
+    getAvailableThinkingLevels(): string[] { return ["off"]; },
+    getContextUsage(): { percent: number } { return { percent: 0 }; },
+    getSessionStats(): any { return { tokens: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 }, cost: { total: 0 } }; },
+    state: { errorMessage: undefined as string | undefined },
+    async prompt(arg: string): Promise<void> { captured = arg; },
+    dispose(): void { /* noop */ },
+  };
+  return { session, getPromptArg: () => captured };
+}
+
+test("new session (no prior transcript) receives assembled worker context — shared_context and hive markers present (fix #3a)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-fix3-new-"));
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  // No prior transcript: builder.jsonl does not exist → isNewSession = true.
+  const state: HiveState = {
+    pi: {} as any,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md" },
+      agents: [worker.config],
+      // Inline shared context (no path separator, no extension) so buildSharedContext
+      // renders it as "## Inline shared context\n<text>" — verifiable in the prompt.
+      sharedContext: ["fix3 shared context sentinel"],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 2, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    } as any,
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: join(dir, "e.jsonl") },
+    runtimes: new Map([["builder", worker]]),
+    widgetCtx: null, activeRuns: 0, mode: "hive", normalToolNames: [],
+    sddStatus: null, obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: () => ({ provider: "test", id: "model" }) } } as any;
+  const { session, getPromptArg } = capturePromptSession();
+  const create: CreateAgentSession = (async () => ({ session })) as any;
+
+  await dispatchAgent(state, "Builder", "the-lean-task", ctx, false, create);
+
+  const received = getPromptArg();
+  // The assembled prompt carries the hive operating context header — absent from
+  // any raw task. Proves fix #3 injected the full context on a new session.
+  assert.ok(received?.includes("## Hive operating context"), `assembled context header missing; got: ${received?.slice(0, 300)}`);
+  // Shared context is also present (proves shared_context reaches workers via fix #3).
+  assert.ok(received?.includes("fix3 shared context sentinel"), "shared context sentinel missing from injected prompt");
+  // The lean task is still present, embedded inside the assembled prompt.
+  assert.ok(received?.includes("the-lean-task"), "lean task must be embedded inside the assembled prompt");
+});
+
+test("resumed session (fresh=false, existing transcript) receives only the lean task — no context re-injection (fix #3b)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-fix3-resume-"));
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  // Materialize a valid prior transcript so SessionManager.open() accepts it and
+  // isNewSession resolves to false (resume path). The first JSONL line must be a
+  // pi session header: {type:"session", id:<string>}.
+  writeFileSync(worker.sessionFile, '{"type":"session","id":"prior-session-id","version":"1"}\n');
+  const state: HiveState = {
+    pi: {} as any,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md" },
+      agents: [worker.config],
+      sharedContext: ["fix3 shared context sentinel"],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 2, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    } as any,
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: join(dir, "e.jsonl") },
+    runtimes: new Map([["builder", worker]]),
+    widgetCtx: null, activeRuns: 0, mode: "hive", normalToolNames: [],
+    sddStatus: null, obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: () => ({ provider: "test", id: "model" }) } } as any;
+  const { session, getPromptArg } = capturePromptSession();
+  const create: CreateAgentSession = (async () => ({ session })) as any;
+
+  await dispatchAgent(state, "Builder", "the-lean-task", ctx, false, create);
+
+  const received = getPromptArg();
+  // Resume path: only the lean task must reach session.prompt(). The transcript
+  // already carries the assembled context from the original session start.
+  assert.equal(received, "the-lean-task", "resumed session must receive only the lean task, not the assembled context");
+  assert.ok(!received?.includes("## Hive operating context"), "assembled context must not be re-injected on a resumed session");
+});


### PR DESCRIPTION
## Summary

Two independent worker-session bugs in `dispatchAgent` (`src/engine/dispatch.ts`), both silent — no error is thrown, the wrong behavior is just quietly accepted.

---

## reload() — domain enforcement silently bypassed when a resource loader is supplied

### Problem
`createAgentSession` calls `reload()` on the resource loader only when it creates its own loader internally. When a loader is supplied by the caller, the SDK skips `reload()`, leaving `extensionsResult` empty:

- `extensionFactories` never run
- `runner.hasHandlers("tool_call")` is `false`
- `beforeToolCall` short-circuits

The `tool_call` handler (which registers worker extensions and enforces the filesystem `domain` scope) is never registered. **Domain enforcement is silently inactive for every worker tool call** — reads, writes, deletes — whenever a caller-supplied resource loader is in use.

### Fix
Call `workerLoader.reload()` explicitly before `createSession` so the factory registers the `tool_call` handler regardless of how the resource loader is supplied.

```ts
const workerLoader = workerResourceLoader(state, ctx.cwd, runtime.config.name, skillPaths);
await workerLoader.reload();
const { session } = await createSession({ /* ... */ resourceLoader: workerLoader });
```

### Impact
Without this, any deployment that supplies a resource loader to `dispatchAgent` runs with domain enforcement completely inactive — worker agents can touch files outside their declared `domain` with no block and no error.

---

## Assembled worker context missing on new/fresh sessions

### Problem
`buildWorkerPrompt` assembles the full worker context (`shared_context`, operating markers, task framing) into `prompt`, but `session.prompt()` always received the raw `task` string. For a **first-ever session** (no prior transcript) the worker starts without its assembled context — `shared_context` never reaches the model. For a **resumed session** the transcript already carries the context, so re-injecting would duplicate it.

### Fix
Capture `sessionFileExisted` before the archive step, then choose the input at `session.prompt()`:

```ts
const sessionFileExisted = existsSync(runtime.sessionFile);
// ... archive step ...
const isNewSession = fresh || !sessionFileExisted;
await session.prompt(isNewSession ? prompt : task);
```

New/fresh session → full assembled context; resumed session → lean task.

### Impact
Without this, workers starting a first-ever delegation session begin without `shared_context` or operating markers, so any configuration relying on shared context to inform worker behavior is silently ignored on first contact.

---

## Tests
`tests/dispatch-usage.test.ts` adds two regression tests:
- new session (no prior transcript) receives the assembled worker context (`shared_context` sentinel present)
- resumed session receives only the lean task (no context re-injection)

All existing tests continue to pass with both fixes applied.

---

*Two small, independent commits (one per fix), no new dependencies, no public API changes.*
