### PR TITLE
fix: protect reserved paths and queued writes

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -130,6 +130,7 @@ This file declares **only**: the orchestrator, the agent tree (`name` / `color` 
 | `subagent-output-limit` | Max chars of a worker's answer surfaced to its caller | `12000` |
 | `default-tools` | Fallback tool list **only** if an agent omits `tools` | `read, grep, find, ls` |
 | `max-parallel` | Max concurrent subprocess runs **per process** | `3` |
+| `secret-paths` | Additional project-relative or absolute paths reserved from every worker | `[]` |
 | `distiller.enabled` | Run the mental-model distiller after each worker | `true` |
 | `distiller.model` | `provider/id` for distillation (required if enabled) | — |
 | `distiller.conversation-lines` | Tail of the session fed to the distiller | `200` |
@@ -157,6 +158,10 @@ settings:
   subagent-output-limit: 12000
   default-tools: read, grep, find, ls
   max-parallel: 10
+  # Reserved before normal domain rules. Add project-specific credentials here.
+  secret-paths:
+    - config/secrets.json
+    - .credentials/
   distiller:
     enabled: true
     model: openai-codex/gpt-5.4-mini   # see: pi --list-models
@@ -333,10 +338,17 @@ Capabilities are resolved by **most-specific-wins**: deeper `path` entries beat 
 
 ```yaml
 domain:
-  - path: .                                   # read the whole repo
+  - path: .                                   # read the repo except sensitive state
     read: true
     upsert: false
     delete: false
+    exclude:
+      - ".git/**"
+      - ".env*"
+      - "**/.env*"
+      - ".pi/hive/sessions/**"
+      - "**/*.key"
+      - "**/*.pem"
   - path: backend/internal/                   # write broadly across the backend
     read: true
     upsert: true
@@ -369,9 +381,11 @@ domain:
 
 At the same `path`, the `include` rule is more specific than the catch-all deny, so `*_test.go` writes are allowed while production `.go` writes remain blocked.
 
+Reserved-path policy runs **before** domains and cannot be reopened by a broader or deeper scope. It blocks approval authority, telemetry/session files, daemon metadata, `.git/**`, `.env*`, private-key filenames, and every configured `settings.secret-paths` entry. Only trusted extension internals can pass an explicit override; no agent frontmatter or domain option grants one. Keep the exclusions above as defense in depth and as an auditable declaration of broad-read intent.
+
 Patterns:
 - **Coder** → `read: true, upsert: true, delete: false` over its code area (e.g. `backend/`), plus explicit deny carve-outs for any sub-area another agent owns.
-- **Lead** → `read: true, upsert: false, delete: false` broadly over the repo, plus `upsert: true` over `docs/` or `tasks/` where it writes specs.
+- **Lead** → `read: true, upsert: false, delete: false` over only the areas it must inspect; all writes remain delegated.
 - **Reviewer / QA** → `read: true, upsert: false, delete: false` over what it reviews.
 - **Test-only implementer** → broad read scope plus an `include` write scope for test globs such as `**/*_test.go`, `**/*.test.ts`, or `**/*.spec.ts`.
 - Reserve `delete: true` for the rare agent that must remove files; default it off explicitly.
@@ -410,6 +424,8 @@ domain:
     read: true
     upsert: false
     delete: false
+    exclude:
+      - "sessions/**"
 routing-tags:
   - coordination
   - synthesis
@@ -468,12 +484,17 @@ skills:
 domain:
   - path: docs/
     read: true
-    upsert: true
+    upsert: false
     delete: false
   - path: <area this lead reads to scope work>
     read: true
     upsert: false
     delete: false
+    exclude:
+      - ".env*"
+      - "**/.env*"
+      - "**/*.key"
+      - "**/*.pem"
 routing-tags:
   - <tag>
   - <tag>
@@ -528,6 +549,11 @@ domain:
     read: true
     upsert: true        # false for pure reviewers
     delete: false
+    exclude:
+      - ".env*"
+      - "**/.env*"
+      - "**/*.key"
+      - "**/*.pem"
 routing-tags:
   - <tag>
 consult-when: <one-line: this member's specialty>

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -1,7 +1,8 @@
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { defineTool } from "@earendil-works/pi-coding-agent";
+import { defineTool, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { resolve } from "node:path";
 import type { AgentType, HiveState, ReviewVerdictLevel } from "../core/types";
 import {
   extractFinalAnswer,
@@ -296,7 +297,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         } catch {
           answer = undefined;
         }
-        if (change) recordQuestion(ctx.cwd, change, question, answer || undefined);
+        if (change) await recordQuestion(ctx.cwd, change, question, answer || undefined);
         if (answer && answer.trim()) {
           return { content: [{ type: "text", text: `User answered: ${answer.trim()}` }], details: { ok: true, question, answer: answer.trim() } };
         }
@@ -306,9 +307,9 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
       // Truly headless (no TUI anywhere — cron / RPC / print mode): fall back to
       // the dashboard-actions bridge so the question is at least surfaced and
       // file-recorded, and the planner records an assumption to proceed.
-      if (change) recordQuestion(ctx.cwd, change, question);
+      if (change) await recordQuestion(ctx.cwd, change, question);
       const mainDir = state.session?.sessionDir;
-      const promoted = mainDir ? enqueueQuestion(mainDir, { question, change: change || undefined, askedBy }) : false;
+      const promoted = mainDir ? await enqueueQuestion(mainDir, { question, change: change || undefined, askedBy }) : false;
       const text = promoted
         ? `No interactive prompt is available; your question was recorded and surfaced to the dashboard:\n"${question}"\nRecord a clearly-stated assumption and proceed; flag it for the human to confirm.`
         : `No interactive session is available to answer right now. Record a clearly-stated assumption for "${question}", proceed, and flag it for the human to confirm.`;
@@ -344,17 +345,25 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         const evidence = p.evidence || [];
         const concerns = p.concerns || [];
         const blockers = p.blockers || [];
-        // Emit as a telemetry event; the dashboard materializes it into
-        // plan_verdicts. The core cannot reach bun:sqlite, so this is the path.
+        // Persist content-bound automated review authority before publishing
+        // telemetry or in-memory state. The queue covers the complete
+        // validation/read/write window and shares a key with built-in writes.
+        if (changeId && p.artifact?.trim()) {
+          const artifact = p.artifact.trim();
+          const recordPath = openspec.approvalRecordPath(ctx.cwd, changeId, artifact, "automated-review");
+          if (!recordPath) throw new Error(`Invalid automated review target: ${changeId}/${artifact}`);
+          await withFileMutationQueue(recordPath, async () => {
+            openspec.setAgentReviewVerdict(ctx.cwd, changeId, artifact, p.verdict, callerName);
+          });
+        }
+        // Emit only after authoritative persistence succeeds. The dashboard
+        // materializes this event into plan_verdicts for display.
         emitHiveEvent(state, "review_verdict", { changeId, reviewer: callerName, verdict: p.verdict, summary: p.summary, evidence, concerns, blockers }, callerName);
-        // Also cache in-memory so team_status can surface the latest verdict
-        // without a SQLite read (the core has no access to plan_verdicts).
         if (changeId) {
           (state.latestVerdicts ||= new Map()).set(changeId, {
             changeId, reviewer: callerName, verdict: p.verdict, summary: p.summary,
             evidence, concerns, blockers, createdAt: new Date().toISOString(),
           });
-          if (p.artifact?.trim()) openspec.setAgentReviewVerdict(ctx.cwd, changeId, p.artifact.trim(), p.verdict, callerName);
         }
         const scope = changeId ? `change "${changeId}"` : "the current session (no active change-id)";
         const detail = p.verdict === "red" ? `${blockers.length} blocker(s)` : p.verdict === "yellow" ? `${concerns.length} concern(s)` : "clean";
@@ -384,7 +393,6 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
         if (!openspec.isAvailable()) {
           return { content: [{ type: "text", text: "OpenSpec CLI is not installed, so no plan store is available. Install @fission-ai/openspec to author plans." }], details: { ok: false, reason: "openspec unavailable" } };
         }
-        openspec.ensureInit(ctx.cwd);
         const requestedChangeId = openspec.toChangeId(title);
         if (state.activeChangeId && openspec.changeExists(ctx.cwd, state.activeChangeId) && state.activeChangeId !== requestedChangeId) {
           return {
@@ -395,7 +403,10 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
             details: { ok: false, activeChangeId: state.activeChangeId, requestedChangeId },
           };
         }
-        const result = openspec.newChange(ctx.cwd, title);
+        const result = await withFileMutationQueue(resolve(ctx.cwd, "openspec", "changes", requestedChangeId), async () => {
+          openspec.ensureInit(ctx.cwd);
+          return openspec.newChange(ctx.cwd, title);
+        });
         if (!result) {
           return { content: [{ type: "text", text: `Could not create change from "${title}". Ensure the derived id is valid kebab-case and OpenSpec is initialized.` }], details: { ok: false } };
         }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -187,6 +187,7 @@ export function loadConfig(cwd: string): HiveConfig {
       subagentOutputLimit: Number(settings.subagentOutputLimit || 12_000),
       defaultTools: String(settings.defaultTools || "read, grep, find, ls"),
       maxParallel: Number(settings.maxParallel || 3),
+      secretPaths: Array.isArray(settings.secretPaths) ? settings.secretPaths.map((entry: unknown) => String(entry).trim()).filter(Boolean) : [],
       distiller: {
         enabled: distillerEnabled,
         model: distillerModel,

--- a/src/core/file-lock.ts
+++ b/src/core/file-lock.ts
@@ -1,0 +1,59 @@
+import { closeSync, openSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+
+export interface FileLockOptions {
+  timeoutMs?: number;
+  staleMs?: number;
+  retryMs?: number;
+}
+
+const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepSync(ms: number): void {
+  Atomics.wait(sleepBuffer, 0, 0, ms);
+}
+
+// Short cross-process critical sections for shared local metadata. The lock is
+// an adjacent O_EXCL file, so unrelated resources do not block one another.
+// Stale lock recovery handles a process dying between acquire and cleanup.
+export function withCrossProcessFileLock<T>(resourcePath: string, fn: () => T, options: FileLockOptions = {}): T {
+  const lockPath = `${resourcePath}.lock`;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const staleMs = options.staleMs ?? 30_000;
+  const retryMs = options.retryMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+  let fd: number | undefined;
+
+  while (fd === undefined) {
+    try {
+      const candidate = openSync(lockPath, "wx", 0o600);
+      try {
+        writeFileSync(candidate, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+        fd = candidate;
+      } catch (error) {
+        try { closeSync(candidate); } catch { /* best effort */ }
+        try { unlinkSync(lockPath); } catch { /* best effort */ }
+        throw error;
+      }
+    } catch (error: any) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleMs) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch (statError: any) {
+        if (statError?.code === "ENOENT") continue;
+        throw statError;
+      }
+      if (Date.now() >= deadline) throw new Error(`Timed out waiting for file lock: ${lockPath}`);
+      sleepSync(retryMs);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { closeSync(fd); } catch { /* best effort */ }
+    try { unlinkSync(lockPath); } catch { /* best effort */ }
+  }
+}

--- a/src/core/safe-path.ts
+++ b/src/core/safe-path.ts
@@ -31,7 +31,7 @@ function existsLexically(value: string): boolean {
   }
 }
 
-function canonicalize(value: string, allowMissing: boolean): ContainedPath | null {
+export function resolveCanonicalPath(value: string, options: ContainedPathOptions = {}): ContainedPath | null {
   const lexicalPath = path.resolve(value);
   const exists = existsLexically(lexicalPath);
   if (exists) {
@@ -43,7 +43,7 @@ function canonicalize(value: string, allowMissing: boolean): ContainedPath | nul
       return null;
     }
   }
-  if (!allowMissing) return null;
+  if (options.allowMissing !== true) return null;
 
   let ancestor = lexicalPath;
   while (!existsLexically(ancestor)) {
@@ -82,8 +82,8 @@ export function resolveContainedPath(root: string, candidate: string, options: C
 
   // A configured root may itself be new (for example a not-yet-created tests/
   // domain), so canonicalize it through its nearest existing parent.
-  const canonicalRoot = canonicalize(lexicalRoot, true);
-  const canonicalCandidate = canonicalize(lexicalCandidate, options.allowMissing === true);
+  const canonicalRoot = resolveCanonicalPath(lexicalRoot, { allowMissing: true });
+  const canonicalCandidate = resolveCanonicalPath(lexicalCandidate, options);
   if (!canonicalRoot || !canonicalCandidate) return null;
   if (!isPathInside(canonicalRoot.canonicalPath, canonicalCandidate.canonicalPath)) return null;
   return canonicalCandidate;

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -123,6 +123,7 @@ export function validateHiveConfigShape(config: HiveConfig): void {
     assertObject(config.settings, "settings");
     assertNumber(config.settings.subagentOutputLimit, "settings.subagentOutputLimit");
     assertNumber(config.settings.maxParallel, "settings.maxParallel");
+    validateStringList(config.settings.secretPaths, "settings.secretPaths");
     if (config.settings.distiller) {
       assertObject(config.settings.distiller, "settings.distiller");
       assertBoolean(config.settings.distiller.enabled, "settings.distiller.enabled");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -144,6 +144,10 @@ export interface HiveSettings {
   subagentOutputLimit: number;
   defaultTools: string;
   maxParallel: number;
+  // Project-relative paths that no worker may read or mutate, even when a broad
+  // domain would otherwise allow them. Absolute paths are supported for
+  // explicitly configured external secrets.
+  secretPaths?: string[];
   distiller: {
     enabled: boolean;
     model: string;

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -28,7 +28,7 @@ import { agentMentalModelTarget, buildDistillerPrompt, buildWorkerPrompt, extrac
 import { emitHiveEvent, runtimeSummary, writeHiveStateSnapshot } from "./observability";
 import { buildHiveTools } from "../agents/tools";
 import { normalizeWorkerSkillPaths, workerResourceLoader } from "./worker-extension";
-import { isExecutionGateOpen, isAwaitingHumanApproval, setAgentReviewVerdict, type AgentReviewVerdict, type ArtifactId } from "./openspec";
+import { approvalRecordPath, isExecutionGateOpen, isAwaitingHumanApproval, setAgentReviewVerdict, type AgentReviewVerdict, type ArtifactId } from "./openspec";
 import { agentRoster, resolveRuntime } from "./agent-lookup";
 import { addHiveActivity } from "../ui/tui/activity";
 import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
@@ -667,7 +667,14 @@ export async function dispatchAgent(
     const changeId = currentChangeId() || state.activeChangeId || inferChangeIdFromReviewTask(task) || "";
     const artifact = inferArtifactFromReviewTask(task);
     const verdict = inferReviewVerdict(output);
-    if (changeId && artifact && verdict) setAgentReviewVerdict(ctx.cwd, changeId, artifact, verdict, runtime.config.name);
+    if (changeId && artifact && verdict) {
+      const recordPath = approvalRecordPath(ctx.cwd, changeId, artifact, "automated-review");
+      if (recordPath) {
+        await withFileMutationQueue(recordPath, async () => {
+          setAgentReviewVerdict(ctx.cwd, changeId, artifact, verdict, runtime.config.name);
+        });
+      }
+    }
   }
 
   emitHiveEvent(state, "delegation_end", {
@@ -795,11 +802,20 @@ export async function distillMentalModel(state: HiveState, ctx: ExtensionContext
     // even if the distiller's output drifts. The soft body is left byte-exact.
     const distilled = extracted ? normalizeMentalModelSpine(extracted, runtime.config.name).trim() : null;
     if (distilled && distilled !== currentModel.trim()) {
+      let changed = false;
       await withFileMutationQueue(targetPath, async () => {
+        // Re-read inside the queued mutation window. If another tool updated the
+        // model while distillation was running, do not overwrite fresher state
+        // with a result derived from the old snapshot.
+        const latestModel = safeRead(targetPath);
+        if (latestModel.trim() !== currentModel.trim()) return;
         writeFileSync(targetPath, `${distilled}\n`);
+        changed = true;
       });
-      logRecord(state, { from: "Distiller", to: runtime.config.name, type: "mental_model_distilled", message: `Updated ${target.path}`, path: target.path });
-      emitHiveEvent(state, "distill_end", { agent: runtime.config.name, target: target.path, changed: true }, "Distiller");
+      if (changed) {
+        logRecord(state, { from: "Distiller", to: runtime.config.name, type: "mental_model_distilled", message: `Updated ${target.path}`, path: target.path });
+        emitHiveEvent(state, "distill_end", { agent: runtime.config.name, target: target.path, changed: true }, "Distiller");
+      }
     }
   } catch { /* distillation is best-effort; never fail the delegation */ }
   finally { try { rmSync(snapshotPath, { force: true }); } catch { /* noop */ } }

--- a/src/engine/domain.ts
+++ b/src/engine/domain.ts
@@ -8,6 +8,7 @@ import { globToRegExp, globSpecificity, toPosixPath } from "./glob";
 import { classify } from "./file-class";
 import { checkPlannerStages, checkTypePolicy, type PolicyAction, type PolicyDecision } from "./policy";
 import { hasForeignAbsoluteSyntax, isPathInside, resolveContainedPath, resolveProjectPath } from "../core/safe-path";
+import { checkReservedPath, type ReservedPathAccess } from "./reserved-paths";
 
 function runtimeForCaller(state: HiveState, callerName: string): AgentRuntime | undefined {
   return resolveRuntime(state, callerName);
@@ -379,6 +380,14 @@ function statementIsCommit(statement: string): boolean {
 // message) and independently of the domain-glob layer; both must pass. When the
 // agent has no agent-type (e.g. tests, normal mode) type-policy is skipped and
 // only the domain layer applies. Returns a block reason or undefined.
+function enforceReservedPath(state: HiveState, runtime: AgentRuntime, ctx: ExtensionContext, rawPath: string, access: ReservedPathAccess): string | undefined {
+  const decision = checkReservedPath(ctx.cwd, rawPath, access, {
+    secretPaths: state.config?.settings.secretPaths,
+    allowMissing: access === "upsert",
+  });
+  return decision.ok ? undefined : `${runtime.config.name} cannot ${access} reserved path "${rawPath}": ${decision.reason}. Reserved-path policy takes precedence over domains.`;
+}
+
 function enforceTypePolicyForPath(runtime: AgentRuntime, ctx: ExtensionContext, rawPath: string, action: PolicyAction): string | undefined {
   const agentType = runtime.config.agentType;
   if (!agentType) return undefined;
@@ -410,6 +419,8 @@ export function enforceDomainForTool(state: HiveState, event: any, ctx: Extensio
 
   if (readTools.has(toolName)) {
     for (const path of extractToolPaths(toolName, event.input)) {
+      const reservedBlock = enforceReservedPath(state, runtime, ctx, path, "read");
+      if (reservedBlock) return { block: true, reason: reservedBlock };
       const typeBlock = enforceTypePolicyForPath(runtime, ctx, path, "read");
       if (typeBlock) return { block: true, reason: typeBlock };
       if (!domainAllows(ctx, runtime, path, "read")) {
@@ -420,6 +431,8 @@ export function enforceDomainForTool(state: HiveState, event: any, ctx: Extensio
 
   if (upsertTools.has(toolName)) {
     for (const path of extractToolPaths(toolName, event.input)) {
+      const reservedBlock = enforceReservedPath(state, runtime, ctx, path, "upsert");
+      if (reservedBlock) return { block: true, reason: reservedBlock };
       const typeBlock = enforceTypePolicyForPath(runtime, ctx, path, "upsert");
       if (typeBlock) return { block: true, reason: typeBlock };
       if (!domainAllows(ctx, runtime, path, "upsert")) {
@@ -456,6 +469,13 @@ export function enforceDomainForTool(state: HiveState, event: any, ctx: Extensio
     const kind = bashMutationKind(command);
     const capability = kind === "read" ? "read" : kind;
     const paths = extractBashPathTokens(command);
+    // Reserved-path matching also inspects bare shell words. Normal domain
+    // extraction intentionally ignores bare words because they are ambiguous,
+    // but known secret/authority names must never inherit that fail-open rule.
+    for (const token of parsedCommands.flatMap(({ words }) => words)) {
+      const reservedBlock = enforceReservedPath(state, runtime, ctx, token, capability);
+      if (reservedBlock) return { block: true, reason: reservedBlock };
+    }
     // Git mutates its worktree/repository even when the command names no file.
     // Treat the effective working directory as an explicit policy target so a
     // write-capable agent can use granted Git operations without making generic
@@ -478,6 +498,8 @@ export function enforceDomainForTool(state: HiveState, event: any, ctx: Extensio
     }
 
     for (const path of paths) {
+      const reservedBlock = enforceReservedPath(state, runtime, ctx, path, capability);
+      if (reservedBlock) return { block: true, reason: reservedBlock };
       const typeBlock = enforceTypePolicyForPath(runtime, ctx, path, policyAction);
       if (typeBlock) return { block: true, reason: typeBlock };
       if (!domainAllows(ctx, runtime, path, capability)) {

--- a/src/engine/observability.ts
+++ b/src/engine/observability.ts
@@ -7,6 +7,7 @@ import type { HiveStateSnapshot, HiveTelemetryEvent, HiveTelemetryEventType, Jso
 import { tryResolveProjectIdentity } from "../shared/project-identity";
 import { agentSlug, ensureDir, truncateMiddle } from "../core/utils";
 import { currentAgentName } from "./session";
+import { withCrossProcessFileLock } from "../core/file-lock";
 
 export type HiveObsEventType = HiveTelemetryEventType;
 export type HiveObsEvent<P = JsonRecord> = HiveTelemetryEvent<P>;
@@ -24,19 +25,21 @@ export function registerHiveTelemetrySession(state: HiveState, cwd: string) {
   const registryPath = hiveTelemetryRegistryPath();
   const identity = tryResolveProjectIdentity(cwd);
   ensureDir(dirname(registryPath));
-  appendFileSync(registryPath, `${JSON.stringify({
-    registered_at: new Date().toISOString(),
-    session_id: state.session.sessionId,
-    project_id: identity?.projectId,
-    project_root: identity?.canonicalRoot,
-    project_label: identity?.displayLabel,
-    cwd,
-    session_dir: state.session.sessionDir,
-    conversation_log: state.session.conversationLog,
-    telemetry_log: state.session.observabilityLog,
-    state_file: join(state.session.sessionDir, "hive-state.json"),
-    pid: process.pid,
-  })}\n`);
+  withCrossProcessFileLock(registryPath, () => {
+    appendFileSync(registryPath, `${JSON.stringify({
+      registered_at: new Date().toISOString(),
+      session_id: state.session!.sessionId,
+      project_id: identity?.projectId,
+      project_root: identity?.canonicalRoot,
+      project_label: identity?.displayLabel,
+      cwd,
+      session_dir: state.session!.sessionDir,
+      conversation_log: state.session!.conversationLog,
+      telemetry_log: state.session!.observabilityLog,
+      state_file: join(state.session!.sessionDir, "hive-state.json"),
+      pid: process.pid,
+    })}\n`);
+  });
 }
 
 function agentSummary(agent: AgentConfig): TopologyNode {

--- a/src/engine/openspec.ts
+++ b/src/engine/openspec.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { ensureDir, readIfSmall } from "../core/fs";
 import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
 import { resolveProjectIdentity, type ProjectIdentity } from "../shared/project-identity";
+import { withCrossProcessFileLock } from "../core/file-lock";
 
 // Thin, bounded wrapper around the OpenSpec CLI (@fission-ai/openspec).
 //
@@ -603,7 +604,7 @@ export function readAgentReviewLedger(cwd: string, name: string): AgentReviewLed
 // This function is called only from the trusted dashboard review hook. A green
 // human approval requires a current eligible automated record and current green
 // approvals for every direct upstream artifact.
-export function setArtifactApproval(cwd: string, name: string, artifact: string, verdict: ArtifactVerdict, by = "ui", expectedArtifactHash?: string): boolean {
+function setArtifactApprovalUnlocked(cwd: string, name: string, artifact: string, verdict: ArtifactVerdict, by = "ui", expectedArtifactHash?: string): boolean {
   const id = toArtifactId(artifact);
   if (!id || !isSafeChangeId(name)) throw new Error(`Invalid approval target: ${name}/${artifact}`);
   if (verdict === null) {
@@ -648,12 +649,21 @@ export function setArtifactApproval(cwd: string, name: string, artifact: string,
   return true;
 }
 
+export function setArtifactApproval(cwd: string, name: string, artifact: string, verdict: ArtifactVerdict, by = "ui", expectedArtifactHash?: string): boolean {
+  const recordPath = approvalRecordPath(cwd, name, artifact, "human");
+  if (!recordPath) throw new Error(`Invalid approval target: ${name}/${artifact}`);
+  const changeDir = dirname(dirname(recordPath));
+  mkdirSync(changeDir, { recursive: true, mode: 0o700 });
+  return withCrossProcessFileLock(join(changeDir, ".approval-state"), () =>
+    setArtifactApprovalUnlocked(cwd, name, artifact, verdict, by, expectedArtifactHash));
+}
+
 export function artifactVerdict(cwd: string, name: string, artifact: string): ArtifactVerdict {
   const id = toArtifactId(artifact);
   return id ? (currentHumanRecord(cwd, name, id)?.verdict as ArtifactVerdict) ?? null : null;
 }
 
-export function setAgentReviewVerdict(cwd: string, name: string, artifact: string, verdict: AgentReviewVerdict, by = "agent-reviewer"): boolean {
+function setAgentReviewVerdictUnlocked(cwd: string, name: string, artifact: string, verdict: AgentReviewVerdict, by = "agent-reviewer"): boolean {
   const id = toArtifactId(artifact);
   if (!id || !isSafeChangeId(name)) throw new Error(`Invalid automated review target: ${name}/${artifact}`);
   if (verdict === null) {
@@ -679,6 +689,15 @@ export function setAgentReviewVerdict(cwd: string, name: string, artifact: strin
     artifactHash: hash,
   });
   return true;
+}
+
+export function setAgentReviewVerdict(cwd: string, name: string, artifact: string, verdict: AgentReviewVerdict, by = "agent-reviewer"): boolean {
+  const recordPath = approvalRecordPath(cwd, name, artifact, "automated-review");
+  if (!recordPath) throw new Error(`Invalid automated review target: ${name}/${artifact}`);
+  const changeDir = dirname(dirname(recordPath));
+  mkdirSync(changeDir, { recursive: true, mode: 0o700 });
+  return withCrossProcessFileLock(join(changeDir, ".approval-state"), () =>
+    setAgentReviewVerdictUnlocked(cwd, name, artifact, verdict, by));
 }
 
 export function agentReviewVerdict(cwd: string, name: string, artifact: string): AgentReviewVerdict {

--- a/src/engine/questions.ts
+++ b/src/engine/questions.ts
@@ -1,6 +1,8 @@
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { appendFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { ensureDir } from "../core/fs";
+import { withCrossProcessFileLock } from "../core/file-lock";
 import { isSafeChangeId } from "./openspec";
 
 // The clarifying-questions loop (WS-D) — pi-hive's own contribution on top of
@@ -16,16 +18,19 @@ import { isSafeChangeId } from "./openspec";
 // live only in chat.
 
 // Append a Q (and optionally its answer) to questions.md under the change dir.
-export function recordQuestion(cwd: string, change: string, question: string, answer?: string): void {
+export async function recordQuestion(cwd: string, change: string, question: string, answer?: string): Promise<void> {
   if (!isSafeChangeId(change)) return;
-  const dir = join(cwd, "openspec", "changes", change);
+  const dir = resolve(cwd, "openspec", "changes", change);
+  const target = join(dir, "questions.md");
   try {
-    ensureDir(dir);
-    const stamp = new Date().toISOString();
-    const block = answer
-      ? `\n## Q (${stamp})\n${question}\n\n**A:** ${answer}\n`
-      : `\n## Q (${stamp})\n${question}\n\n**A:** _pending_\n`;
-    appendFileSync(join(dir, "questions.md"), block);
+    await withFileMutationQueue(target, async () => {
+      ensureDir(dir);
+      const stamp = new Date().toISOString();
+      const block = answer
+        ? `\n## Q (${stamp})\n${question}\n\n**A:** ${answer}\n`
+        : `\n## Q (${stamp})\n${question}\n\n**A:** _pending_\n`;
+      withCrossProcessFileLock(target, () => appendFileSync(target, block));
+    });
   } catch {
     /* best-effort file trail */
   }
@@ -34,14 +39,16 @@ export function recordQuestion(cwd: string, change: string, question: string, an
 // Enqueue a `question` action into a session's dashboard-actions.jsonl. Used when
 // a headless planner must promote its question to the human-driven main session.
 // The main session's poller renders it; the human's answer round-trips back.
-export function enqueueQuestion(sessionDir: string, payload: { question: string; change?: string; askedBy?: string }): boolean {
+export async function enqueueQuestion(sessionDir: string, payload: { question: string; change?: string; askedBy?: string }): Promise<boolean> {
+  const target = resolve(sessionDir, "dashboard-actions.jsonl");
   try {
-    ensureDir(sessionDir);
-    appendFileSync(
-      join(sessionDir, "dashboard-actions.jsonl"),
-      `${JSON.stringify({ at: new Date().toISOString(), type: "question", ...payload })}\n`,
-    );
-    return true;
+    return await withFileMutationQueue(target, async () => {
+      ensureDir(sessionDir);
+      withCrossProcessFileLock(target, () => {
+        appendFileSync(target, `${JSON.stringify({ at: new Date().toISOString(), type: "question", ...payload })}\n`);
+      });
+      return true;
+    });
   } catch {
     return false;
   }

--- a/src/engine/reserved-paths.ts
+++ b/src/engine/reserved-paths.ts
@@ -1,0 +1,81 @@
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve, sep } from "node:path";
+import { HIVE_SESSIONS_DIR } from "../core/constants";
+import { isPathInside, resolveCanonicalPath } from "../core/safe-path";
+
+export type ReservedPathAccess = "read" | "upsert" | "delete";
+
+export interface ReservedPathOptions {
+  secretPaths?: string[];
+  // Core-owned persistence may opt out explicitly. Worker tool enforcement never
+  // supplies this flag, so a broad domain cannot silently override reservations.
+  trustedOverride?: boolean;
+  allowMissing?: boolean;
+}
+
+export interface ReservedPathDecision {
+  ok: boolean;
+  reason?: string;
+}
+
+const PRIVATE_KEY_NAMES = new Set([
+  "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "identity",
+  "secring.gpg", "private-key.pem", "private_key.pem",
+]);
+const PRIVATE_KEY_SUFFIXES = [".key", ".pem", ".p12", ".pfx", ".jks", ".keystore"];
+
+function pathSegments(value: string): string[] {
+  return resolve(value).split(sep).filter(Boolean).map((part) => part.toLowerCase());
+}
+
+function sensitiveBasename(value: string): string | undefined {
+  const base = basename(value).toLowerCase();
+  if (base.startsWith(".env")) return ".env* files";
+  if (PRIVATE_KEY_NAMES.has(base) || PRIVATE_KEY_SUFFIXES.some((suffix) => base.endsWith(suffix))) return "private key material";
+  return undefined;
+}
+
+function matchesConfiguredSecret(projectRoot: string, candidate: string, secretPaths: string[]): boolean {
+  return secretPaths.some((configured) => {
+    if (!configured?.trim()) return false;
+    const target = isAbsolute(configured) ? configured : resolve(projectRoot, configured);
+    const canonical = resolveCanonicalPath(target, { allowMissing: true });
+    return canonical ? isPathInside(canonical.canonicalPath, candidate) : isPathInside(target, candidate);
+  });
+}
+
+function reservationReason(projectRoot: string, candidate: string, secretPaths: string[]): string | undefined {
+  const agentDir = process.env.PI_CODING_AGENT_DIR || resolve(homedir(), ".pi", "agent");
+  const globalHiveRoot = resolve(agentDir, "hive");
+  if (isPathInside(globalHiveRoot, candidate)) return "pi-hive approval, daemon, registry, or telemetry authority";
+
+  const projectSessions = resolve(projectRoot, HIVE_SESSIONS_DIR);
+  if (isPathInside(projectSessions, candidate)) return "pi-hive session and telemetry state";
+
+  if (candidate === resolve(projectRoot, ".pi-hive-approval.json")) return "legacy approval data";
+  if (pathSegments(candidate).includes(".git")) return "Git repository metadata";
+
+  const basenameReason = sensitiveBasename(candidate);
+  if (basenameReason) return basenameReason;
+  if (matchesConfiguredSecret(projectRoot, candidate, secretPaths)) return "configured secret path";
+  return undefined;
+}
+
+export function checkReservedPath(
+  projectRoot: string,
+  requestedPath: string,
+  _access: ReservedPathAccess,
+  options: ReservedPathOptions = {},
+): ReservedPathDecision {
+  if (options.trustedOverride === true) return { ok: true };
+  if (!requestedPath?.trim()) return { ok: false, reason: "empty path cannot be authorized" };
+
+  const lexical = isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(projectRoot, requestedPath);
+  const canonical = resolveCanonicalPath(lexical, { allowMissing: options.allowMissing === true });
+  // Check both names: lexical matching catches a symlink named like a reserved
+  // target, while canonical matching catches an innocent-looking symlink that
+  // resolves into reserved state.
+  const reason = reservationReason(projectRoot, lexical, options.secretPaths || [])
+    || (canonical ? reservationReason(projectRoot, canonical.canonicalPath, options.secretPaths || []) : undefined);
+  return reason ? { ok: false, reason } : { ok: true };
+}

--- a/src/observability/server/plan-bridge.ts
+++ b/src/observability/server/plan-bridge.ts
@@ -3,6 +3,7 @@ import { appendFileSync } from "node:fs";
 import { PROJECT_CWD } from "./config";
 import { sessionSummaries } from "./runtime";
 import { ensureDir } from "../../core/fs";
+import { withCrossProcessFileLock } from "../../core/file-lock";
 
 // Shared plan/review infrastructure for the (Bun) dashboard server: project-cwd
 // scoping and the dashboard-actions.jsonl bridge producer. Extracted so it
@@ -45,6 +46,8 @@ export function enqueueDashboardAction(
   if (!target?.session_dir) return false;
   const file = path.join(target.session_dir, "dashboard-actions.jsonl");
   ensureDir(path.dirname(file));
-  appendFileSync(file, `${JSON.stringify({ at: new Date().toISOString(), ...action })}\n`);
+  withCrossProcessFileLock(file, () => {
+    appendFileSync(file, `${JSON.stringify({ at: new Date().toISOString(), ...action })}\n`);
+  });
   return true;
 }

--- a/src/observability/server/runtime.ts
+++ b/src/observability/server/runtime.ts
@@ -5,6 +5,7 @@ import { projectName } from "../../shared/project";
 import { tryResolveProjectIdentity } from "../../shared/project-identity";
 import { loadConfig } from "../../core/config";
 import type { AgentConfig, HiveTeam } from "../../core/types";
+import { withCrossProcessFileLock } from "../../core/file-lock";
 import type { HiveStateSnapshot, HiveTelemetryEvent, TelemetryRegistryRow, TelemetrySessionSummary, TopologyNode } from "../../shared/telemetry";
 import { BOOT_SESSION_ID, CONVERSATION_LOG, PROJECT_CWD, REGISTRY_PATH, SINGLE_LOG_PATH } from "./config";
 import {
@@ -640,15 +641,18 @@ export function sessionSummaries(): TelemetrySessionSummary[] {
 // Rewrite the global registry file, dropping any rows for the given session ids.
 function pruneRegistry(removed: Set<string>) {
   if (!fs.existsSync(REGISTRY_PATH)) return;
-  const kept: string[] = [];
-  for (const line of fs.readFileSync(REGISTRY_PATH, "utf8").split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const row = JSON.parse(line) as TelemetryRegistryRow;
-      if (!row.session_id || !removed.has(row.session_id)) kept.push(line);
-    } catch { kept.push(line); }
-  }
-  fs.writeFileSync(REGISTRY_PATH, kept.length ? kept.join("\n") + "\n" : "");
+  withCrossProcessFileLock(REGISTRY_PATH, () => {
+    if (!fs.existsSync(REGISTRY_PATH)) return;
+    const kept: string[] = [];
+    for (const line of fs.readFileSync(REGISTRY_PATH, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line) as TelemetryRegistryRow;
+        if (!row.session_id || !removed.has(row.session_id)) kept.push(line);
+      } catch { kept.push(line); }
+    }
+    fs.writeFileSync(REGISTRY_PATH, kept.length ? kept.join("\n") + "\n" : "");
+  });
 }
 
 // Delete sessions everywhere they live: SQLite (events/states/sessions),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -19,6 +19,9 @@ function fixtureProject() {
 settings:
   default-tools: read, grep
   max-parallel: 2
+  secret-paths:
+    - config/secrets.json
+    - .credentials/
   distiller:
     enabled: false
 shared-context:
@@ -54,6 +57,7 @@ test("loadConfig normalizes settings and enriches model frontmatter", () => {
 
   assert.equal(config.settings.maxParallel, 2);
   assert.equal(config.settings.defaultTools, "read, grep");
+  assert.deepEqual(config.settings.secretPaths, ["config/secrets.json", ".credentials/"]);
   assert.equal(config.settings.distiller.enabled, false);
   assert.equal(config.orchestrator.model, "openai/gpt-5");
   assert.equal(config.orchestrator.thinking, "medium");

--- a/tests/file-lock.test.ts
+++ b/tests/file-lock.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { closeSync, mkdtempSync, openSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { withCrossProcessFileLock } from "../src/core/file-lock.ts";
+
+function runWriter(resource: string, value: string): Promise<void> {
+  const script = `
+    import { appendFileSync } from 'node:fs';
+    import { withCrossProcessFileLock } from './src/core/file-lock.ts';
+    withCrossProcessFileLock(${JSON.stringify(resource)}, () => appendFileSync(${JSON.stringify(resource)}, ${JSON.stringify(`${value}\n`)}), { timeoutMs: 5000 });
+  `;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--experimental-strip-types", "--import", "./tests/register-ts-loader.mjs", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: unknown) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("exit", (code: number | null) => code === 0 ? resolve() : reject(new Error(`writer exited ${code}: ${stderr}`)));
+  });
+}
+
+test("cross-process file lock preserves every concurrent registry-style append", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-lock-"));
+  const resource = join(dir, "registry.jsonl");
+  writeFileSync(resource, "");
+  await Promise.all(Array.from({ length: 8 }, (_, index) => runWriter(resource, `row-${index}`)));
+  const rows = readFileSync(resource, "utf8").trim().split("\n").sort();
+  assert.deepEqual(rows, Array.from({ length: 8 }, (_, index) => `row-${index}`).sort());
+});
+
+test("cross-process file lock recovers stale locks and times out on active locks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-lock-stale-"));
+  const resource = join(dir, "registry.jsonl");
+  const lock = `${resource}.lock`;
+  writeFileSync(lock, "stale");
+  const old = new Date(Date.now() - 60_000);
+  utimesSync(lock, old, old);
+  assert.equal(withCrossProcessFileLock(resource, () => "recovered", { staleMs: 1_000 }), "recovered");
+
+  const fd = openSync(lock, "wx");
+  try {
+    assert.throws(() => withCrossProcessFileLock(resource, (): void => undefined, { timeoutMs: 20, retryMs: 5 }), /Timed out waiting for file lock/);
+  } finally {
+    closeSync(fd);
+  }
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdirSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { classify } from "../src/engine/file-class.ts";
 import { checkPlannerStages, checkTypePolicy } from "../src/engine/policy.ts";
 import { bashMutationKind, enforceDomainForTool, isCommitCommand, readOnlyCommandDecision } from "../src/engine/domain.ts";
+import { checkReservedPath } from "../src/engine/reserved-paths.ts";
 import { runAsAgent } from "../src/engine/session.ts";
 import { buildOperatingContract } from "../src/engine/prompts.ts";
 import type { AgentRuntime, AgentType, HiveState, PlanStage } from "../src/core/types.ts";
@@ -218,6 +219,38 @@ test("enforce: planner blocked from code, allowed spec", () => {
   const state = stateWith([runtime("Plan", { agentType: "planner", domain: specDomain })]);
   assert.match(block(state, "Plan", { toolName: "write", input: { path: "src/x.ts" } }) ?? "", /may not upsert code files/);
   assert.equal(block(state, "Plan", { toolName: "write", input: { path: ".pi/hive/plans/a/proposal.md" } }), undefined);
+});
+
+test("reserved paths override broad read and mutation domains", () => {
+  const state = stateWith([runtime("Dev", { agentType: "coder", domain: codeDomain })]);
+  state.config = { settings: { secretPaths: ["config/secrets.json"] } } as any;
+  const reserved = [
+    ["read", ".git/config"],
+    ["write", ".env.local"],
+    ["read", "keys/id_ed25519"],
+    ["write", "certs/service.pem"],
+    ["read", ".pi/hive/sessions/s1/hive-events.jsonl"],
+    ["read", "config/secrets.json"],
+    ["write", ".pi-hive-approval.json"],
+    ["read", join(homedir(), ".pi", "agent", "hive", "approvals", "record.json")],
+  ];
+  for (const [toolName, path] of reserved) {
+    assert.match(block(state, "Dev", { toolName, input: { path } }) ?? "", /reserved path/, `${toolName} ${path}`);
+  }
+  assert.equal(block(state, "Dev", { toolName: "read", input: { path: "src/tmp" } }), undefined);
+});
+
+test("reserved path matching catches bare bash names and symlink destinations", () => {
+  const state = stateWith([runtime("Dev", { agentType: "coder", domain: codeDomain })]);
+  writeFileSync(join(policyRoot, ".env"), "SECRET=x\n");
+  try { symlinkSync(join(policyRoot, ".env"), join(policyRoot, "public-config")); } catch { /* already created by rerun */ }
+  assert.match(block(state, "Dev", { toolName: "bash", input: { command: "cat .env" } }) ?? "", /reserved path/);
+  assert.match(block(state, "Dev", { toolName: "read", input: { path: "public-config" } }) ?? "", /reserved path/);
+});
+
+test("reserved paths require an explicit trusted override", () => {
+  assert.equal(checkReservedPath(policyRoot, ".env", "read").ok, false);
+  assert.equal(checkReservedPath(policyRoot, ".env", "read", { trustedOverride: true }).ok, true);
 });
 
 test("enforce: planner cannot forge global approval records with file tools or classified bash", () => {

--- a/tests/questions.test.ts
+++ b/tests/questions.test.ts
@@ -32,22 +32,29 @@ test("ask_user is a base tool available to planners/leads", () => {
   assert.ok(buildHiveTools(state, "Planner").some((t) => t.name === "ask_user"));
 });
 
-test("recordQuestion writes a file-backed trail under the change", () => {
+test("recordQuestion writes a file-backed trail under the change", async () => {
   const cwd = mkdtempSync(join(tmpdir(), "pi-hive-q-cwd-"));
-  recordQuestion(cwd, "add-auth", "Which auth provider?", "OIDC via Auth0");
+  await recordQuestion(cwd, "add-auth", "Which auth provider?", "OIDC via Auth0");
   const file = join(cwd, "openspec", "changes", "add-auth", "questions.md");
   assert.ok(existsSync(file));
   const body = readFileSync(file, "utf8");
   assert.match(body, /Which auth provider\?/);
   assert.match(body, /OIDC via Auth0/);
   // Unsafe change ids are ignored (no traversal).
-  recordQuestion(cwd, "../evil", "x");
+  await recordQuestion(cwd, "../evil", "x");
   assert.ok(!existsSync(join(cwd, "..", "evil", "questions.md")));
 });
 
-test("enqueueQuestion appends a question action to dashboard-actions.jsonl", () => {
+test("question writes share Pi's per-file mutation queue", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-q-concurrent-"));
+  await Promise.all(Array.from({ length: 20 }, (_, index) => recordQuestion(cwd, "queued", `Question ${index}?`)));
+  const body = readFileSync(join(cwd, "openspec", "changes", "queued", "questions.md"), "utf8");
+  for (let index = 0; index < 20; index++) assert.match(body, new RegExp(`Question ${index}\\?`));
+});
+
+test("enqueueQuestion appends a question action to dashboard-actions.jsonl", async () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-hive-q-enq-"));
-  assert.ok(enqueueQuestion(dir, { question: "Scope?", change: "add-auth", askedBy: "Planner" }));
+  assert.ok(await enqueueQuestion(dir, { question: "Scope?", change: "add-auth", askedBy: "Planner" }));
   const body = readFileSync(join(dir, "dashboard-actions.jsonl"), "utf8");
   const action = JSON.parse(body.trim().split("\n")[0]);
   assert.equal(action.type, "question");


### PR DESCRIPTION
## Summary
- enforce reserved approval, daemon, telemetry, Git, environment, private-key, and configured secret paths before domain policy
- add explicit trusted-only override semantics and secure broad-read setup defaults
- route question, automated-review, plan creation, and mental-model mutations through Pi's per-file mutation queue
- serialize cross-process approval, registry, and dashboard-action writes with stale-lock recovery

## Tests
- `just ci`
- 184 Node tests passed
- 38 Bun tests passed
