### PR TITLE
feat: bind approvals to artifact content

### DIFF
--- a/src/engine/openspec.ts
+++ b/src/engine/openspec.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, readIfSmall } from "../core/fs";
 import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
+import { resolveProjectIdentity, type ProjectIdentity } from "../shared/project-identity";
 
 // Thin, bounded wrapper around the OpenSpec CLI (@fission-ai/openspec).
 //
@@ -15,9 +18,9 @@ import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 // OpenSpec is the *store + validator*: it owns the artifact dependency graph
 // (proposal -> {design, specs} -> tasks) and validation, and reports readiness
 // per artifact via `openspec status --json`. It does NOT model human approval —
-// pi-hive owns the approval gate (verdicts in SQLite). `isReadyToExecute` here
-// answers only "are the artifacts materially complete + valid", which the
-// dispatch execution gate combines with pi-hive's own approval state.
+// pi-hive owns the approval gate (content-bound records in the global agent
+// directory). `isReadyToExecute` here answers only "are the artifacts materially
+// complete + valid", which dispatch combines with pi-hive's approval authority.
 
 // Node's Dirent, declared locally because the core tsconfig loads no @types/node
 // (matches the pattern in plan-store.ts / sdd.ts).
@@ -357,37 +360,332 @@ export function readArtifact(cwd: string, name: string, relPath: string): string
 }
 
 // ---------------------------------------------------------------------------
-// pi-hive approval gate (pi-hive owns approval; OpenSpec has no phase gates)
+// Content-bound approval authority
 // ---------------------------------------------------------------------------
 //
-// OpenSpec is the store + validator; it models artifact dependencies but not
-// human approval. pi-hive layers its own approval on top, persisted as a sidecar
-// under the change dir so the CORE (Node, inside the Pi session) can read it
-// without touching the dashboard's Bun SQLite. The self-hosted review surface
-// (Bun server, which has fs access to the project) writes it on approve.
+// Project files are agent-controlled and therefore cannot be an approval
+// authority. Automated and human records live in separate atomic files under
+// ~/.pi/agent/hive/approvals/<projectId>/<changeId>/<artifactId>/ (or the
+// configured PI_CODING_AGENT_DIR). Every standing verdict is revalidated
+// against the current artifact bytes before it can affect a gate.
 
-const APPROVAL_FILE = ".pi-hive-approval.json";
-
-// The four spec-driven artifacts, in dependency order, and each artifact's
-// direct upstream deps (mirrors what `openspec status --json` reports). A human
-// approval of an artifact is only meaningful while its upstream artifacts remain
-// approved, so DENYING an upstream artifact invalidates everything downstream.
+export const APPROVAL_SCHEMA_VERSION = 1 as const;
 export const ARTIFACT_ORDER = ["proposal", "design", "specs", "tasks"] as const;
 export type ArtifactId = (typeof ARTIFACT_ORDER)[number];
+export type ArtifactVerdict = "green" | "red" | null;
+export type AgentReviewVerdict = "green" | "yellow" | "red" | null;
+export type ApprovalAuthority = "automated-review" | "human";
+export type ApprovalLedger = Partial<Record<ArtifactId, ArtifactVerdict>>;
+export type AgentReviewLedger = Partial<Record<ArtifactId, AgentReviewVerdict>>;
+
+export interface ApprovalRecord {
+  schemaVersion: typeof APPROVAL_SCHEMA_VERSION;
+  authority: ApprovalAuthority;
+  projectId: string;
+  canonicalRoot: string;
+  changeId: string;
+  artifactId: ArtifactId;
+  verdict: Exclude<AgentReviewVerdict, null>;
+  actor: string;
+  timestamp: string;
+  artifactHash: string;
+  automatedReviewHash?: string;
+}
+
 const UPSTREAM: Record<ArtifactId, ArtifactId[]> = {
   proposal: [],
   design: ["proposal"],
   specs: ["proposal"],
   tasks: ["design", "specs"],
 };
+const APPROVAL_RECORD_MAX_BYTES = 16_000;
+const APPROVAL_ARTIFACT_MAX_BYTES = 64 * 1024 * 1024;
+const APPROVAL_SPEC_MAX_FILES = 10_000;
+const HASH_RE = /^[a-f0-9]{64}$/;
 
-// The set of artifacts that (transitively) depend on `artifact` — the ones whose
-// approval must be revoked when `artifact` is denied.
+function toArtifactId(artifact: string): ArtifactId | null {
+  const id = artifact.replace(/\.md$/, "").replace(/^specs.*/, "specs");
+  return (ARTIFACT_ORDER as readonly string[]).includes(id) ? (id as ArtifactId) : null;
+}
+
+function approvalIdentity(cwd: string): ProjectIdentity {
+  return resolveProjectIdentity(cwd);
+}
+
+function approvalBaseDir(): string {
+  const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+  return join(agentDir, "hive", "approvals");
+}
+
+export function approvalRecordPath(cwd: string, name: string, artifact: string, authority: ApprovalAuthority): string | null {
+  if (!isSafeChangeId(name)) return null;
+  const id = toArtifactId(artifact);
+  if (!id) return null;
+  const identity = approvalIdentity(cwd);
+  return join(approvalBaseDir(), identity.projectId, name, id, authority === "human" ? "human.json" : "automated.json");
+}
+
+function framed(hash: ReturnType<typeof createHash>, value: string | Uint8Array): void {
+  const bytes = typeof value === "string" ? Buffer.from(value, "utf8") : Buffer.from(value);
+  const size = Buffer.allocUnsafe(8);
+  size.writeBigUInt64BE(BigInt(bytes.byteLength));
+  hash.update(size);
+  hash.update(bytes);
+}
+
+function approvalSpecFiles(cwd: string, name: string): string[] | null {
+  const root = resolveArtifact(cwd, name, "specs");
+  if (!root) return null;
+  const files: string[] = [];
+  let overflow = false;
+  const walk = (dir: string, rel: string, depth: number): void => {
+    if (overflow || depth > 32) { overflow = true; return; }
+    let entries: FsDirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true }) as FsDirent[];
+    } catch {
+      overflow = true;
+      return;
+    }
+    for (const entry of entries) {
+      if (overflow) return;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(join(dir, entry.name), childRel, depth + 1);
+      else if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(`specs/${childRel}`);
+        if (files.length > APPROVAL_SPEC_MAX_FILES) overflow = true;
+      }
+    }
+  };
+  walk(root, "", 0);
+  return overflow || files.length === 0 ? null : files.sort((a, b) => a.localeCompare(b));
+}
+
+// Hash one exact top-level artifact, or a stable path+bytes aggregate for specs.
+// Length framing avoids ambiguous concatenations; sorted relative paths make the
+// specs hash independent of filesystem enumeration order while still changing
+// on rename/add/remove.
+export function artifactHash(cwd: string, name: string, artifact: string): string | null {
+  const id = toArtifactId(artifact);
+  if (!id || !isSafeChangeId(name)) return null;
+  const files = id === "specs" ? approvalSpecFiles(cwd, name) : [`${id}.md`];
+  if (!files) return null;
+  const hash = createHash("sha256").update("pi-hive-artifact-v1\0");
+  framed(hash, id);
+  let total = 0;
+  try {
+    for (const relPath of files) {
+      const target = resolveArtifact(cwd, name, relPath);
+      if (!target) return null;
+      const bytes = readFileSync(target);
+      total += bytes.byteLength;
+      if (total > APPROVAL_ARTIFACT_MAX_BYTES) return null;
+      framed(hash, relPath);
+      framed(hash, bytes);
+    }
+    return hash.digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function recordDigest(record: ApprovalRecord): string {
+  return createHash("sha256")
+    .update("pi-hive-approval-record-v1\0")
+    .update(JSON.stringify(record))
+    .digest("hex");
+}
+
+function validRecordShape(value: unknown, authority: ApprovalAuthority, identity: ProjectIdentity, name: string, id: ArtifactId): value is ApprovalRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const r = value as Record<string, unknown>;
+  const verdictOk = authority === "human"
+    ? r.verdict === "green" || r.verdict === "red"
+    : r.verdict === "green" || r.verdict === "yellow" || r.verdict === "red";
+  return r.schemaVersion === APPROVAL_SCHEMA_VERSION
+    && r.authority === authority
+    && r.projectId === identity.projectId
+    && r.canonicalRoot === identity.canonicalRoot
+    && r.changeId === name
+    && r.artifactId === id
+    && verdictOk
+    && typeof r.actor === "string" && r.actor.trim().length > 0
+    && typeof r.timestamp === "string" && Number.isFinite(Date.parse(r.timestamp))
+    && typeof r.artifactHash === "string" && HASH_RE.test(r.artifactHash)
+    && (r.automatedReviewHash === undefined || (typeof r.automatedReviewHash === "string" && HASH_RE.test(r.automatedReviewHash)));
+}
+
+function readApprovalRecord(cwd: string, name: string, id: ArtifactId, authority: ApprovalAuthority): ApprovalRecord | null {
+  try {
+    const identity = approvalIdentity(cwd);
+    const path = approvalRecordPath(cwd, name, id, authority);
+    if (!path) return null;
+    const raw = readIfSmall(path, APPROVAL_RECORD_MAX_BYTES);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return validRecordShape(parsed, authority, identity, name, id) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function currentAutomatedRecord(cwd: string, name: string, id: ArtifactId): ApprovalRecord | null {
+  const record = readApprovalRecord(cwd, name, id, "automated-review");
+  const currentHash = artifactHash(cwd, name, id);
+  return record && currentHash && record.artifactHash === currentHash ? record : null;
+}
+
+function currentHumanRecord(cwd: string, name: string, id: ArtifactId, seen = new Set<ArtifactId>()): ApprovalRecord | null {
+  if (seen.has(id)) return null;
+  seen.add(id);
+  const record = readApprovalRecord(cwd, name, id, "human");
+  const currentHash = artifactHash(cwd, name, id);
+  if (!record || !currentHash || record.artifactHash !== currentHash) return null;
+  if (record.verdict === "red") return record;
+  const automated = currentAutomatedRecord(cwd, name, id);
+  if (!automated || (automated.verdict !== "green" && automated.verdict !== "yellow")) return null;
+  if (record.automatedReviewHash !== recordDigest(automated)) return null;
+  for (const upstream of UPSTREAM[id]) {
+    if (currentHumanRecord(cwd, name, upstream, new Set(seen))?.verdict !== "green") return null;
+  }
+  return record;
+}
+
+function writeApprovalRecord(path: string, record: ApprovalRecord): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700);
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+    renameSync(tmp, path);
+  } catch (error) {
+    try { unlinkSync(tmp); } catch { /* best effort cleanup */ }
+    throw error;
+  }
+}
+
+function removeApprovalRecord(cwd: string, name: string, id: ArtifactId, authority: ApprovalAuthority): void {
+  const path = approvalRecordPath(cwd, name, id, authority);
+  if (!path) throw new Error(`Invalid approval target: ${name}/${id}`);
+  try {
+    unlinkSync(path);
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+export function readApprovalLedger(cwd: string, name: string): ApprovalLedger {
+  const ledger: ApprovalLedger = {};
+  for (const id of ARTIFACT_ORDER) {
+    const verdict = currentHumanRecord(cwd, name, id)?.verdict;
+    if (verdict === "green" || verdict === "red") ledger[id] = verdict;
+  }
+  return ledger;
+}
+
+export function readAgentReviewLedger(cwd: string, name: string): AgentReviewLedger {
+  const ledger: AgentReviewLedger = {};
+  for (const id of ARTIFACT_ORDER) {
+    const verdict = currentAutomatedRecord(cwd, name, id)?.verdict;
+    if (verdict === "green" || verdict === "yellow" || verdict === "red") ledger[id] = verdict;
+  }
+  return ledger;
+}
+
+// This function is called only from the trusted dashboard review hook. A green
+// human approval requires a current eligible automated record and current green
+// approvals for every direct upstream artifact.
+export function setArtifactApproval(cwd: string, name: string, artifact: string, verdict: ArtifactVerdict, by = "ui"): boolean {
+  const id = toArtifactId(artifact);
+  if (!id || !isSafeChangeId(name)) throw new Error(`Invalid approval target: ${name}/${artifact}`);
+  if (verdict === null) {
+    removeApprovalRecord(cwd, name, id, "human");
+    for (const down of downstreamOf(id)) removeApprovalRecord(cwd, name, down, "human");
+    return true;
+  }
+  if (!by.trim()) throw new Error("Approval actor is required");
+  const identity = approvalIdentity(cwd);
+  const hash = artifactHash(cwd, name, id);
+  if (!hash) throw new Error(`Cannot approve missing, unsafe, or oversized artifact: ${id}`);
+  const automated = currentAutomatedRecord(cwd, name, id);
+  if (verdict === "green") {
+    if (!automated || (automated.verdict !== "green" && automated.verdict !== "yellow")) {
+      throw new Error(`Artifact ${id} has no current eligible automated review`);
+    }
+    for (const upstream of UPSTREAM[id]) {
+      if (currentHumanRecord(cwd, name, upstream)?.verdict !== "green") {
+        throw new Error(`Artifact ${id} requires current human approval of ${upstream}`);
+      }
+    }
+  }
+  const path = approvalRecordPath(cwd, name, id, "human");
+  if (!path) throw new Error(`Invalid approval target: ${name}/${id}`);
+  writeApprovalRecord(path, {
+    schemaVersion: APPROVAL_SCHEMA_VERSION,
+    authority: "human",
+    projectId: identity.projectId,
+    canonicalRoot: identity.canonicalRoot,
+    changeId: name,
+    artifactId: id,
+    verdict,
+    actor: by.trim(),
+    timestamp: new Date().toISOString(),
+    artifactHash: hash,
+    ...(automated ? { automatedReviewHash: recordDigest(automated) } : {}),
+  });
+  if (verdict === "red") {
+    for (const down of downstreamOf(id)) removeApprovalRecord(cwd, name, down, "human");
+  }
+  return true;
+}
+
+export function artifactVerdict(cwd: string, name: string, artifact: string): ArtifactVerdict {
+  const id = toArtifactId(artifact);
+  return id ? (currentHumanRecord(cwd, name, id)?.verdict as ArtifactVerdict) ?? null : null;
+}
+
+export function setAgentReviewVerdict(cwd: string, name: string, artifact: string, verdict: AgentReviewVerdict, by = "agent-reviewer"): boolean {
+  const id = toArtifactId(artifact);
+  if (!id || !isSafeChangeId(name)) throw new Error(`Invalid automated review target: ${name}/${artifact}`);
+  if (verdict === null) {
+    removeApprovalRecord(cwd, name, id, "automated-review");
+    return true;
+  }
+  if (!by.trim()) throw new Error("Automated reviewer actor is required");
+  const identity = approvalIdentity(cwd);
+  const hash = artifactHash(cwd, name, id);
+  if (!hash) throw new Error(`Cannot review missing, unsafe, or oversized artifact: ${id}`);
+  const path = approvalRecordPath(cwd, name, id, "automated-review");
+  if (!path) throw new Error(`Invalid automated review target: ${name}/${id}`);
+  writeApprovalRecord(path, {
+    schemaVersion: APPROVAL_SCHEMA_VERSION,
+    authority: "automated-review",
+    projectId: identity.projectId,
+    canonicalRoot: identity.canonicalRoot,
+    changeId: name,
+    artifactId: id,
+    verdict,
+    actor: by.trim(),
+    timestamp: new Date().toISOString(),
+    artifactHash: hash,
+  });
+  return true;
+}
+
+export function agentReviewVerdict(cwd: string, name: string, artifact: string): AgentReviewVerdict {
+  const id = toArtifactId(artifact);
+  return id ? (currentAutomatedRecord(cwd, name, id)?.verdict as AgentReviewVerdict) ?? null : null;
+}
+
+export function isArtifactApproved(cwd: string, name: string, artifact: string): boolean {
+  return artifactVerdict(cwd, name, artifact) === "green";
+}
+
 function downstreamOf(artifact: ArtifactId): ArtifactId[] {
   const out: ArtifactId[] = [];
   for (const id of ARTIFACT_ORDER) {
     if (id === artifact) continue;
-    // Walk id's upstream chain; if it reaches `artifact`, it's downstream.
     const seen = new Set<ArtifactId>();
     const stack = [...UPSTREAM[id]];
     while (stack.length) {
@@ -399,127 +697,11 @@ function downstreamOf(artifact: ArtifactId): ArtifactId[] {
   return out;
 }
 
-export type ArtifactVerdict = "green" | "red" | null;
-export type AgentReviewVerdict = "green" | "yellow" | "red" | null;
-// Per-artifact approval ledger — pi-hive's own gate state, independent of
-// OpenSpec, persisted as a sidecar the CORE can read without SQLite.
-export type ApprovalLedger = Partial<Record<ArtifactId, ArtifactVerdict>>;
-export type AgentReviewLedger = Partial<Record<ArtifactId, AgentReviewVerdict>>;
-
-type ApprovalSidecar = {
-  approved?: boolean;
-  artifacts?: ApprovalLedger;
-  agentReviews?: AgentReviewLedger;
-  by?: string;
-  at?: string;
-};
-
-function approvalPath(cwd: string, name: string): string | null {
-  return resolveArtifact(cwd, name, APPROVAL_FILE);
-}
-
-function toArtifactId(artifact: string): ArtifactId | null {
-  const id = artifact.replace(/\.md$/, "").replace(/^specs.*/, "specs");
-  return (ARTIFACT_ORDER as readonly string[]).includes(id) ? (id as ArtifactId) : null;
-}
-
-// Read the ledger. Back-compat: the old flat shape {approved:true} maps to
-// {tasks:"green"} so pre-existing sidecars keep gating execution.
-function readApprovalSidecar(cwd: string, name: string): ApprovalSidecar {
-  const p = approvalPath(cwd, name);
-  if (!p) return {};
-  const raw = readIfSmall(p, 16_000);
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw) as ApprovalSidecar;
-  } catch {
-    return {};
-  }
-}
-
-export function readApprovalLedger(cwd: string, name: string): ApprovalLedger {
-  const parsed = readApprovalSidecar(cwd, name);
-  if (parsed.artifacts) return parsed.artifacts;
-  if (parsed.approved === true) return { tasks: "green" }; // legacy flat shape
-  return {};
-}
-
-export function readAgentReviewLedger(cwd: string, name: string): AgentReviewLedger {
-  return readApprovalSidecar(cwd, name).agentReviews || {};
-}
-
-// Atomic write (temp + rename) so the core dispatch gate never reads a
-// half-written ledger. Single writer in practice, but preserve unrelated sidecar
-// sections so UI approvals and agent-review gates do not overwrite each other.
-function writeApprovalSidecar(cwd: string, name: string, sidecar: ApprovalSidecar, by: string): boolean {
-  const p = approvalPath(cwd, name);
-  if (!p) return false;
-  try {
-    ensureDir(dirname(p));
-    const tmp = `${p}.${process.pid}.tmp`;
-    writeFileSync(tmp, `${JSON.stringify({ ...sidecar, by, at: new Date().toISOString() }, null, 2)}\n`);
-    renameSync(tmp, p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function writeApprovalLedger(cwd: string, name: string, ledger: ApprovalLedger, by: string): boolean {
-  return writeApprovalSidecar(cwd, name, { ...readApprovalSidecar(cwd, name), artifacts: ledger }, by);
-}
-
-// Record a human verdict for one artifact. On a DENY (red), also revoke the
-// approval of every downstream artifact — work built on a rejected upstream
-// artifact can no longer be trusted, so the pipeline rewinds.
-export function setArtifactApproval(cwd: string, name: string, artifact: string, verdict: ArtifactVerdict, by = "ui"): boolean {
-  const id = toArtifactId(artifact);
-  if (!id) return false;
-  const ledger = readApprovalLedger(cwd, name);
-  ledger[id] = verdict;
-  if (verdict === "red") {
-    for (const down of downstreamOf(id)) ledger[down] = null;
-  }
-  return writeApprovalLedger(cwd, name, ledger, by);
-}
-
-export function artifactVerdict(cwd: string, name: string, artifact: string): ArtifactVerdict {
-  const id = toArtifactId(artifact);
-  if (!id) return null;
-  return readApprovalLedger(cwd, name)[id] ?? null;
-}
-
-export function setAgentReviewVerdict(cwd: string, name: string, artifact: string, verdict: AgentReviewVerdict, by = "agent-reviewer"): boolean {
-  const id = toArtifactId(artifact);
-  if (!id) return false;
-  const sidecar = readApprovalSidecar(cwd, name);
-  const agentReviews = { ...(sidecar.agentReviews || {}) };
-  agentReviews[id] = verdict;
-  return writeApprovalSidecar(cwd, name, { ...sidecar, agentReviews }, by);
-}
-
-export function agentReviewVerdict(cwd: string, name: string, artifact: string): AgentReviewVerdict {
-  const id = toArtifactId(artifact);
-  if (!id) return null;
-  return readAgentReviewLedger(cwd, name)[id] ?? null;
-}
-
-export function isArtifactApproved(cwd: string, name: string, artifact: string): boolean {
-  return artifactVerdict(cwd, name, artifact) === "green";
-}
-
-// An artifact may be AUTHORED (by a planner) only when every one of its upstream
-// dependencies has a standing green approval. This is the per-artifact planning
-// gate the dispatch guard consults (H2).
 export function canAuthorArtifact(cwd: string, name: string, artifact: string): boolean {
   const id = toArtifactId(artifact);
-  if (!id) return false;
-  const ledger = readApprovalLedger(cwd, name);
-  return UPSTREAM[id].every((dep) => ledger[dep] === "green");
+  return id ? UPSTREAM[id].every((dep) => isArtifactApproved(cwd, name, dep)) : false;
 }
 
-// The next artifact the planning team should author: the first in dependency
-// order that is not yet on disk and whose upstream deps are all approved.
 export function nextAuthorableArtifact(cwd: string, name: string): ArtifactId | null {
   const files = new Set(listArtifacts(cwd, name).map((f) => f.replace(/\.md$/, "")));
   const hasSpecs = existsSync(join(cwd, "openspec", "changes", name, "specs"));
@@ -530,37 +712,25 @@ export function nextAuthorableArtifact(cwd: string, name: string): ArtifactId | 
   return null;
 }
 
-// True once the tasks artifact is human-approved. Retained name for the
-// execution-gate callers; now backed by the per-artifact ledger.
 export function isApprovedForExecution(cwd: string, name: string): boolean {
-  return isArtifactApproved(cwd, name, "tasks");
+  return ARTIFACT_ORDER.every((id) => isArtifactApproved(cwd, name, id));
 }
 
-// The most-recently-authored artifact that the human has NOT YET decided on
-// (ledger entry is absent — not green, not red). A red entry means the human
-// asked for a revision, which is a permitted planner action, so it does not
-// count as "awaiting". Returns null when there is nothing waiting on the human.
 export function pendingReviewArtifact(cwd: string, name: string): ArtifactId | null {
   const files = new Set(listArtifacts(cwd, name).map((f) => f.replace(/\.md$/, "")));
   const hasSpecs = existsSync(join(cwd, "openspec", "changes", name, "specs"));
-  const ledger = readApprovalLedger(cwd, name);
-  let pending: ArtifactId | null = null;
+  // Return the earliest invalid artifact so an upstream edit rewinds review to
+  // the correct dependency instead of presenting a still-authored downstream
+  // artifact first. Automated red means that same artifact is awaiting planner
+  // revision, not human review, so the planning gate remains open for revision.
   for (const id of ARTIFACT_ORDER) {
     const present = id === "specs" ? hasSpecs : files.has(id);
-    // If the automated reviewer already rejected this artifact, it is not
-    // awaiting human review; it is awaiting same-artifact revision. Missing or
-    // green/yellow agent review still holds the pipeline before the next artifact.
-    if (present && ledger[id] == null && agentReviewVerdict(cwd, name, id) !== "red") pending = id;
+    if (!present || artifactVerdict(cwd, name, id) !== null) continue;
+    return agentReviewVerdict(cwd, name, id) === "red" ? null : id;
   }
-  return pending;
+  return null;
 }
 
-// The core hard-stop planning gate: once an artifact is authored and awaiting
-// the human's first decision, the planning team may NOT author the next one
-// until the human approves. Returns the artifact holding the pipeline, or null
-// when planning may proceed (nothing authored-and-undecided). A DENIED artifact
-// does not block — revising it is exactly what the planner should do next.
-// Ledger+files only (core-readable, no SQLite).
 export function isAwaitingHumanApproval(cwd: string, name: string): ArtifactId | null {
   return pendingReviewArtifact(cwd, name);
 }

--- a/src/integration/commands.ts
+++ b/src/integration/commands.ts
@@ -76,7 +76,7 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
         return;
       }
       if (!openspec.isApprovedForExecution(ctx.cwd, changeId)) {
-        if (ctx.hasUI) ctx.ui.notify(`Change "${changeId}" is not approved for execution yet. Approve its tasks artifact in the dashboard's plan-review UI first.`, "error");
+        if (ctx.hasUI) ctx.ui.notify(`Change "${changeId}" is not approved for execution yet. Current human approvals are required for proposal, design, specs, and tasks.`, "error");
         return;
       }
       // Select the change so delegations are scoped to it, ensure HIVE (execution)

--- a/src/observability/server/plan-routes.ts
+++ b/src/observability/server/plan-routes.ts
@@ -47,18 +47,12 @@ export interface PlanDetail {
   verdicts: ReturnType<typeof listVerdicts>;
 }
 
-// The reviewer AGENT's standing verdict for an artifact. The sidecar is the
-// source of truth for new reviews because it is keyed by artifact and readable
-// by the core dispatch gate. Fall back to old change-level SQLite verdicts only
-// when no sidecar agent-review state exists at all (legacy sessions).
+// Only a current, content-bound automated record clears an artifact. Historical
+// SQLite verdicts and project-controlled legacy sidecars remain visible as
+// history but never become approval authority.
 function agentClearedArtifact(cwd: string, changeId: string, artifact: string): boolean {
-  const sidecarVerdict = openspec.agentReviewVerdict(cwd, changeId, artifact);
-  if (sidecarVerdict) return sidecarVerdict === "green" || sidecarVerdict === "yellow";
-  if (Object.keys(openspec.readAgentReviewLedger(cwd, changeId)).length > 0) return false;
-
-  const verdicts = listVerdicts(changeId, cwd).filter((v) => v.reviewer !== "ui");
-  if (!verdicts.length) return false;
-  return verdicts[0].verdict === "green" || verdicts[0].verdict === "yellow";
+  const verdict = openspec.agentReviewVerdict(cwd, changeId, artifact);
+  return verdict === "green" || verdict === "yellow";
 }
 
 export function planDetail(cwd: string, changeId: string): PlanDetail | null {

--- a/src/observability/server/review-wiring.ts
+++ b/src/observability/server/review-wiring.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { handleReviewSurface, registerReviewSurface, renderReviewInput, type ReviewContext, type ReviewInput, type ReviewSurface } from "../../engine/review";
 import { parseRid } from "../../engine/review";
 import * as openspec from "../../engine/openspec";
-import { insertPlanVerdict, listVerdicts } from "./db";
+import { insertPlanVerdict } from "./db";
 import { enqueueDashboardAction, resolveProjectCwd } from "./plan-bridge";
 
 // Bun-side wiring for the self-hosted Plannotator plan-review surface. Builds the
@@ -29,19 +29,10 @@ function recordVerdict(ctx: ReviewContext, verdict: "green" | "red", feedback: s
 }
 
 function latestAgentVerdict(ctx: ReviewContext): openspec.AgentReviewVerdict {
-  const sidecarVerdict = openspec.agentReviewVerdict(ctx.cwd, ctx.change, ctx.artifact);
-  if (sidecarVerdict) return sidecarVerdict;
-
-  // If any structured per-artifact review state exists, absence for THIS
-  // artifact is meaningful: do not fall back to a change-level SQLite verdict
-  // from another artifact. That mismatch is what made proposal approval look
-  // available and then reject in the live session.
-  if (Object.keys(openspec.readAgentReviewLedger(ctx.cwd, ctx.change)).length > 0) return null;
-
-  // Older reviewer flows may have only persisted a change-level SQLite verdict.
-  // Use it only for fully legacy changes with no sidecar agent-review state.
-  const verdict = listVerdicts(ctx.change, ctx.cwd).find((v) => v.reviewer !== "ui")?.verdict;
-  return verdict === "green" || verdict === "yellow" || verdict === "red" ? verdict : null;
+  // Only a current, content-bound automated-review record can make an artifact
+  // eligible for human approval. SQLite rows and project sidecars are display
+  // history, not authority, and deliberately receive no migration fallback.
+  return openspec.agentReviewVerdict(ctx.cwd, ctx.change, ctx.artifact);
 }
 
 const surface: ReviewSurface | null = registerReviewSurface({
@@ -73,11 +64,11 @@ const surface: ReviewSurface | null = registerReviewSurface({
         });
         return;
       }
-      recordVerdict(ctx, "green", feedback);
-      // Record the human's per-artifact approval in the ledger. This both
-      // advances the planning gate (the next artifact becomes authorable) and,
-      // for tasks, opens the execution gate.
+      // Persist authority first. If the atomic write fails, the exception
+      // reaches the request handler; no success verdict or unblock action is
+      // recorded. This both advances planning and, for tasks, may open execution.
       openspec.setArtifactApproval(ctx.cwd, ctx.change, ctx.artifact, "green");
+      recordVerdict(ctx, "green", feedback);
       // Unblock the live session: the artifact's gate is satisfied; the planner
       // proceeds to the next authorable artifact (or /hive-execute once tasks
       // pass validation).
@@ -96,11 +87,10 @@ const surface: ReviewSurface | null = registerReviewSurface({
       // ("on <quote>: <comment>") so the planner gets anchored, per-location
       // guidance instead of a single blob.
       const feedback = renderReviewInput(input);
-      recordVerdict(ctx, "red", feedback);
-      // Record the human's per-artifact denial. This revokes the artifact's
-      // approval AND (in the ledger) every downstream artifact's approval, since
-      // work built on a rejected upstream artifact can no longer be trusted.
+      // Persist authority before display history or planner actions. A denial
+      // removes downstream human records; write failures propagate fail-closed.
       openspec.setArtifactApproval(ctx.cwd, ctx.change, ctx.artifact, "red");
+      recordVerdict(ctx, "red", feedback);
       // Route the structured feedback back to the planning agent.
       enqueueDashboardAction(ctx.cwd, {
         type: "plan_review_denied",

--- a/src/observability/server/runtime.ts
+++ b/src/observability/server/runtime.ts
@@ -373,7 +373,7 @@ function materializePlanEvent(event: HiveTelemetryEvent) {
   // approvals and comments used to come from the in-house approve_plan tool and
   // the home-grown annotator; both are gone — approval/annotation now happens in
   // the self-hosted Plannotator review surface, which writes plan_verdicts + the
-  // execution-approval sidecar directly (see review-wiring.ts). The
+  // content-bound global approval authority directly (see review-wiring.ts). The
   // plan_approvals / plan_comments tables are left in place (no DROP migration);
   // they simply stop receiving new rows.
   if (event.type === "review_verdict") {

--- a/tests/openspec.test.ts
+++ b/tests/openspec.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -8,8 +9,21 @@ import { parseRid, renderReviewInput, ridFromReferer } from "../src/engine/revie
 import { resolveHiveSddStatus } from "../src/engine/sdd.ts";
 import type { HiveState } from "../src/core/types.ts";
 
+process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "pi-hive-approval-agent-"));
+
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "pi-hive-osx-"));
+}
+
+function changeDir(cwd: string, name = "add-auth"): string {
+  const dir = join(cwd, "openspec", "changes", name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function clearAndApprove(cwd: string, name: string, artifact: string, actor = "Human Reviewer"): void {
+  openspec.setAgentReviewVerdict(cwd, name, artifact, "green", "Plan Reviewer");
+  openspec.setArtifactApproval(cwd, name, artifact, "green", actor);
 }
 
 function emptyState(): HiveState {
@@ -82,64 +96,151 @@ test("specs glob expands to concrete spec markdown for review", () => {
   assert.match(openspec.readArtifact(cwd, "add-auth", "specs/auth"), /ADDED Requirements/);
 });
 
-test("per-artifact approval ledger round-trips and gates execution", () => {
+test("content-bound automated and human records are separate and versioned", () => {
   const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
-  openspec.setArtifactApproval(cwd, "add-auth", "tasks.md", "green");
-  assert.equal(openspec.isArtifactApproved(cwd, "add-auth", "tasks"), true);
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
-  openspec.setArtifactApproval(cwd, "add-auth", "tasks", "red");
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# p\n");
+
+  assert.throws(() => openspec.setArtifactApproval(cwd, "add-auth", "proposal", "green"), /no current eligible automated review/);
+  openspec.setAgentReviewVerdict(cwd, "add-auth", "proposal", "green", "Plan Reviewer");
+  writeFileSync(join(dir, "proposal.md"), "# changed after review\n");
+  assert.throws(() => openspec.setArtifactApproval(cwd, "add-auth", "proposal", "green"), /no current eligible automated review/);
+  clearAndApprove(cwd, "add-auth", "proposal");
+
+  const automatedPath = openspec.approvalRecordPath(cwd, "add-auth", "proposal", "automated-review")!;
+  const humanPath = openspec.approvalRecordPath(cwd, "add-auth", "proposal", "human")!;
+  assert.notEqual(automatedPath, humanPath);
+  assert.ok(existsSync(automatedPath));
+  assert.ok(existsSync(humanPath));
+  const automated = JSON.parse(readFileSync(automatedPath, "utf8"));
+  const human = JSON.parse(readFileSync(humanPath, "utf8"));
+  assert.equal(automated.schemaVersion, openspec.APPROVAL_SCHEMA_VERSION);
+  assert.equal(automated.authority, "automated-review");
+  assert.equal(human.authority, "human");
+  assert.equal(human.projectId, automated.projectId);
+  assert.equal(human.canonicalRoot, cwd);
+  assert.equal(human.changeId, "add-auth");
+  assert.equal(human.artifactId, "proposal");
+  assert.equal(human.actor, "Human Reviewer");
+  assert.match(human.artifactHash, /^[a-f0-9]{64}$/);
+  assert.match(human.automatedReviewHash, /^[a-f0-9]{64}$/);
+  assert.ok(Number.isFinite(Date.parse(human.timestamp)));
 });
 
-test("legacy flat sidecar {approved:true} maps to tasks green", () => {
+test("legacy project sidecars never open execution", () => {
   const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, ".pi-hive-approval.json"), JSON.stringify({ approved: true }));
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
-});
-
-test("denying an upstream artifact invalidates everything downstream", () => {
-  const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
-  // Approve the whole chain.
-  for (const a of ["proposal", "design", "specs", "tasks"]) openspec.setArtifactApproval(cwd, "add-auth", a, "green");
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
-  // Deny design — only tasks depends on design (specs is a sibling), so tasks is
-  // revoked but specs and proposal are untouched.
-  openspec.setArtifactApproval(cwd, "add-auth", "design", "red");
-  assert.equal(openspec.artifactVerdict(cwd, "add-auth", "design"), "red");
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, ".pi-hive-approval.json"), JSON.stringify({ approved: true, artifacts: { tasks: "green" } }));
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
   assert.equal(openspec.artifactVerdict(cwd, "add-auth", "tasks"), null);
-  assert.equal(openspec.artifactVerdict(cwd, "add-auth", "specs"), "green"); // sibling, untouched
-  assert.equal(openspec.artifactVerdict(cwd, "add-auth", "proposal"), "green"); // upstream, untouched
-  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
+});
 
-  // Deny proposal — everything downstream (design, specs, tasks) is revoked.
-  for (const a of ["proposal", "design", "specs", "tasks"]) openspec.setArtifactApproval(cwd, "add-auth", a, "green");
-  openspec.setArtifactApproval(cwd, "add-auth", "proposal", "red");
+test("editing approved bytes invalidates that artifact and downstream approvals", () => {
+  const cwd = scratch();
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# p\n");
+  writeFileSync(join(dir, "design.md"), "# d\n");
+  mkdirSync(join(dir, "specs", "auth"), { recursive: true });
+  writeFileSync(join(dir, "specs", "auth", "spec.md"), "# s\n");
+  writeFileSync(join(dir, "tasks.md"), "# tasks\n- [ ] one\n");
+  for (const artifact of openspec.ARTIFACT_ORDER) clearAndApprove(cwd, "add-auth", artifact);
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
+
+  writeFileSync(join(dir, "tasks.md"), "# tasks revised\n- [ ] one\n");
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
+  clearAndApprove(cwd, "add-auth", "tasks");
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
+
+  writeFileSync(join(dir, "proposal.md"), "# changed\n");
+  assert.equal(openspec.artifactVerdict(cwd, "add-auth", "proposal"), null);
   assert.equal(openspec.artifactVerdict(cwd, "add-auth", "design"), null);
   assert.equal(openspec.artifactVerdict(cwd, "add-auth", "specs"), null);
   assert.equal(openspec.artifactVerdict(cwd, "add-auth", "tasks"), null);
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
+});
+
+test("denying an upstream artifact removes downstream human records", () => {
+  const cwd = scratch();
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# p\n");
+  writeFileSync(join(dir, "design.md"), "# d\n");
+  mkdirSync(join(dir, "specs", "auth"), { recursive: true });
+  writeFileSync(join(dir, "specs", "auth", "spec.md"), "# s\n");
+  writeFileSync(join(dir, "tasks.md"), "# tasks\n- [ ] one\n");
+  for (const artifact of openspec.ARTIFACT_ORDER) clearAndApprove(cwd, "add-auth", artifact);
+  openspec.setArtifactApproval(cwd, "add-auth", "proposal", "red", "Human Reviewer");
+  assert.equal(openspec.artifactVerdict(cwd, "add-auth", "proposal"), "red");
+  for (const artifact of ["design", "specs", "tasks"] as const) {
+    assert.equal(openspec.artifactVerdict(cwd, "add-auth", artifact), null);
+    assert.equal(existsSync(openspec.approvalRecordPath(cwd, "add-auth", artifact, "human")!), false);
+  }
+});
+
+test("spec aggregate hash is stable across creation order and changes on membership", () => {
+  const cwd = scratch();
+  const first = changeDir(cwd, "first");
+  const second = changeDir(cwd, "second");
+  for (const dir of [first, second]) mkdirSync(join(dir, "specs"), { recursive: true });
+  writeFileSync(join(first, "specs", "b.md"), "B\n");
+  writeFileSync(join(first, "specs", "a.md"), "A\n");
+  writeFileSync(join(second, "specs", "a.md"), "A\n");
+  writeFileSync(join(second, "specs", "b.md"), "B\n");
+  assert.equal(openspec.artifactHash(cwd, "first", "specs"), openspec.artifactHash(cwd, "second", "specs"));
+  const before = openspec.artifactHash(cwd, "first", "specs");
+  writeFileSync(join(first, "specs", "c.md"), "C\n");
+  assert.notEqual(openspec.artifactHash(cwd, "first", "specs"), before);
+});
+
+test("concurrent automated and human writers do not overwrite one another", async () => {
+  const cwd = scratch();
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# p\n");
+  openspec.setAgentReviewVerdict(cwd, "add-auth", "proposal", "green", "Initial Reviewer");
+  const modulePath = join(process.cwd(), "src", "engine", "openspec.ts");
+  const loaderPath = join(process.cwd(), "tests", "register-ts-loader.mjs");
+  const run = (expression: string) => new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", loaderPath, "--input-type=module", "-e", expression], {
+      env: process.env,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("exit", (code: number | null) => code === 0 ? resolve() : reject(new Error(stderr || `child exited ${code}`)));
+  });
+  const imported = JSON.stringify(modulePath);
+  const project = JSON.stringify(cwd);
+  await Promise.all([
+    run(`const o=await import(${imported});o.setAgentReviewVerdict(${project},"add-auth","proposal","green","Concurrent Reviewer")`),
+    run(`const o=await import(${imported});o.setArtifactApproval(${project},"add-auth","proposal","green","Concurrent Human")`),
+  ]);
+  assert.ok(existsSync(openspec.approvalRecordPath(cwd, "add-auth", "proposal", "automated-review")!));
+  assert.ok(existsSync(openspec.approvalRecordPath(cwd, "add-auth", "proposal", "human")!));
+});
+
+test("approval persistence failures propagate", () => {
+  const cwd = scratch();
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# p\n");
+  const prior = process.env.PI_CODING_AGENT_DIR;
+  const blocked = join(scratch(), "not-a-directory");
+  writeFileSync(blocked, "file");
+  process.env.PI_CODING_AGENT_DIR = blocked;
+  try {
+    assert.throws(() => openspec.setAgentReviewVerdict(cwd, "add-auth", "proposal", "green"));
+  } finally {
+    process.env.PI_CODING_AGENT_DIR = prior;
+  }
 });
 
 test("isAwaitingHumanApproval halts the pipeline until the human decides", () => {
   const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
-  // Nothing authored yet → nothing pending.
+  const dir = changeDir(cwd);
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), null);
-  // Author proposal, no human verdict yet → pipeline awaits approval of proposal.
   writeFileSync(join(dir, "proposal.md"), "# p\n");
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), "proposal");
-  // Human approves proposal → no longer awaiting.
-  openspec.setArtifactApproval(cwd, "add-auth", "proposal", "green");
+  clearAndApprove(cwd, "add-auth", "proposal");
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), null);
-  // Author design, then human DENIES it → a denied artifact does NOT block
-  // (revising it is the intended next planner action).
   writeFileSync(join(dir, "design.md"), "# d\n");
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), "design");
   openspec.setArtifactApproval(cwd, "add-auth", "design", "red");
@@ -148,8 +249,7 @@ test("isAwaitingHumanApproval halts the pipeline until the human decides", () =>
 
 test("agent reviewer red unlocks same-artifact revision without human denial", () => {
   const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
+  const dir = changeDir(cwd);
   writeFileSync(join(dir, "proposal.md"), "# p\n");
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), "proposal");
   openspec.setAgentReviewVerdict(cwd, "add-auth", "proposal.md", "red", "Plan Reviewer");
@@ -157,19 +257,18 @@ test("agent reviewer red unlocks same-artifact revision without human denial", (
   assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), null);
 });
 
-test("canAuthorArtifact enforces upstream approval; nextAuthorable walks the pipeline", () => {
+test("canAuthorArtifact enforces current upstream approval", () => {
   const cwd = scratch();
-  const dir = join(cwd, "openspec", "changes", "add-auth");
-  mkdirSync(dir, { recursive: true });
-  // Nothing approved: only proposal (no upstream deps) is authorable.
+  const dir = changeDir(cwd);
   assert.equal(openspec.canAuthorArtifact(cwd, "add-auth", "proposal"), true);
   assert.equal(openspec.canAuthorArtifact(cwd, "add-auth", "design"), false);
   assert.equal(openspec.nextAuthorableArtifact(cwd, "add-auth"), "proposal");
-  // Author + approve proposal → design and specs become authorable.
   writeFileSync(join(dir, "proposal.md"), "# p\n");
-  openspec.setArtifactApproval(cwd, "add-auth", "proposal", "green");
+  clearAndApprove(cwd, "add-auth", "proposal");
   assert.equal(openspec.canAuthorArtifact(cwd, "add-auth", "design"), true);
   assert.equal(openspec.nextAuthorableArtifact(cwd, "add-auth"), "design");
+  writeFileSync(join(dir, "proposal.md"), "# revised\n");
+  assert.equal(openspec.canAuthorArtifact(cwd, "add-auth", "design"), false);
 });
 
 // --- review rid parsing ---

--- a/tests/plan-server.spec.ts
+++ b/tests/plan-server.spec.ts
@@ -11,6 +11,7 @@ const PROJECT = mkdtempSync(join(tmpdir(), "pi-hive-plansrv-"));
 // server/config.ts reads these at import; point them at throwaway locations.
 process.env.HIVE_PROJECT_CWD = PROJECT;
 process.env.HIVE_TELEMETRY_DB = join(mkdtempSync(join(tmpdir(), "pi-hive-plansrv-db-")), "telemetry.db");
+process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "pi-hive-plansrv-agent-"));
 
 // Resolve the OpenSpec binary the same way src/engine/openspec.ts does; skip the
 // CLI-dependent assertions when it is absent.
@@ -92,7 +93,7 @@ async function approveProposal(changeId: string, activeProject: string) {
   return review.handlePlanReview(req, new URL(req.url));
 }
 
-test("review approval honors legacy SQLite-only agent verdicts", async () => {
+test("review approval ignores legacy SQLite-only agent verdicts", async () => {
   const activeProject = bridge.resolveProjectCwd(null)!;
   const changeId = "legacy-agent-green";
   const dir = join(activeProject, "openspec", "changes", changeId);
@@ -111,13 +112,30 @@ test("review approval honors legacy SQLite-only agent verdicts", async () => {
   try {
     const res = await approveProposal(changeId, activeProject);
     expect(res?.status).toBe(200);
-    expect(openspec.artifactVerdict(activeProject, changeId, "proposal.md")).toBe("green");
+    expect(openspec.artifactVerdict(activeProject, changeId, "proposal.md")).toBeNull();
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("review approval does not borrow SQLite verdicts when sidecar targets another artifact", async () => {
+test("review approval accepts a current content-bound automated verdict", async () => {
+  const activeProject = bridge.resolveProjectCwd(null)!;
+  const changeId = "current-agent-green";
+  const dir = join(activeProject, "openspec", "changes", changeId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "proposal.md"), "# Current agent green\n\nReady.\n");
+  openspec.setAgentReviewVerdict(activeProject, changeId, "proposal", "green", "Plan Reviewer");
+
+  try {
+    const res = await approveProposal(changeId, activeProject);
+    expect(res?.status).toBe(200);
+    expect(openspec.artifactVerdict(activeProject, changeId, "proposal")).toBe("green");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("review approval does not borrow SQLite verdicts for another artifact", async () => {
   const activeProject = bridge.resolveProjectCwd(null)!;
   const changeId = "sidecar-mismatch";
   const dir = join(activeProject, "openspec", "changes", changeId);
@@ -132,7 +150,6 @@ test("review approval does not borrow SQLite verdicts when sidecar targets anoth
     cwd: activeProject,
     createdAt: new Date().toISOString(),
   });
-  openspec.setAgentReviewVerdict(activeProject, changeId, "tasks", "green", "Plan Reviewer");
 
   try {
     const res = await approveProposal(changeId, activeProject);
@@ -143,7 +160,7 @@ test("review approval does not borrow SQLite verdicts when sidecar targets anoth
   }
 });
 
-test.if(OSX)("planDetail does not show review-now for artifacts missing sidecar verdicts", () => {
+test.if(OSX)("planDetail does not show review-now for artifacts missing authoritative verdicts", () => {
   const changeId = "sidecar-mismatch-detail";
   osx(["new", "change", changeId]);
   const dir = join(PROJECT, "openspec", "changes", changeId);
@@ -157,7 +174,6 @@ test.if(OSX)("planDetail does not show review-now for artifacts missing sidecar 
     cwd: PROJECT,
     createdAt: new Date().toISOString(),
   });
-  openspec.setAgentReviewVerdict(PROJECT, changeId, "tasks", "green", "Plan Reviewer");
 
   try {
     const detail = routes.planDetail(PROJECT, changeId)!;

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -213,6 +213,15 @@ test("enforce: planner blocked from code, allowed spec", () => {
   assert.equal(block(state, "Plan", { toolName: "write", input: { path: ".pi/hive/plans/a/proposal.md" } }), undefined);
 });
 
+test("enforce: planner cannot forge global approval records with file tools or classified bash", () => {
+  const state = stateWith([runtime("Plan", { agentType: "planner", domain: [{ path: ".", read: true, upsert: true, delete: true }] })]);
+  const authority = "/home/test/.pi/agent/hive/approvals/project/change/proposal/human.json";
+  for (const toolName of ["write", "edit"]) {
+    assert.match(block(state, "Plan", { toolName, input: { path: authority } }) ?? "", /may not upsert|cannot modify/);
+  }
+  assert.match(block(state, "Plan", { toolName: "bash", input: { command: `cp ./approval.json ${authority}` } }) ?? "", /cannot upsert|may not upsert/);
+});
+
 test("enforce: planner stages narrow which gate files", () => {
   const specDomain = [{ path: ".", read: true, upsert: true, delete: false }];
   const state = stateWith([runtime("Plan", { agentType: "planner", stages: ["design"], domain: specDomain })]);

--- a/tests/verdicts.test.ts
+++ b/tests/verdicts.test.ts
@@ -84,8 +84,8 @@ test("submit_review_verdict caches the latest verdict per change and degrades wi
 
 // Note: gate approval is no longer a chat tool. Approving an artifact happens in
 // the dashboard's plan-review UI (POST /api/approve -> review-wiring), which
-// records a verdict and writes pi-hive's execution-approval sidecar. That path
-// is exercised through src/engine/review.ts + openspec.setExecutionApproval.
+// records a verdict and atomically writes pi-hive's global content-bound human
+// approval record. That path is exercised through review.ts + review-wiring.ts.
 
 test("team_status surfaces the latest verdict", async () => {
   const state = stateWith([runtime("Rev", { agentType: "reviewer" })]);


### PR DESCRIPTION
## Summary
- replace project-controlled approval sidecars with versioned, per-project approval records in the global Pi agent directory
- bind automated reviews and human approvals to canonical project identity and exact artifact hashes, including a stable aggregate for specs
- fail closed on stale, malformed, legacy, or unwritable records and require current upstream approvals before execution
- keep automated and human writers isolated in separate atomic files

## Tests
- `just ci`
- 167 Node tests passed
- 40 Bun tests passed
