### PR TITLE
fix: enforce canonical path containment

### DIFF
--- a/src/core/agent-type-audit.ts
+++ b/src/core/agent-type-audit.ts
@@ -1,8 +1,9 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import type { AgentType } from "./types";
 import { parseFrontmatter, parseYamlLite } from "./yaml";
 import { AGENT_TYPES, normalizeAgentType } from "./normalize";
 import { safeRead } from "./fs";
+import { resolveProjectPath } from "./safe-path";
 
 // One agent's agent-type status, resilient to a config that no longer loads
 // because validation now hard-fails on a missing/invalid agent-type. The doctor
@@ -58,7 +59,8 @@ function declaredType(cwd: string, node: RawAgentNode): string | undefined {
   const path = typeof node.path === "string" ? node.path : undefined;
   if (!path) return undefined;
   try {
-    const raw = safeRead(resolve(cwd, path));
+    const safePath = resolveProjectPath(cwd, path);
+    const raw = safePath ? safeRead(safePath.canonicalPath) : "";
     if (!raw) return undefined;
     const { attrs } = parseFrontmatter(raw);
     return normalizeAgentType(attrs.agentType);
@@ -74,7 +76,8 @@ export function auditAgentTypes(cwd: string): AgentTypeAudit {
   const rows: AgentTypeAuditRow[] = [];
   let parsed: any;
   try {
-    const raw = safeRead(join(cwd, ".pi", "hive", "hive-config.yaml"));
+    const configPath = resolveProjectPath(cwd, join(cwd, ".pi", "hive", "hive-config.yaml"));
+    const raw = configPath ? safeRead(configPath.canonicalPath) : "";
     if (!raw) return { rows, offenders: [] };
     parsed = parseYamlLite(raw);
   } catch {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,8 +1,9 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import type { AgentConfig, HiveConfig, HiveMode, HiveTeam } from "./types";
 import { parseYamlLite, parseFrontmatter } from "./yaml";
 import { agentSlug, configuredChildAgents, flatAgentConfig, normalizeAgentType, normalizeCommit, normalizePlanStages, safeRead, slug } from "./utils";
 import { validateAgentTypes, validateHiveConfigShape } from "./schema";
+import { resolveProjectPath } from "./safe-path";
 
 // Read an agent's .md frontmatter and copy model/thinking onto the config node
 // when the config itself does not set them. The config tree (from hive-config.
@@ -88,7 +89,8 @@ function enrichFromFrontmatter(cwd: string, agent: AgentConfig | undefined): voi
   // onto the config node whenever the node itself does not already set them.
   const needsEnrich = !agent.slug || !agent.model || !agent.thinking || agent.agentType === undefined || agent.stages === undefined || agent.commit === undefined;
   if (agent.path && needsEnrich) {
-    const raw = safeRead(resolve(cwd, agent.path));
+    const promptPath = resolveProjectPath(cwd, agent.path);
+    const raw = promptPath ? safeRead(promptPath.canonicalPath) : "";
     if (raw) {
       const { attrs } = parseFrontmatter(raw);
       if (!agent.slug && attrs.slug) agent.slug = slug(String(attrs.slug));
@@ -131,7 +133,8 @@ function enrichTeam(cwd: string, team: HiveTeam | undefined): void {
 
 export function loadConfig(cwd: string): HiveConfig {
   const configPath = join(cwd, ".pi", "hive", "hive-config.yaml");
-  const raw = safeRead(configPath);
+  const safeConfigPath = resolveProjectPath(cwd, configPath);
+  const raw = safeConfigPath ? safeRead(safeConfigPath.canonicalPath) : "";
   if (!raw) throw new Error(`Missing config: ${configPath}`);
   const parsed = parseYamlLite(raw) as any;
 

--- a/src/core/prompting.ts
+++ b/src/core/prompting.ts
@@ -1,15 +1,15 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { resolve } from "node:path";
 import type { DomainScope, HiveState, KnowledgeRef } from "./types";
 import { readIfSmall } from "./utils";
+import { resolveProjectPath } from "./safe-path";
 
 export function buildSharedContext(state: HiveState, ctx: ExtensionContext): string {
   if (!state.config) return "";
   const blocks: string[] = [];
   for (const entry of state.config.sharedContext || []) {
     const text = String(entry);
-    const fullPath = resolve(ctx.cwd, text);
-    const content = readIfSmall(fullPath);
+    const safePath = resolveProjectPath(ctx.cwd, text);
+    const content = safePath ? readIfSmall(safePath.canonicalPath) : "";
     if (content) {
       blocks.push(`## ${text}\n${content}`);
       continue;
@@ -25,8 +25,8 @@ export function buildSharedContext(state: HiveState, ctx: ExtensionContext): str
 export function renderKnowledgeRefs(ctx: ExtensionContext, title: string, refs: KnowledgeRef[] | undefined): string {
   if (!refs?.length) return `## ${title}\nNo configured ${title.toLowerCase()}.`;
   const blocks = refs.map((ref) => {
-    const fullPath = resolve(ctx.cwd, ref.path);
-    const content = readIfSmall(fullPath, 96_000);
+    const safePath = resolveProjectPath(ctx.cwd, ref.path);
+    const content = safePath ? readIfSmall(safePath.canonicalPath, 96_000) : "";
     const body = content || `[not readable: ${ref.path}]`;
     const meta = [
       ref.useWhen ? `use when: ${ref.useWhen}` : undefined,

--- a/src/core/safe-path.ts
+++ b/src/core/safe-path.ts
@@ -1,0 +1,96 @@
+import { lstatSync, realpathSync } from "node:fs";
+import * as path from "node:path";
+
+export type PathApi = Pick<typeof path, "isAbsolute" | "relative" | "resolve" | "dirname" | "basename" | "sep">;
+
+export interface ContainedPath {
+  lexicalPath: string;
+  canonicalPath: string;
+  exists: boolean;
+}
+
+export interface ContainedPathOptions {
+  allowMissing?: boolean;
+}
+
+// Segment-aware containment. Unlike startsWith(), this cannot confuse
+// /project/app with /project/application and works with either POSIX or win32
+// path semantics in pure unit tests.
+export function isPathInside(parent: string, child: string, pathApi: PathApi = path): boolean {
+  const rel = pathApi.relative(pathApi.resolve(parent), pathApi.resolve(child));
+  return rel === "" || (!rel.startsWith(`..${pathApi.sep}`) && rel !== ".." && !pathApi.isAbsolute(rel));
+}
+
+function existsLexically(value: string): boolean {
+  try {
+    lstatSync(value);
+    return true;
+  } catch (error: any) {
+    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") return false;
+    throw error;
+  }
+}
+
+function canonicalize(value: string, allowMissing: boolean): ContainedPath | null {
+  const lexicalPath = path.resolve(value);
+  const exists = existsLexically(lexicalPath);
+  if (exists) {
+    try {
+      return { lexicalPath, canonicalPath: realpathSync.native(lexicalPath), exists: true };
+    } catch {
+      // Broken links, loops, and permission failures are indeterminate and must
+      // never become an authorization success.
+      return null;
+    }
+  }
+  if (!allowMissing) return null;
+
+  let ancestor = lexicalPath;
+  while (!existsLexically(ancestor)) {
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) return null;
+    ancestor = parent;
+  }
+  let canonicalAncestor: string;
+  try {
+    canonicalAncestor = realpathSync.native(ancestor);
+  } catch {
+    return null;
+  }
+  const suffix = path.relative(ancestor, lexicalPath);
+  return {
+    lexicalPath,
+    canonicalPath: path.resolve(canonicalAncestor, suffix),
+    exists: false,
+  };
+}
+
+export function hasForeignAbsoluteSyntax(value: string): boolean {
+  if (process.platform === "win32") return path.posix.isAbsolute(value) && !path.win32.isAbsolute(value);
+  return path.win32.isAbsolute(value) && !path.posix.isAbsolute(value);
+}
+
+// Resolve a path only when BOTH its lexical location and its real filesystem
+// destination remain under root. Existing paths use realpath. Missing targets
+// are projected from their nearest existing realpath parent, which catches a
+// symlinked ancestor escaping the allowed tree before a file is created.
+export function resolveContainedPath(root: string, candidate: string, options: ContainedPathOptions = {}): ContainedPath | null {
+  if (!root || !candidate || hasForeignAbsoluteSyntax(root) || hasForeignAbsoluteSyntax(candidate)) return null;
+  const lexicalRoot = path.resolve(root);
+  const lexicalCandidate = path.resolve(candidate);
+  if (!isPathInside(lexicalRoot, lexicalCandidate)) return null;
+
+  // A configured root may itself be new (for example a not-yet-created tests/
+  // domain), so canonicalize it through its nearest existing parent.
+  const canonicalRoot = canonicalize(lexicalRoot, true);
+  const canonicalCandidate = canonicalize(lexicalCandidate, options.allowMissing === true);
+  if (!canonicalRoot || !canonicalCandidate) return null;
+  if (!isPathInside(canonicalRoot.canonicalPath, canonicalCandidate.canonicalPath)) return null;
+  return canonicalCandidate;
+}
+
+export function resolveProjectPath(projectRoot: string, requestedPath: string, options: ContainedPathOptions = {}): ContainedPath | null {
+  if (!requestedPath || hasForeignAbsoluteSyntax(requestedPath)) return null;
+  const candidate = path.isAbsolute(requestedPath) ? requestedPath : path.resolve(projectRoot, requestedPath);
+  return resolveContainedPath(projectRoot, candidate, options);
+}

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -31,6 +31,7 @@ import { normalizeWorkerSkillPaths, workerResourceLoader } from "./worker-extens
 import { isExecutionGateOpen, isAwaitingHumanApproval, setAgentReviewVerdict, type AgentReviewVerdict, type ArtifactId } from "./openspec";
 import { agentRoster, resolveRuntime } from "./agent-lookup";
 import { addHiveActivity } from "../ui/tui/activity";
+import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 
 // Dashboard activity should show reviewer/worker conclusions without confusing
 // middle elision in normal cases. Keep a high hard cap to avoid unbounded shared
@@ -84,7 +85,10 @@ function archivePriorRun(sessionFile: string) {
 export type CreateAgentSession = typeof createAgentSession;
 
 export function resolveWorkerSkillPaths(cwd: string, refs: unknown[] = []): string[] {
-  return normalizeWorkerSkillPaths(refs).map((skillPath) => resolve(cwd, skillPath));
+  return normalizeWorkerSkillPaths(refs).flatMap((skillPath) => {
+    const safe = resolveProjectPath(cwd, skillPath);
+    return safe ? [safe.canonicalPath] : [];
+  });
 }
 
 const ARTIFACT_REVISION_MARKERS = /\b(revise|revision|fix|address|correct|update|rewrite|repair|failed review|review failed|rejected|denied|blocker|blocking)\b/i;
@@ -761,8 +765,10 @@ export async function distillMentalModel(state: HiveState, ctx: ExtensionContext
 
   // Write guard: the mental-model file must live under the agents/ root.
   const agentsRoot = resolve(ctx.cwd, HIVE_AGENTS_DIR);
-  const targetPath = resolve(ctx.cwd, target.path);
-  if (!targetPath.startsWith(agentsRoot)) return;
+  if (!resolveProjectPath(ctx.cwd, HIVE_AGENTS_DIR, { allowMissing: true })) return;
+  const safeTarget = resolveContainedPath(agentsRoot, resolve(ctx.cwd, target.path), { allowMissing: true });
+  if (!safeTarget) return;
+  const targetPath = safeTarget.canonicalPath;
 
   // Snapshot the just-finished conversation, distill from the copy, then delete
   // it — so a re-delegation of the same agent can reuse its live session freely.

--- a/src/engine/domain.ts
+++ b/src/engine/domain.ts
@@ -7,6 +7,7 @@ import { agentMatches } from "../core/utils";
 import { globToRegExp, globSpecificity, toPosixPath } from "./glob";
 import { classify } from "./file-class";
 import { checkPlannerStages, checkTypePolicy, type PolicyAction } from "./policy";
+import { hasForeignAbsoluteSyntax, isPathInside, resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 
 function runtimeForCaller(state: HiveState, callerName: string): AgentRuntime | undefined {
   return resolveRuntime(state, callerName);
@@ -27,9 +28,7 @@ export function canDelegateTo(state: HiveState, callerName: string, targetName: 
 }
 
 export function pathWithin(parent: string, child: string): boolean {
-  const normalizedParent = resolve(parent);
-  const normalizedChild = resolve(child);
-  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}/`);
+  return isPathInside(parent, child);
 }
 
 export function resolveDomainPath(ctx: ExtensionContext, rawPath: string): string {
@@ -50,10 +49,12 @@ function excludedBy(scope: DomainScope, relativePath: string): boolean {
   return Boolean(scope.exclude?.some((pattern) => globToRegExp(pattern).test(relativePath)));
 }
 
-function domainScopeMatch(ctx: ExtensionContext, scope: DomainScope, target: string): { matches: boolean; specificity: number } {
+function domainScopeMatch(ctx: ExtensionContext, scope: DomainScope, target: string, allowMissing: boolean): { matches: boolean; specificity: number } {
   const scopePath = resolve(ctx.cwd, scope.path);
-  if (!pathWithin(scopePath, target)) return { matches: false, specificity: 0 };
-  const relativePath = toPosixPath(relative(scopePath, target) || ".");
+  if (!resolveProjectPath(ctx.cwd, scope.path, { allowMissing: true })) return { matches: false, specificity: 0 };
+  const contained = resolveContainedPath(scopePath, target, { allowMissing });
+  if (!contained) return { matches: false, specificity: 0 };
+  const relativePath = toPosixPath(relative(scopePath, contained.lexicalPath) || ".");
   if (excludedBy(scope, relativePath)) return { matches: false, specificity: 0 };
   const includeSpecificity = matchingGlobSpecificity(scope.include, relativePath);
   if (includeSpecificity === undefined) return { matches: false, specificity: 0 };
@@ -71,11 +72,12 @@ function domainScopeMatch(ctx: ExtensionContext, scope: DomainScope, target: str
 //   - On an exact specificity tie, DENY wins (fail safe).
 //   - If no scope matches, the default is DENY.
 export function domainAllows(ctx: ExtensionContext, runtime: AgentRuntime, rawPath: string, capability: "read" | "upsert" | "delete"): boolean {
+  if (hasForeignAbsoluteSyntax(rawPath)) return false;
   const target = resolveDomainPath(ctx, rawPath);
   let bestSpecificity = -1;
   let decision = false;
   for (const scope of runtime.config.domain || []) {
-    const match = domainScopeMatch(ctx, scope, target);
+    const match = domainScopeMatch(ctx, scope, target, capability === "upsert");
     if (!match.matches) continue;
     const opinion = scope[capability];
     if (match.specificity > bestSpecificity) {

--- a/src/engine/openspec.ts
+++ b/src/engine/openspec.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, readIfSmall } from "../core/fs";
+import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 
 // Thin, bounded wrapper around the OpenSpec CLI (@fission-ai/openspec).
 //
@@ -298,7 +299,8 @@ export function validate(cwd: string, name?: string): ValidateResult {
 // is missing.
 export function hasTasks(cwd: string, name: string): boolean {
   if (!isSafeChangeId(name)) return false;
-  const raw = readIfSmall(join(cwd, "openspec", "changes", name, "tasks.md"), MAX_ARTIFACT_BYTES);
+  const tasksPath = resolveArtifact(cwd, name, "tasks.md");
+  const raw = tasksPath ? readIfSmall(tasksPath, MAX_ARTIFACT_BYTES) : "";
   if (!raw.trim()) return false;
   if (/^\s*(?:[-*]|\d+\.)\s*\[[ xX]\]/m.test(raw)) return true;
   const hasTasksHeading = /^#\s+Tasks\b/im.test(raw);
@@ -331,10 +333,12 @@ export function isExecutionGateOpen(cwd: string, name: string): boolean {
 // plan-store.resolveArtifact.
 export function resolveArtifact(cwd: string, name: string, relPath: string): string | null {
   if (!isSafeChangeId(name)) return null;
-  const base = resolve(cwd, "openspec", "changes", name);
-  const target = resolve(base, relPath);
-  if (target !== base && !target.startsWith(`${base}/`)) return null;
-  return target;
+  const baseRequest = resolve(cwd, "openspec", "changes", name);
+  const safeBase = resolveProjectPath(cwd, baseRequest, { allowMissing: true });
+  if (!safeBase) return null;
+  const target = resolve(baseRequest, relPath);
+  const safeTarget = resolveContainedPath(baseRequest, target, { allowMissing: true });
+  return safeTarget?.canonicalPath || null;
 }
 
 // Read an artifact under a change folder, path-guarded and capped at 512 KB.
@@ -411,8 +415,7 @@ type ApprovalSidecar = {
 };
 
 function approvalPath(cwd: string, name: string): string | null {
-  if (!isSafeChangeId(name)) return null;
-  return join(cwd, "openspec", "changes", name, APPROVAL_FILE);
+  return resolveArtifact(cwd, name, APPROVAL_FILE);
 }
 
 function toArtifactId(artifact: string): ArtifactId | null {
@@ -611,7 +614,9 @@ function listSpecArtifacts(cwd: string, name: string, relRoot = "specs"): string
 export function listArtifacts(cwd: string, name: string): string[] {
   if (!isSafeChangeId(name)) return [];
   try {
-    const topLevel = (readdirSync(join(cwd, "openspec", "changes", name), { withFileTypes: true }) as FsDirent[])
+    const changeRoot = resolveArtifact(cwd, name, ".");
+    if (!changeRoot) return [];
+    const topLevel = (readdirSync(changeRoot, { withFileTypes: true }) as FsDirent[])
       .filter((e) => e.isFile() && e.name.endsWith(".md"))
       .map((e) => e.name);
     return [...topLevel, ...listSpecArtifacts(cwd, name)].sort((a, b) => a.localeCompare(b));

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -20,6 +20,7 @@ import {
 import { allConfiguredAgents, loadConfig, teamForMode } from "../core/config";
 import { canonicalMode } from "../core/types";
 import { runtimeKey } from "./agent-lookup";
+import { resolveProjectPath } from "../core/safe-path";
 
 export function restoreOrCreateSession(state: HiveState, ctx: ExtensionContext, _cfg: HiveConfig): SessionState {
   const existing = ctx.sessionManager
@@ -48,7 +49,9 @@ export function restoreOrCreateSession(state: HiveState, ctx: ExtensionContext, 
 }
 
 export function loadAgentRuntime(state: HiveState, ctx: ExtensionContext, cfg: HiveConfig, agent: AgentConfig): AgentRuntime {
-  const fullPath = resolve(ctx.cwd, agent.path);
+  const safePromptPath = resolveProjectPath(ctx.cwd, agent.path);
+  if (!safePromptPath) throw new Error(`Agent prompt is missing or escapes the project root: ${agent.path}`);
+  const fullPath = safePromptPath.canonicalPath;
   const parsed = parseFrontmatter(safeRead(fullPath));
   const attrs = parsed.attrs || {};
   const agentSlug = slug(String(attrs.slug || agent.slug || agent.name || attrs.name || fullPath));
@@ -70,9 +73,11 @@ export function loadAgentRuntime(state: HiveState, ctx: ExtensionContext, cfg: H
   // targets it). No need to declare it in frontmatter.
   const explicitContext = normalizeKnowledgeRefs(attrs.context || (agent as any).context);
   const mentalModelPath = agent.path.replace(/\.md$/, "-mental-model.yaml");
-  const hasMentalModel = existsSync(resolve(ctx.cwd, mentalModelPath));
-  const alreadyListed = explicitContext.some((ref) => resolve(ctx.cwd, ref.path) === resolve(ctx.cwd, mentalModelPath));
-  const context = hasMentalModel && !alreadyListed
+  const safeMentalModel = resolveProjectPath(ctx.cwd, mentalModelPath);
+  const alreadyListed = safeMentalModel
+    ? explicitContext.some((ref) => resolveProjectPath(ctx.cwd, ref.path)?.canonicalPath === safeMentalModel.canonicalPath)
+    : false;
+  const context = safeMentalModel && !alreadyListed
     ? [{ path: mentalModelPath, useWhen: "Your durable mental model for this role.", updatable: true }, ...explicitContext]
     : explicitContext;
   const mergedConfig: AgentConfig = {

--- a/src/integration/hooks.ts
+++ b/src/integration/hooks.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import type { AgentConfig, HiveState } from "../core/types";
@@ -14,6 +13,7 @@ import { resolveHiveSddStatus } from "../engine/sdd";
 import { ensureDashboard } from "../engine/dashboard";
 import { resolveRuntime } from "../engine/agent-lookup";
 import { emitHiveEvent, emitModelCatalog, writeHiveStateSnapshot } from "../engine/observability";
+import { resolveProjectPath } from "../core/safe-path";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -377,7 +377,7 @@ ${catalog}`,
       }).catch(() => { /* best-effort; the dashboard is optional */ });
       const missingSkills = Array.from(state.runtimes.values()).flatMap((runtime) =>
         (runtime.config.skills || [])
-          .filter((ref) => !existsSync(ref.path.startsWith("/") ? ref.path : resolve(ctx.cwd, ref.path)))
+          .filter((ref) => !resolveProjectPath(ctx.cwd, ref.path))
           .map((ref) => `${runtime.config.name}: ${ref.path}`),
       );
       const missing = missingSkills.length ? `\nMissing configured skills: ${missingSkills.slice(0, 5).join(", ")}${missingSkills.length > 5 ? "..." : ""}` : "";

--- a/src/observability/static.ts
+++ b/src/observability/static.ts
@@ -1,11 +1,13 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveContainedPath } from "../core/safe-path";
 
 // The dashboard is a prebuilt React SPA under ui/web/dist. We serve its
 // index.html at "/" and its hashed assets from "/assets/*". If the build is
 // missing (developer hasn't run `just dashboard-build`), we fall back to a short
 // instructional page rather than a blank screen.
-export const DASHBOARD_DIR = path.resolve(import.meta.dir, "..", "..", "ui", "web", "dist");
+export const DASHBOARD_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "ui", "web", "dist");
 
 const MIME: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -22,9 +24,10 @@ const MIME: Record<string, string> = {
 
 export function dashboardFile(relPath: string): Response | null {
   // Resolve safely inside DASHBOARD_DIR (no path traversal).
-  const target = path.resolve(DASHBOARD_DIR, "." + (relPath.startsWith("/") ? relPath : "/" + relPath));
-  if (!target.startsWith(DASHBOARD_DIR)) return null;
-  if (!fs.existsSync(target) || !fs.statSync(target).isFile()) return null;
+  const requested = path.resolve(DASHBOARD_DIR, "." + (relPath.startsWith("/") ? relPath : "/" + relPath));
+  const safeTarget = resolveContainedPath(DASHBOARD_DIR, requested);
+  if (!safeTarget || !fs.statSync(safeTarget.canonicalPath).isFile()) return null;
+  const target = safeTarget.canonicalPath;
   const body = fs.readFileSync(target);
   const ext = path.extname(target).toLowerCase();
   const cacheable = relPath.startsWith("/assets/");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { allConfiguredAgents, loadConfig } from "../src/core/config.ts";
 import { normalizeDomainScopes } from "../src/core/normalize.ts";
 import { auditAgentTypes, inferAgentType } from "../src/core/agent-type-audit.ts";
-import { buildSharedContext } from "../src/core/prompting.ts";
+import { buildSharedContext, renderKnowledgeRefs } from "../src/core/prompting.ts";
 
 function fixtureProject() {
   const cwd = mkdtempSync(join(tmpdir(), "pi-hive-config-"));
@@ -93,6 +93,22 @@ test("loadConfig recovers quoted inline shared_context containing a colon", () =
   const rendered = buildSharedContext({ config } as any, { cwd } as any);
   assert.match(rendered, /Inline shared context/);
   assert.match(rendered, /HIPAA-regulated: no TODOs/);
+});
+
+test("shared context and knowledge refs reject symlink escapes", () => {
+  const cwd = fixtureProject();
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-context-outside-"));
+  writeFileSync(join(outside, "secret.md"), "DO NOT LEAK");
+  symlinkSync(join(outside, "secret.md"), join(cwd, "linked-secret.md"));
+  const config = loadConfig(cwd);
+  config.sharedContext = ["linked-secret.md"];
+
+  const shared = buildSharedContext({ config } as any, { cwd } as any);
+  assert.doesNotMatch(shared, /DO NOT LEAK/);
+  assert.match(shared, /not readable/);
+  const knowledge = renderKnowledgeRefs({ cwd } as any, "Context", [{ path: "linked-secret.md" }]);
+  assert.doesNotMatch(knowledge, /DO NOT LEAK/);
+  assert.match(knowledge, /not readable/);
 });
 
 test("loadConfig rejects non-string shared_context entries before delegation", () => {

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -46,16 +46,27 @@ test("review change inference uses explicit OpenSpec change references", () => {
   assert.equal(inferChangeIdFromReviewTask("Inputs: `openspec/changes/add-auth/specs/auth/spec.md`"), "add-auth");
 });
 
-test("resolveWorkerSkillPaths flattens skill refs so delegate setup never passes objects to path.resolve", () => {
-  const cwd = "/repo";
+test("resolveWorkerSkillPaths flattens skill refs and rejects unsafe resources", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-skills-"));
+  const first = join(cwd, ".pi/hive/skills/imed-repo-map/SKILL.md");
+  const second = join(cwd, ".pi/hive/skills/imed-frontend-map/SKILL.md");
+  mkdirSync(join(cwd, ".pi/hive/skills/imed-repo-map"), { recursive: true });
+  mkdirSync(join(cwd, ".pi/hive/skills/imed-frontend-map"), { recursive: true });
+  writeFileSync(first, "# skill");
+  writeFileSync(second, "# skill");
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-skills-outside-"));
+  writeFileSync(join(outside, "SKILL.md"), "# secret skill");
+  symlinkSync(join(outside, "SKILL.md"), join(cwd, ".pi/hive/skills/escape.md"));
   assert.deepEqual(
     resolveWorkerSkillPaths(cwd, [
       { path: ".pi/hive/skills/imed-repo-map/SKILL.md", useWhen: "planning" },
       { path: { path: ".pi/hive/skills/imed-frontend-map/SKILL.md" } },
+      { path: ".pi/hive/skills/escape.md" },
+      { path: "../outside-skill.md" },
     ] as any),
     [
-      "/repo/.pi/hive/skills/imed-repo-map/SKILL.md",
-      "/repo/.pi/hive/skills/imed-frontend-map/SKILL.md",
+      first,
+      second,
     ],
   );
 });

--- a/tests/domain-routing.test.ts
+++ b/tests/domain-routing.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { bashMutationKind, domainAllows, enforceDomainForTool, pathWithin } from "../src/engine/domain.ts";
 import { routeAgents } from "../src/engine/routing.ts";
 import { runAsAgent } from "../src/engine/session.ts";
@@ -65,7 +68,11 @@ test("domainAllows uses most-specific-wins with deny tie-breaks", () => {
 });
 
 test("domainAllows applies include globs more specifically than catch-all denies", () => {
-  const ctx = { cwd: "/repo" } as any;
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-domain-"));
+  mkdirSync(join(cwd, "backend/patient"), { recursive: true });
+  writeFileSync(join(cwd, "backend/patient/search_test.go"), "package patient");
+  writeFileSync(join(cwd, "backend/patient/search.go"), "package patient");
+  const ctx = { cwd } as any;
   const agent = runtime("Core Tester", {
     domain: [
       { path: "backend", read: true, upsert: false, delete: false },
@@ -77,6 +84,30 @@ test("domainAllows applies include globs more specifically than catch-all denies
   assert.equal(domainAllows(ctx, agent, "backend/patient/search_test.go", "upsert"), true);
   assert.equal(domainAllows(ctx, agent, "backend/patient/search.go", "read"), true);
   assert.equal(domainAllows(ctx, agent, "backend/patient/search.go", "upsert"), false);
+});
+
+test("domainAllows rejects existing and new targets through an escaping symlink", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-domain-symlink-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-domain-outside-"));
+  mkdirSync(join(cwd, "allowed"));
+  writeFileSync(join(cwd, "allowed/inside.txt"), "inside");
+  writeFileSync(join(outside, "secret.txt"), "secret");
+  symlinkSync(outside, join(cwd, "allowed/escape"));
+  symlinkSync(outside, join(cwd, "linked-domain"));
+  const ctx = { cwd } as any;
+  const agent = runtime("Symlink Tester", {
+    domain: [{ path: "allowed", read: true, upsert: true, delete: true }],
+  });
+
+  assert.equal(domainAllows(ctx, agent, "allowed/inside.txt", "read"), true);
+  assert.equal(domainAllows(ctx, agent, "allowed/escape/secret.txt", "read"), false);
+  assert.equal(domainAllows(ctx, agent, "allowed/escape/new.txt", "upsert"), false);
+  assert.equal(domainAllows(ctx, agent, "allowed/escape/secret.txt", "delete"), false);
+  const linkedRootAgent = runtime("Linked Root", {
+    domain: [{ path: "linked-domain", read: true, upsert: true, delete: true }],
+  });
+  assert.equal(domainAllows(ctx, linkedRootAgent, "linked-domain/secret.txt", "read"), false);
+  assert.equal(domainAllows(ctx, linkedRootAgent, "linked-domain/new.txt", "upsert"), false);
 });
 
 test("domainAllows honors exclude globs", () => {

--- a/tests/openspec.test.ts
+++ b/tests/openspec.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -28,6 +28,19 @@ test("isSafeChangeId enforces kebab-case", () => {
   assert.ok(!openspec.isSafeChangeId("../evil"));
   assert.ok(!openspec.isSafeChangeId("Add_Auth"));
   assert.ok(!openspec.isSafeChangeId(""));
+});
+
+test("resolveArtifact rejects symlink escapes", () => {
+  const cwd = scratch();
+  const outside = scratch();
+  mkdirSync(join(cwd, "openspec/changes/add-auth"), { recursive: true });
+  writeFileSync(join(outside, "proposal.md"), "secret");
+  symlinkSync(join(outside, "proposal.md"), join(cwd, "openspec/changes/add-auth/proposal.md"));
+  symlinkSync(outside, join(cwd, "openspec/changes/escaped-change"));
+
+  assert.equal(openspec.resolveArtifact(cwd, "add-auth", "proposal.md"), null);
+  assert.equal(openspec.readArtifact(cwd, "add-auth", "proposal.md"), "");
+  assert.equal(openspec.resolveArtifact(cwd, "escaped-change", "proposal.md"), null);
 });
 
 test("toChangeId normalizes to kebab", () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { classify } from "../src/engine/file-class.ts";
 import { checkPlannerStages, checkTypePolicy } from "../src/engine/policy.ts";
 import { bashMutationKind, enforceDomainForTool, isCommitCommand } from "../src/engine/domain.ts";
@@ -187,7 +190,9 @@ test("enforce: coder upsert on plans/**/tasks.md is denied by type policy (G3)",
 
 // ── Both layers via enforceDomainForTool ───────────────────────────────────
 
-const ctx = { cwd: "/repo" } as any;
+const policyRoot = mkdtempSync(join(tmpdir(), "pi-hive-policy-"));
+mkdirSync(join(policyRoot, "src/tmp"), { recursive: true });
+const ctx = { cwd: policyRoot } as any;
 const codeDomain = [{ path: ".", read: true, upsert: true, delete: true }];
 
 function block(state: HiveState, agent: string, event: any): string | undefined {

--- a/tests/safe-path.test.ts
+++ b/tests/safe-path.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, win32 } from "node:path";
+import { test } from "node:test";
+import { hasForeignAbsoluteSyntax, isPathInside, resolveContainedPath, resolveProjectPath } from "../src/core/safe-path.ts";
+
+test("segment-aware containment rejects sibling prefixes and traversal", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-safe-path-"));
+  const sibling = `${root}-sibling`;
+  mkdirSync(sibling);
+  assert.equal(isPathInside(root, root), true);
+  assert.equal(isPathInside(root, join(root, "src/file.ts")), true);
+  assert.equal(isPathInside(root, sibling), false);
+  assert.equal(resolveProjectPath(root, "../outside.txt", { allowMissing: true }), null);
+  assert.equal(resolveProjectPath(root, join(sibling, "outside.txt"), { allowMissing: true }), null);
+});
+
+test("existing paths use realpath and reject symlink escapes", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-safe-path-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-safe-outside-"));
+  mkdirSync(join(root, "inside"));
+  writeFileSync(join(root, "inside/file.txt"), "inside");
+  writeFileSync(join(outside, "secret.txt"), "secret");
+  symlinkSync(join(root, "inside/file.txt"), join(root, "inside-link"));
+  symlinkSync(join(outside, "secret.txt"), join(root, "escape-link"));
+
+  const inside = resolveProjectPath(root, "inside-link");
+  assert.equal(inside?.canonicalPath, join(root, "inside/file.txt"));
+  assert.equal(resolveProjectPath(root, "escape-link"), null);
+  assert.equal(resolveContainedPath(root, join(root, "escape-link")), null);
+});
+
+test("new targets resolve through their nearest existing parent", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-safe-path-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-safe-outside-"));
+  mkdirSync(join(root, "inside"));
+  symlinkSync(join(root, "inside"), join(root, "inside-dir-link"));
+  symlinkSync(outside, join(root, "escape-dir-link"));
+
+  const safeNew = resolveProjectPath(root, "inside-dir-link/new/deep.txt", { allowMissing: true });
+  assert.equal(safeNew?.canonicalPath, join(root, "inside/new/deep.txt"));
+  assert.equal(safeNew?.exists, false);
+  assert.equal(resolveProjectPath(root, "escape-dir-link/new.txt", { allowMissing: true }), null);
+  assert.equal(resolveProjectPath(root, "missing.txt"), null);
+});
+
+test("broken symlinks and foreign absolute syntax fail closed", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-safe-path-"));
+  symlinkSync(join(root, "does-not-exist"), join(root, "broken"));
+  assert.equal(resolveProjectPath(root, "broken", { allowMissing: true }), null);
+  if (process.platform !== "win32") {
+    assert.equal(hasForeignAbsoluteSyntax("C:\\outside\\secret.txt"), true);
+    assert.equal(resolveProjectPath(root, "C:\\outside\\secret.txt", { allowMissing: true }), null);
+  }
+});
+
+test("Windows containment uses path segments rather than string prefixes", () => {
+  assert.equal(isPathInside("C:\\work\\app", "C:\\work\\app\\src\\x.ts", win32), true);
+  assert.equal(isPathInside("C:\\work\\app", "C:\\work\\application\\x.ts", win32), false);
+  assert.equal(isPathInside("C:\\work\\app", "D:\\work\\app\\x.ts", win32), false);
+  assert.equal(isPathInside("C:\\work\\app", "C:\\work\\app\\..\\secret.txt", win32), false);
+});

--- a/tests/static-path.test.ts
+++ b/tests/static-path.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dashboardFile } from "../src/observability/static.ts";
+
+test("dashboard static files reject traversal and sibling-prefix paths", () => {
+  assert.equal(dashboardFile("/../package.json"), null);
+  assert.equal(dashboardFile("/../../ui/web/package.json"), null);
+  assert.equal(dashboardFile("/assets/../../../SECURITY.md"), null);
+});


### PR DESCRIPTION
## Summary
- centralize lexical and canonical containment with segment-aware path.relative checks
- resolve existing paths through realpath and project missing targets from their nearest existing parent
- reject traversal, sibling-prefix collisions, broken links, foreign absolute syntax, and symlink escapes
- apply containment to agent domains, distiller targets, OpenSpec artifacts, static assets, agent prompts, skills, shared context, and knowledge refs
- add adversarial coverage for existing and nonexistent targets, domain-root escapes, Windows paths, OpenSpec links, and static traversal

## Testing
- just ci
- 162 Node tests passed
- 39 Bun tests passed