### PR TITLE
fix: enforce read-only shell policy

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -242,7 +242,8 @@ Every agent (orchestrator, leads, members) is a Markdown file: **YAML frontmatte
 | `thinking` | **yes** | string | One of `off, minimal, low, medium, high, xhigh`. |
 | `agent-type` | **yes** | string | One of `planner, coder, tester, reviewer, lead`. Enforced capability type (see §7.1). Config **hard-fails** if missing/invalid. The orchestrator and every lead/routing node is `lead`. |
 | `stages` | no | list | **Planner-only.** Which planning gates this planner may write: any of `proposal, requirements, design, tasks`. Omitted = all four. Error if set on a non-planner. |
-| `commit` | no | string | Optional commit guidance. Its **presence** unlocks the commit gate for this agent (only leads carry it). The text is injected into the agent's prompt. |
+| `network` | no | boolean | Enables network commands for this worker. Defaults to `false`; the local pi-hive dashboard API remains blocked. |
+| `commit` | no | string | Optional commit guidance. Its **presence** unlocks the commit gate for a write-capable agent. It never overrides the read-only `reviewer`/`lead` type policy. |
 | `tools` | no | list | Allow-list of tool names for this agent. Falls back to `default-tools` if omitted. See §7. |
 | `context` | no | list of `{path, use-when}` | Files **always inlined** into the prompt (full content). The agent's always-on knowledge. |
 | `skills` | no | list of `{path, use-when}` | On-demand procedures using Pi's native skill system. Worker launches disable ambient discovery with `--no-skills` and pass these paths explicitly with `--skill`. |
@@ -294,8 +295,8 @@ Agent type is **separate from the derived tree role** (orchestrator/lead/member)
 | `planner` | `spec` / `docs` / `tasks` artifacts only — **never `code`** | no | no | Writes `proposal.md` / `requirements.md` / `design.md` / `tasks.md` under `.pi/hive/plans/`. Scope further with `stages`. |
 | `coder` | `code` / `docs` / `tasks` — **never `spec`** | no | only if it has a `commit:` field | Implements production code and tests **within its domain**. |
 | `tester` | tests (drawn by its domain `include`/`exclude` globs) | no | only with `commit:` | Writes tests, not production code. |
-| `reviewer` | **nothing (read-only)** — may run inspection/test `bash` | **yes** — `submit_review_verdict` (reviewer-only tool) | no | Reads and reviews; submits a structured red/yellow/green verdict. |
-| `lead` | **nothing (read-only)** | no | only if it has a `commit:` field | Delegates and coordinates. Includes the orchestrator. |
+| `reviewer` | **nothing (read-only)** — explicit inspection-command allowlist only | **yes** — `submit_review_verdict` (reviewer-only tool) | no | Reads and reviews; delegates tests to a tester; submits a structured red/yellow/green verdict. |
+| `lead` | **nothing (read-only)** — explicit inspection-command allowlist only | no | no | Delegates and coordinates. Includes the orchestrator. |
 
 **Two layers gate every mutation; both must pass.** (1) The **domain** globs (§8) — "may this agent touch this path at all?" (2) The **type policy** — "may this *type* perform this *action* on this *kind of file*?" So a `coder` whose domain allows `src/**` still cannot write a `.pi/hive/plans/**` spec file (wrong type), and a `planner` cannot write `src/**` even if its domain allows it (wrong type × class).
 
@@ -303,7 +304,11 @@ Agent type is **separate from the derived tree role** (orchestrator/lead/member)
 
 **Leads (including the orchestrator) cannot mutate files.** All mutation flows through typed `coder`/`tester` agents. Invariant: *if a file changed, a typed mutator did it.*
 
-**Commits are blocked at the tool layer** unless the agent's config has a non-empty **`commit:`** field (a static config fact — no review-state check). Local working-tree ops (`git merge`, `git rebase`, `git add`, `git status`, `git diff`) stay allowed; publish/history-creation (`git commit`, `git push`, `git tag`, `gh pr merge`, `gh release create`, `npm/pnpm/yarn/bun publish`, `just release`) is blocked without `commit:`. Only leads carry `commit:`; a lead commits the working tree that coders/testers produced. "Commit only when green" is prompt guidance in the `commit:` text, not a mechanical gate.
+**Reviewer and lead bash is fail-closed.** They may use the explicit file-inspection allowlist and non-mutating Git inspection (`status`, `diff`, `log`, `show`, `blame`, `rev-parse`, `ls-files`). Unknown commands, interpreters, tests/builds/task runners, patches, archive extraction, package installation, and every Git index/worktree/history mutation are blocked. Tests are potentially mutating project scripts and must be delegated to a `tester`; pi-hive does not provision disposable reviewer checkouts.
+
+**Commits are blocked at the tool layer** unless a write-capable agent's config has a non-empty **`commit:`** field (a static config fact — no review-state check). The field does not override the read-only `reviewer`/`lead` boundary. "Commit only when green" is prompt guidance in the `commit:` text, not a mechanical review-state gate.
+
+**Network commands are disabled by default.** Set `network: true` only on workers that require external access. This capability does not permit worker requests to the local pi-hive dashboard API.
 
 **`stages` (planner scoping).** A `planner` may optionally list which gate artifacts it may write: `stages: [proposal, requirements]`. Omitted = all four gates. One planner can own all gates, or you can run N specialist planners one gate each — same type, config decides granularity.
 
@@ -440,7 +445,6 @@ name: <Lead Name>
 model: inherit          # or a strong reasoning model, e.g. openai-codex/gpt-5.5
 thinking: off           # bump to low/medium for harder coordination
 agent-type: lead
-# commit: "Only commit when the user explicitly asks after review is green."  # uncomment on the lead that commits
 tools:
   - read
   - grep
@@ -591,7 +595,7 @@ Naming: prefix by scope — `behavior-*` (cross-cutting), `<role>-*` (role-owned
 - [ ] `.pi/hive/hive-config.yaml` exists (this is what activates the extension).
 - [ ] Every `path` in the config points to a file that **exists**.
 - [ ] Every agent `.md` has **`name`, `model`, `thinking`, `agent-type`** in frontmatter (these are required — missing `model`/`thinking`/`agent-type` throws at load). The orchestrator and every lead are `agent-type: lead`.
-- [ ] `stages` appears only on `agent-type: planner` agents. `commit:` unlocks the commit gate for whatever agent carries it: commit capability follows this config field, **not** agent-type — there is no "only leads may commit" enforcement, so a small project may deliberately give a leaf agent `commit:`. In practice you will usually put it only on the lead(s).
+- [ ] `stages` appears only on `agent-type: planner` agents. `network` is a boolean and is enabled only where external access is required. `commit:` unlocks the commit gate only for a write-capable agent; it cannot override a `reviewer`/`lead` read-only boundary.
 - [ ] Every `name` is **unique** across the tree and **matches** between config and the agent's frontmatter `name`.
 - [ ] Every agent has a sibling `<stem>-mental-model.yaml` with a valid spine and `owner` = the agent's name.
 - [ ] Every `context`/`skills`/`domain` path referenced in frontmatter **exists** (knowledge files created).

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -84,10 +84,10 @@ function warnOnPlanningExecutionAgents(planning: HiveTeam | undefined): void {
 
 function enrichFromFrontmatter(cwd: string, agent: AgentConfig | undefined): void {
   if (!agent) return;
-  // agent-type/stages/commit live in the agent's .md frontmatter (like
+  // agent-type/stages/network/commit live in the agent's .md frontmatter (like
   // model/thinking) but must be validated at the config layer, so copy them
   // onto the config node whenever the node itself does not already set them.
-  const needsEnrich = !agent.slug || !agent.model || !agent.thinking || agent.agentType === undefined || agent.stages === undefined || agent.commit === undefined;
+  const needsEnrich = !agent.slug || !agent.model || !agent.thinking || agent.agentType === undefined || agent.stages === undefined || agent.network === undefined || agent.commit === undefined;
   if (agent.path && needsEnrich) {
     const promptPath = resolveProjectPath(cwd, agent.path);
     const raw = promptPath ? safeRead(promptPath.canonicalPath) : "";
@@ -98,6 +98,7 @@ function enrichFromFrontmatter(cwd: string, agent: AgentConfig | undefined): voi
       if (!agent.thinking && attrs.thinking) agent.thinking = String(attrs.thinking).trim();
       if (agent.agentType === undefined) agent.agentType = normalizeAgentType(attrs.agentType) as AgentConfig["agentType"];
       if (agent.stages === undefined) agent.stages = normalizePlanStages(attrs.stages) as AgentConfig["stages"];
+      if (agent.network === undefined && attrs.network !== undefined) agent.network = attrs.network;
       if (agent.commit === undefined) agent.commit = normalizeCommit(attrs.commit);
     }
   }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -92,6 +92,9 @@ function validateAgentType(agent: AgentConfig, label: string) {
       }
     });
   }
+  if (agent.network !== undefined && typeof agent.network !== "boolean") {
+    throw new Error(`${label}.network must be true or false when provided.`);
+  }
   if (agent.commit !== undefined && (typeof agent.commit !== "string" || !agent.commit.trim())) {
     throw new Error(`${label}.commit must be a non-empty string when provided.`);
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -117,6 +117,9 @@ export interface AgentConfig {
   // Planner-only: which planning gate artifacts this planner may write.
   // Omitted = all four gates. Ignored for non-planners.
   stages?: PlanStage[];
+  // Optional network capability for bash commands. Disabled by default. This
+  // does not grant access to pi-hive's authenticated local dashboard API.
+  network?: boolean;
   // Optional commit guidance. Its PRESENCE (non-empty) unlocks the commit gate
   // for this agent; the text is injected into the agent's prompt as guidance.
   // DECISION (Phase 5.6): commit capability intentionally follows this `commit:`

--- a/src/engine/domain.ts
+++ b/src/engine/domain.ts
@@ -6,7 +6,7 @@ import { resolveRuntime } from "./agent-lookup";
 import { agentMatches } from "../core/utils";
 import { globToRegExp, globSpecificity, toPosixPath } from "./glob";
 import { classify } from "./file-class";
-import { checkPlannerStages, checkTypePolicy, type PolicyAction } from "./policy";
+import { checkPlannerStages, checkTypePolicy, type PolicyAction, type PolicyDecision } from "./policy";
 import { hasForeignAbsoluteSyntax, isPathInside, resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 
 function runtimeForCaller(state: HiveState, callerName: string): AgentRuntime | undefined {
@@ -143,19 +143,170 @@ export function extractBashPathTokens(command: string): string[] {
     .filter((token) => !token.startsWith("http://") && !token.startsWith("https://"))));
 }
 
+type ParsedCommand = { words: string[]; operatorBefore?: string };
+
+// A deliberately small shell lexer. It supports ordinary quoting and command
+// separators, but marks expansion/redirection syntax as unsafe for read-only
+// agents rather than pretending to understand a full shell grammar.
+function parseShellCommands(command: string): ParsedCommand[] | null {
+  const commands: ParsedCommand[] = [];
+  let words: string[] = [];
+  let word = "";
+  let quote = "";
+  let escaped = false;
+  let pendingOperator: string | undefined;
+  const pushWord = () => { if (word) { words.push(word); word = ""; } };
+  const pushCommand = (operator?: string) => {
+    pushWord();
+    if (!words.length) return false;
+    commands.push({ words, operatorBefore: pendingOperator });
+    words = [];
+    pendingOperator = operator;
+    return true;
+  };
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (escaped) { word += ch; escaped = false; continue; }
+    if (ch === "\\" && quote !== "'") { escaped = true; continue; }
+    if (quote) {
+      if (ch === quote) quote = "";
+      else word += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') { quote = ch; continue; }
+    if (/\s/.test(ch)) { pushWord(); continue; }
+    if (ch === ";" || ch === "|" || ch === "&") {
+      const pair = command.slice(i, i + 2);
+      const op = pair === "||" || pair === "&&" ? pair : ch;
+      if (op === "&") return null; // background jobs are ambiguous
+      if (!pushCommand(op)) return null;
+      if (op.length === 2) i++;
+      continue;
+    }
+    word += ch;
+  }
+  if (escaped || quote) return null;
+  pushWord();
+  if (words.length) commands.push({ words, operatorBefore: pendingOperator });
+  else if (pendingOperator) return null;
+  return commands.length ? commands : null;
+}
+
+const GIT_GLOBAL_VALUE_OPTIONS = new Set(["-C", "-c", "--git-dir", "--work-tree", "--namespace"]);
+
+function gitSubcommand(words: string[]): { subcommand: string; args: string[]; safeGlobals: boolean } | null {
+  if (words[0] !== "git") return null;
+  let i = 1;
+  let safeGlobals = true;
+  while (i < words.length) {
+    const token = words[i];
+    if (GIT_GLOBAL_VALUE_OPTIONS.has(token)) {
+      if (token === "-c") safeGlobals = false;
+      if (i + 1 >= words.length) return { subcommand: "", args: [], safeGlobals: false };
+      i += 2;
+      continue;
+    }
+    if (/^--(?:git-dir|work-tree|namespace)=/.test(token)) { i++; continue; }
+    if (/^-c=/.test(token)) { safeGlobals = false; i++; continue; }
+    if (token.startsWith("-")) { safeGlobals = false; i++; continue; }
+    break;
+  }
+  return { subcommand: words[i] || "", args: words.slice(i + 1), safeGlobals };
+}
+
+function classifiedGitSubcommand(words: string[]): ReturnType<typeof gitSubcommand> {
+  let i = 0;
+  if (words[i] === "command") i++;
+  if (words[i] === "env") {
+    i++;
+    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[i] || "")) i++;
+  }
+  return gitSubcommand(words.slice(i));
+}
+
+const GIT_DELETE_COMMANDS = new Set(["clean", "restore"]);
+const GIT_MUTATION_COMMANDS = new Set([
+  "add", "am", "apply", "checkout", "cherry-pick", "commit", "fetch", "merge",
+  "mv", "pull", "push", "rebase", "reset", "restore", "revert", "rm", "stash",
+  "switch", "tag",
+]);
+const READ_ONLY_GIT_COMMANDS = new Set(["status", "diff", "log", "show", "blame", "rev-parse", "ls-files"]);
+const READ_ONLY_COMMANDS = new Set([
+  "basename", "cat", "cd", "cmp", "cut", "dirname", "du", "file", "find", "grep",
+  "head", "ls", "pwd", "readlink", "realpath", "rg", "sort", "stat", "tail",
+  "uniq", "wc",
+]);
+const NETWORK_COMMANDS = new Set(["curl", "wget", "nc", "ncat", "telnet", "ssh", "scp", "sftp", "ftp"]);
+
+function commandUsesNetwork(parsed: ParsedCommand[], command = ""): boolean {
+  return parsed.some(({ words }) => NETWORK_COMMANDS.has(words[0] || ""))
+    || /(?:^|[\s;&|])(?:[^\s;&|]*\/)?(?:curl|wget|nc|ncat|telnet|ssh|scp|sftp|ftp)(?=\s|$)/.test(command);
+}
+
+function targetsDashboardLoopback(command: string): boolean {
+  return /(?:https?:\/\/)?(?:127(?:\.\d{1,3}){3}|localhost|0\.0\.0\.0|\[?::1\]?):43191(?:[\s/'"?]|$)/i.test(command);
+}
+
+// Reviewer/lead shell policy. Unknown commands, shell expansion, interpreters,
+// project scripts, and mutating Git are denied instead of falling through as
+// reads. Network inspection is opt-in and remains unable to reach the local
+// dashboard API.
+export function readOnlyCommandDecision(command: string, networkAllowed = false): PolicyDecision {
+  if (!command.trim()) return { ok: false, reason: "empty or pathless shell command" };
+  if (/[`$<>{}\n]/.test(command)) return { ok: false, reason: "shell expansion, redirection, or multiline syntax is not permitted" };
+  const parsed = parseShellCommands(command);
+  if (!parsed) return { ok: false, reason: "ambiguous shell syntax" };
+  if (targetsDashboardLoopback(command)) return { ok: false, reason: "worker access to the pi-hive dashboard loopback API is blocked" };
+  if (commandUsesNetwork(parsed, command) && !networkAllowed) return { ok: false, reason: "network access is not enabled for this agent" };
+
+  for (const { words } of parsed) {
+    const head = words[0] || "";
+    const git = gitSubcommand(words);
+    if (git) {
+      if (!git.safeGlobals || !READ_ONLY_GIT_COMMANDS.has(git.subcommand)) {
+        return { ok: false, reason: `git ${git.subcommand || "command"} is not an allowed inspection operation` };
+      }
+      if (git.args.some((arg) => arg === "--ext-diff" || arg === "--textconv" || arg === "--output" || arg.startsWith("--output=") || arg.startsWith("--exec="))) {
+        return { ok: false, reason: `git ${git.subcommand} option may execute or write` };
+      }
+      continue;
+    }
+    if (head === "curl" && networkAllowed) {
+      if (!/https?:\/\//i.test(command) || words.slice(1).some((arg) => /^(?:-o|-O|-T|-d|-F|-K|--output|--remote-name|--upload-file|--data(?:-binary|-raw|-urlencode)?|--form|--request|--config|--json|--next|-X)(?:=|$)/.test(arg))) {
+        return { ok: false, reason: "curl is limited to read-only GET/HEAD requests" };
+      }
+      continue;
+    }
+    if (!READ_ONLY_COMMANDS.has(head)) return { ok: false, reason: `${head || "command"} is not in the read-only inspection allowlist` };
+    if (head === "find" && words.some((arg) => /^(?:-delete|-exec|-execdir|-ok|-okdir|-fprint|-fprintf|-fls)$/.test(arg))) {
+      return { ok: false, reason: "find action may execute or write" };
+    }
+    if (head === "sort" && words.some((arg) => arg === "-o" || arg === "--output" || arg.startsWith("--output=") || arg.startsWith("--compress-program="))) {
+      return { ok: false, reason: "sort option may execute or write" };
+    }
+  }
+  return { ok: true };
+}
+
 export function bashMutationKind(command: string): "delete" | "upsert" | "read" {
-  // Deletions. `find ... -delete`, `git clean` (removes untracked files), and
-  // the destructive git working-tree resets (`restore`, `checkout --`) join the
-  // classic rm/rmdir. NOTE: interpreters (node -e, python -c, sh x.sh, npm run)
-  // remain statically unpoliceable — documented as an accepted risk (G1).
+  const parsed = parseShellCommands(command) || [];
+  const gitCommands = parsed.map(({ words }) => classifiedGitSubcommand(words)?.subcommand).filter(Boolean) as string[];
+  // Deletions and destructive working-tree operations.
   if (/\brm\b|\brmdir\b/.test(command)) return "delete";
   if (/\bfind\b[^\n]*\s-delete\b/.test(command)) return "delete";
-  if (/\bgit\s+clean\b/.test(command)) return "delete";
-  if (/\bgit\s+(restore|checkout)\b[^\n]*\s--(\s|$)/.test(command)) return "delete";
-  if (/\bgit\s+restore\b/.test(command)) return "delete";
-  // Upserts (create/overwrite). Adds dd of=, rsync, install, and awk -i inplace
-  // to the classic set; redirections and in-place editors stay.
-  if (/\b(mv|cp|touch|mkdir|chmod|chown|ln|truncate|rsync|install)\b|>>?|\bsed\s+-i\b|\bperl\s+-pi\b|\btee\b/.test(command)) return "upsert";
+  if (gitCommands.some((subcommand) => GIT_DELETE_COMMANDS.has(subcommand))) return "delete";
+  if (parsed.some(({ words }) => {
+    const git = classifiedGitSubcommand(words);
+    return git?.subcommand === "checkout" && git.args.includes("--");
+  })) return "delete";
+  // Upserts include every Git repository/history mutation, patch/archive
+  // extraction, package installation, and known file-writing command.
+  if (gitCommands.some((subcommand) => GIT_MUTATION_COMMANDS.has(subcommand))) return "upsert";
+  if (/\b(mv|cp|touch|mkdir|chmod|chown|ln|truncate|rsync|install|patch|unzip|gunzip|bunzip2|unxz)\b|>>?|\bsed\s+-i\b|\bperl\s+-pi\b|\btee\b/.test(command)) return "upsert";
+  if (/\b(?:tar|bsdtar)\s+(?:-[^\s]*[xcru]|[xcru][^\s]*|--(?:extract|create|append|update))|\b7z\s+(?:x|e|a)\b|\bjar\s+[xcu]/.test(command)) return "upsert";
+  if (/\b(?:npm|pnpm|yarn|bun)\s+(?:i|install|add|remove|uninstall)\b|\b(?:pip|pip3|apt|apt-get|dnf|yum|apk|cargo|gem|go)\s+(?:install|add)\b|\bcomposer\s+(?:install|require|remove)\b/.test(command)) return "upsert";
+  if (/\bcurl\b[^\n]*(?:\s-o(?:\s|$)|\s--output(?:=|\s)|\s-O(?:\s|$)|\s--remote-name(?:\s|$))/.test(command)) return "upsert";
+  if (/\bwget\b/.test(command) && !/\bwget\b[^\n]*(?:\s-O\s*-|\s--output-document=-)/.test(command)) return "upsert";
   if (/\bdd\b[^\n]*\bof=/.test(command)) return "upsert";
   if (/\bawk\b[^\n]*\s-i(\s|$)|\bawk\b[^\n]*inplace/.test(command)) return "upsert";
   return "read";
@@ -208,17 +359,7 @@ function statementIsCommit(statement: string): boolean {
   // Bare git aliases that publish/create history.
   if (/^(gc|gcm|gca|gp|gpf|gcam)$/.test(head)) return true;
   if (head === "git") {
-    // Skip git global flags before the subcommand: -C <dir>, -c <k=v>,
-    // --git-dir=…, --work-tree=…, -c/--namespace etc.
-    let j = 0;
-    while (j < rest.length) {
-      const tok = rest[j];
-      if (tok === "-C" || tok === "-c" || tok === "--namespace") { j += 2; continue; }
-      if (tok.startsWith("--git-dir=") || tok.startsWith("--work-tree=") || tok.startsWith("-c=")) { j++; continue; }
-      if (tok.startsWith("-")) { j++; continue; }
-      break;
-    }
-    const sub = rest[j] || "";
+    const sub = gitSubcommand([head, ...rest])?.subcommand || "";
     if (sub === "commit" || sub === "push" || sub === "tag" || sub === "am") return true;
   }
   if (head === "gh") {
@@ -289,17 +430,40 @@ export function enforceDomainForTool(state: HiveState, event: any, ctx: Extensio
 
   if (toolName === "bash") {
     const command = String(event.input?.command || "");
+    const readOnlyType = runtime.config.agentType === "reviewer" || runtime.config.agentType === "lead";
 
-    // Commit gate: publish/history-creation is blocked unless the agent carries
-    // a non-empty `commit:` field (a static config fact — no DB read). Local
-    // working-tree ops (merge/rebase/add/…) are not commit-class and pass.
+    // Read-only types get a positive allowlist before the broader mutation and
+    // domain checks. A commit: field never turns a reviewer/lead into a writer.
+    if (readOnlyType) {
+      const decision = readOnlyCommandDecision(command, runtime.config.network === true);
+      if (!decision.ok) return { block: true, reason: `${runtime.config.name} cannot run this shell command: ${decision.reason}.` };
+    }
+
+    const parsedCommands = parseShellCommands(command) || [];
+    if (targetsDashboardLoopback(command)) {
+      return { block: true, reason: `${runtime.config.name} cannot access the pi-hive dashboard loopback API from a worker.` };
+    }
+    if (commandUsesNetwork(parsedCommands, command) && runtime.config.network !== true) {
+      return { block: true, reason: `${runtime.config.name} cannot use network commands (network: true is not configured).` };
+    }
+
+    // Commit gate: publish/history creation is blocked unless a write-capable
+    // agent carries a non-empty `commit:` field (a static config fact).
     if (isCommitCommand(command) && !runtime.config.commit?.trim()) {
-      return { block: true, reason: `${runtime.config.name} cannot run commit/publish operations (no commit: field configured). This command creates history or publishes. Only agents with a commit: guidance field may commit; local git merge/rebase/add remain allowed.` };
+      return { block: true, reason: `${runtime.config.name} cannot run commit/publish operations (no commit: field configured). This command creates history or publishes. Only write-capable agents with a commit: guidance field may commit.` };
     }
 
     const kind = bashMutationKind(command);
     const capability = kind === "read" ? "read" : kind;
     const paths = extractBashPathTokens(command);
+    // Git mutates its worktree/repository even when the command names no file.
+    // Treat the effective working directory as an explicit policy target so a
+    // write-capable agent can use granted Git operations without making generic
+    // pathless mutations fail open.
+    if (kind !== "read" && parsedCommands.some(({ words }) => {
+      const git = classifiedGitSubcommand(words);
+      return Boolean(git && GIT_MUTATION_COMMANDS.has(git.subcommand));
+    }) && !paths.includes(".")) paths.push(".");
     // Non-mutating bash is a "command"; mutating bash maps to upsert/delete.
     const policyAction: PolicyAction = kind === "read" ? "command" : kind;
 

--- a/src/engine/prompts.ts
+++ b/src/engine/prompts.ts
@@ -25,7 +25,7 @@ export function buildOperatingContract(runtime: AgentRuntime): string {
       lines.push("You are a **tester**. You write tests, not production code. You do not write spec files or issue verdicts.");
       break;
     case "reviewer":
-      lines.push("You are a **reviewer**. You are read-only: you may run inspection and test commands but must not modify files. Before your final answer, you MUST call `submit_review_verdict` with your red/yellow/green verdict and include the reviewed OpenSpec artifact when known (for example `proposal.md`, `design.md`, `specs/**/*.md`, or `tasks.md`). Do not rely on chat text like PASS/FAIL as the gate signal. A red verdict unlocks same-artifact revision; green/yellow marks it ready for human UI review.");
+      lines.push("You are a **reviewer**. You are read-only: bash is limited to explicit file and Git inspection commands. Project tests, builds, package managers, interpreters, patches, archive extraction, and all mutating Git commands are blocked; delegate tests to a tester because workers do not receive disposable checkouts. Before your final answer, you MUST call `submit_review_verdict` with your red/yellow/green verdict and include the reviewed OpenSpec artifact when known (for example `proposal.md`, `design.md`, `specs/**/*.md`, or `tasks.md`). Do not rely on chat text like PASS/FAIL as the gate signal. A red verdict unlocks same-artifact revision; green/yellow marks it ready for human UI review.");
       break;
     case "lead": {
       lines.push("You are a **lead**. You delegate and coordinate; you do not modify files (all edits go through your coder/tester reports).");
@@ -41,6 +41,11 @@ export function buildOperatingContract(runtime: AgentRuntime): string {
   // recognizes. This is an explicit trust boundary, not a loophole.
   if (type === "coder" || type === "tester") {
     lines.push("Note: file changes made *through* an interpreter (`node -e`, `python -c`, `sh script.sh`, `npm run …`) are not visible to the domain enforcer. Do not use them to write outside your domain — use edit/write, which are enforced.");
+  }
+  if (runtime.config.network === true) {
+    lines.push("Network capability is enabled for this agent. The local pi-hive dashboard API remains blocked.");
+  } else {
+    lines.push("Network commands are disabled for this worker.");
   }
   return lines.join("\n");
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -334,10 +334,10 @@ hive:
 
 // ── Agent-type contract (Phase A) ──────────────────────────────────────────
 
-test("loadConfig reads agent-type/stages/commit from frontmatter onto config", () => {
+test("loadConfig reads agent-type/stages/network/commit from frontmatter onto config", () => {
   const cwd = mkdtempSync(join(tmpdir(), "pi-hive-types-"));
   mkdirSync(join(cwd, ".pi", "hive", "agents"), { recursive: true });
-  writeFileSync(join(cwd, ".pi", "hive", "agents", "orchestrator.md"), "---\nmodel: openai/gpt-5\nthinking: off\nagent-type: lead\ncommit: \"Only commit after review is green.\"\n---\nLead.");
+  writeFileSync(join(cwd, ".pi", "hive", "agents", "orchestrator.md"), "---\nmodel: openai/gpt-5\nthinking: off\nagent-type: lead\nnetwork: true\ncommit: \"Only commit after review is green.\"\n---\nLead.");
   writeFileSync(join(cwd, ".pi", "hive", "agents", "plan-main.md"), "---\nmodel: openai/gpt-5\nthinking: off\nagent-type: planner\n---\nPlan.");
   writeFileSync(join(cwd, ".pi", "hive", "agents", "planner.md"), "---\nmodel: openai/gpt-5\nthinking: off\nagent-type: planner\nstages: [proposal, requirements]\n---\nPlan.");
   writeFileSync(join(cwd, ".pi", "hive", "hive-config.yaml"), `
@@ -359,6 +359,7 @@ hive:
 
   const config = loadConfig(cwd);
   assert.equal(config.orchestrator.agentType, "lead");
+  assert.equal(config.orchestrator.network, true);
   assert.equal(config.orchestrator.commit, "Only commit after review is green.");
   assert.equal(config.agents[0].agentType, "planner");
   assert.deepEqual(config.agents[0].stages, ["proposal", "requirements"]);
@@ -412,6 +413,11 @@ test("loadConfig rejects stages on a non-planner", () => {
 test("loadConfig rejects an invalid stage on a planner", () => {
   const cwd = typedFixture("agent-type: lead", "agent-type: planner\nstages: [proposal, ship]");
   assert.throws(() => loadConfig(cwd), /stages\[1\] must be one of/);
+});
+
+test("loadConfig rejects a non-boolean network capability", () => {
+  const cwd = typedFixture("agent-type: lead", "agent-type: reviewer\nnetwork: yes");
+  assert.throws(() => loadConfig(cwd), /network must be true or false/);
 });
 
 test("inferAgentType applies name/report heuristics", () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { classify } from "../src/engine/file-class.ts";
 import { checkPlannerStages, checkTypePolicy } from "../src/engine/policy.ts";
-import { bashMutationKind, enforceDomainForTool, isCommitCommand } from "../src/engine/domain.ts";
+import { bashMutationKind, enforceDomainForTool, isCommitCommand, readOnlyCommandDecision } from "../src/engine/domain.ts";
 import { runAsAgent } from "../src/engine/session.ts";
 import { buildOperatingContract } from "../src/engine/prompts.ts";
 import type { AgentRuntime, AgentType, HiveState, PlanStage } from "../src/core/types.ts";
@@ -141,6 +141,7 @@ test("isCommitCommand closes the parsing bypasses (G2)", () => {
   assert.equal(isCommitCommand("git -C /repo commit -m x"), true);
   assert.equal(isCommitCommand("git -c user.name=x commit -m y"), true);
   assert.equal(isCommitCommand("git --git-dir=/r/.git commit"), true);
+  assert.equal(isCommitCommand("git --git-dir /r/.git --work-tree /r commit"), true);
   assert.equal(isCommitCommand("git -C /repo -c a=b push"), true);
   // command / env wrappers.
   assert.equal(isCommitCommand("command git commit"), true);
@@ -167,6 +168,12 @@ test("bashMutationKind classifies the previously-missed mutators (G1)", () => {
   assert.equal(bashMutationKind("rsync -a src/ dst/"), "upsert");
   assert.equal(bashMutationKind("install -m 0755 bin/x /usr/local/bin/x"), "upsert");
   assert.equal(bashMutationKind("awk -i inplace '{print}' file.txt"), "upsert");
+  for (const command of [
+    "git merge feature", "command git merge feature", "env GIT_OPTIONAL_LOCKS=0 git rebase main", "git cherry-pick abc", "git revert abc",
+    "git reset --hard", "git checkout main", "git switch main", "git stash", "git apply fix.patch",
+    "git -C ./repo am fix.patch", "git --git-dir=./repo/.git --work-tree=./repo add .",
+    "patch -p1 ./fix.patch", "tar -xf ./bundle.tar", "tar xf ./bundle.tar", "unzip ./bundle.zip", "7z x ./bundle.7z", "npm install", "cargo install ripgrep",
+  ]) assert.equal(bashMutationKind(command), "upsert", command);
   // Read-only stays read.
   assert.equal(bashMutationKind("git status"), "read");
   assert.equal(bashMutationKind("find . -name '*.ts'"), "read");
@@ -247,24 +254,70 @@ test("enforce: both layers must pass — in-domain but wrong type still blocked,
   assert.match(block(state, "Dev", { toolName: "write", input: { path: "server/x.ts" } }) ?? "", /cannot modify/); // domain layer
 });
 
-test("enforce: commit gate blocks without commit field, allows with it", () => {
-  const noCommit = stateWith([runtime("Lead", { agentType: "lead", domain: [{ path: ".", read: true, upsert: false, delete: false }] })]);
-  assert.match(block(noCommit, "Lead", { toolName: "bash", input: { command: "git commit -m wip" } }) ?? "", /cannot run commit\/publish/);
+test("enforce: commit gate requires both a write-capable type and commit guidance", () => {
+  const noCommit = stateWith([runtime("Dev", { agentType: "coder", domain: [{ path: ".", read: true, upsert: true, delete: false }] })]);
+  assert.match(block(noCommit, "Dev", { toolName: "bash", input: { command: "git commit -m wip" } }) ?? "", /cannot run commit\/publish/);
 
-  const withCommit = stateWith([runtime("Lead", { agentType: "lead", commit: "commit when green", domain: [{ path: ".", read: true, upsert: false, delete: false }] })]);
-  assert.equal(block(withCommit, "Lead", { toolName: "bash", input: { command: "git commit -m wip" } }), undefined);
+  const withCommit = stateWith([runtime("Dev", { agentType: "coder", commit: "commit when green", domain: [{ path: ".", read: true, upsert: true, delete: false }] })]);
+  assert.equal(block(withCommit, "Dev", { toolName: "bash", input: { command: "git commit -m wip" } }), undefined);
+
+  const readOnly = stateWith([runtime("Lead", { agentType: "lead", commit: "commit when green", domain: [{ path: ".", read: true, upsert: true, delete: true }] })]);
+  assert.match(block(readOnly, "Lead", { toolName: "bash", input: { command: "git commit -m wip" } }) ?? "", /not an allowed inspection operation/);
 });
 
-test("enforce: git merge allowed regardless of commit field", () => {
-  const state = stateWith([runtime("Lead", { agentType: "lead", domain: [{ path: ".", read: true, upsert: false, delete: false }] })]);
-  // git merge is non-mutating from a commit standpoint and reads only → allowed.
-  assert.equal(block(state, "Lead", { toolName: "bash", input: { command: "git merge feature" } }), undefined);
+test("enforce: read-only agents allow inspection Git and deny repository mutations", () => {
+  const domain = [{ path: ".", read: true, upsert: false, delete: false }];
+  for (const agentType of ["reviewer", "lead"] as const) {
+    const state = stateWith([runtime("Audit", { agentType, domain })]);
+    for (const command of ["git status", "git diff -- ./src", "git -C . log -5", "git --git-dir . --work-tree . status"]) {
+      assert.equal(block(state, "Audit", { toolName: "bash", input: { command } }), undefined, `${agentType} should inspect: ${command}`);
+    }
+    for (const command of ["git merge feature", "git rebase main", "git cherry-pick abc", "git revert abc", "git reset --hard", "git checkout main", "git switch main", "git stash", "git apply fix.patch", "git am fix.patch", "git clean -fd", "git restore ./src/app.ts"]) {
+      assert.match(block(state, "Audit", { toolName: "bash", input: { command } }) ?? "", /not an allowed inspection operation/, `${agentType} must block: ${command}`);
+    }
+  }
 });
 
-test("enforce: reviewer may run non-mutating inspection bash but not mutating bash", () => {
+test("enforce: reviewer shell surface is an explicit inspection allowlist", () => {
   const state = stateWith([runtime("Rev", { agentType: "reviewer", domain: [{ path: ".", read: true, upsert: false, delete: false }] })]);
-  assert.equal(block(state, "Rev", { toolName: "bash", input: { command: "grep -r foo ./src" } }), undefined);
-  assert.match(block(state, "Rev", { toolName: "bash", input: { command: "touch src/x.ts" } }) ?? "", /may not upsert/);
+  assert.equal(block(state, "Rev", { toolName: "bash", input: { command: "grep -r foo ./src | head -20" } }), undefined);
+  for (const command of ["touch src/x.ts", "node -e 'inspect()'", "npm test", "just test", "patch -p1 ./fix.patch", "tar xf ./bundle.tar", "unzip ./bundle.zip", "npm install", "mystery ./src", "", "echo $(cat ./src/x.ts)"]) {
+    assert.match(block(state, "Rev", { toolName: "bash", input: { command } }) ?? "", /cannot run this shell command/, `must block: ${command}`);
+  }
+});
+
+ test("read-only command classifier is table-driven and fail-closed", () => {
+  const cases: Array<[string, boolean]> = [
+    ["ls -la ./src", true],
+    ["find ./src -name '*.ts'", true],
+    ["git show HEAD:src/app.ts", true],
+    ["git -C ./nested diff", true],
+    ["git --git-dir=./.git --work-tree=. ls-files", true],
+    ["git -c alias.status='!touch /tmp/pwn' status", false],
+    ["git diff --output=./diff.txt", false],
+    ["git diff --textconv", false],
+    ["find ./src -exec touch {} ;", false],
+    ["sort -o ./sorted ./input", false],
+    ["less ./src/x.ts", false],
+    ["python -c 'print(1)'", false],
+    ["sh ./script.sh", false],
+    ["cat ./src/x.ts > ./copy.ts", false],
+    ["gc", false],
+  ];
+  for (const [command, expected] of cases) {
+    assert.equal(readOnlyCommandDecision(command).ok, expected, command);
+  }
+});
+
+ test("network capability is opt-in and dashboard loopback remains blocked", () => {
+  const domain = [{ path: ".", read: true, upsert: false, delete: false }];
+  const denied = stateWith([runtime("Rev", { agentType: "reviewer", domain })]);
+  assert.match(block(denied, "Rev", { toolName: "bash", input: { command: "curl -fsS https://example.com/status" } }) ?? "", /network access is not enabled/);
+
+  const allowed = stateWith([runtime("Rev", { agentType: "reviewer", network: true, domain })]);
+  assert.equal(block(allowed, "Rev", { toolName: "bash", input: { command: "curl -fsS https://example.com/status" } }), undefined);
+  assert.match(block(allowed, "Rev", { toolName: "bash", input: { command: "curl http://127.0.0.1:43191/api/sessions" } }) ?? "", /dashboard loopback API/);
+  assert.match(block(allowed, "Rev", { toolName: "bash", input: { command: "curl -o ./out https://example.com" } }) ?? "", /limited to read-only/);
 });
 
 test("enforce: pathless mutating bash is blocked fail-safe (L3)", () => {
@@ -276,7 +329,7 @@ test("enforce: pathless mutating bash is blocked fail-safe (L3)", () => {
   assert.match(reason ?? "", /without explicit in-domain paths/);
   // A reviewer hits the type layer first (no mutation at all), also blocked.
   const rev = stateWith([runtime("Rev", { agentType: "reviewer", domain: codeDomain })]);
-  assert.match(block(rev, "Rev", { toolName: "bash", input: { command: "rm -rf *" } }) ?? "", /may not/);
+  assert.match(block(rev, "Rev", { toolName: "bash", input: { command: "rm -rf *" } }) ?? "", /cannot run this shell command/);
   // Sanity: a mutating bash WITH an in-domain path is allowed for the coder.
   assert.equal(block(state, "Dev", { toolName: "bash", input: { command: "rm -rf src/tmp" } }), undefined);
 });


### PR DESCRIPTION
## Summary
- replace reviewer/lead shell fallthrough with an explicit inspection-command allowlist
- classify Git, patch, archive, extraction, package-install, and local-output network commands as mutations
- add an opt-in worker network capability while blocking dashboard loopback access
- document test/build delegation and read-only commit semantics

## Tests
- `just ci`
- 178 Node tests passed
- 38 Bun tests passed
