### PR TITLE
fix: harden worker lifecycle and telemetry ingestion

### DIFF
--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -12,7 +12,7 @@ import {
   truncateMiddle,
 } from "../core/utils";
 import { routeAgents } from "../engine/routing";
-import { dispatchAgent, distillMentalModel } from "../engine/dispatch";
+import { dispatchAgent, scheduleMentalModelDistillation } from "../engine/dispatch";
 import { renderHiveSddStatus, resolveHiveSddStatus } from "../engine/sdd";
 import { currentAgentName, currentChangeId } from "../engine/session";
 import { emitHiveEvent } from "../engine/observability";
@@ -183,7 +183,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
       // re-delegating the same agent never races it.
       if (result.exitCode === 0) {
         const distillRuntime = resolveRuntime(state, agent);
-        if (distillRuntime) void distillMentalModel(state, ctx, distillRuntime);
+        if (distillRuntime) void scheduleMentalModelDistillation(state, ctx, distillRuntime);
       }
       const limit = state.config?.settings.subagentOutputLimit || 12_000;
       const finalAnswer = extractFinalAnswer(result.output);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -313,4 +313,11 @@ export interface HiveState {
   activityLog?: HiveActivityEntry[];
   activityRender?: () => void;
   activityWidgetInstalled?: boolean;
+  // Session lifecycle guards for fire-and-forget work. Dashboard startup results
+  // and mental-model distillers must not mutate a state that has shut down.
+  shuttingDown?: boolean;
+  lifecycleGeneration?: number;
+  backgroundTasks?: Set<Promise<void>>;
+  distillQueues?: Map<string, Promise<void>>;
+  backgroundDistillerSessions?: Set<any>;
 }

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -84,6 +84,57 @@ function archivePriorRun(sessionFile: string) {
 // live model. Kept as the last optional param so existing callers are unchanged.
 export type CreateAgentSession = typeof createAgentSession;
 
+class WorkerRunLifecycle {
+  private session: any;
+  private unsubscribe?: () => void;
+  private abortListener?: () => void;
+  private closed = false;
+  private readonly state: HiveState;
+  private readonly runtime: AgentRuntime;
+  private readonly abortSignal?: AbortSignal;
+
+  constructor(state: HiveState, runtime: AgentRuntime, abortSignal?: AbortSignal) {
+    this.state = state;
+    this.runtime = runtime;
+    this.abortSignal = abortSignal;
+    state.activeRuns++;
+  }
+
+  attachSession(session: any): void {
+    this.session = session;
+    this.runtime.session = session;
+  }
+
+  attachSubscription(unsubscribe: () => void): void {
+    this.unsubscribe = unsubscribe;
+  }
+
+  watchParentAbort(listener: () => void): void {
+    this.abortListener = listener;
+    if (this.abortSignal?.aborted) listener();
+    else this.abortSignal?.addEventListener("abort", listener, { once: true });
+  }
+
+  async close(failed: boolean): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.abortListener) this.abortSignal?.removeEventListener("abort", this.abortListener);
+    if (this.runtime.timer) {
+      clearInterval(this.runtime.timer);
+      this.runtime.timer = undefined;
+    }
+    try { this.unsubscribe?.(); } catch { /* cleanup must continue */ }
+    if (failed && this.session?.abort) {
+      // Do not let a hung provider abort strand the slot forever. Invoking abort
+      // starts cancellation; disposal and counter release remain unconditional.
+      try { void Promise.resolve(this.session.abort()).catch((): void => undefined); } catch { /* cleanup must continue */ }
+    }
+    try { this.session?.dispose?.(); } catch { /* cleanup must continue */ }
+    this.runtime.session = undefined;
+    this.state.activeRuns = Math.max(0, this.state.activeRuns - 1);
+  }
+}
+
 export function resolveWorkerSkillPaths(cwd: string, refs: unknown[] = []): string[] {
   return normalizeWorkerSkillPaths(refs).flatMap((skillPath) => {
     const safe = resolveProjectPath(cwd, skillPath);
@@ -250,7 +301,7 @@ export async function dispatchAgent(
   runtime.elapsedMs = 0;
   runtime.runCount++;
   runtime.startedAt = Date.now();
-  state.activeRuns++;
+  const lifecycle = new WorkerRunLifecycle(state, runtime, abortSignal);
   // TOK/S baselines (J8/Decision 4): lifetime token counts at run start so the UI
   // divides the *per-run output* delta by *per-run* elapsedMs — not lifetime
   // tokens by per-run elapsed.
@@ -263,6 +314,24 @@ export async function dispatchAgent(
   runtime.runStartReasoningTokens = runtime.reasoningTokens;
   runtime.runStartCostUsd = runtime.costUsd;
 
+  const chunks: string[] = [];
+  let streamedSnapshot = "";
+  let session: any;
+  let abortedByParent = false;
+  let errorMessage: string | undefined;
+  const modelsSeen = new Set<string>();
+  const providersSeen = new Set<string>();
+  const apisSeen = new Set<string>();
+  let firstResponseId: string | undefined;
+  let lastResponseId: string | undefined;
+  const diagnostics: Array<{ type?: string; message?: string }> = [];
+  const MAX_DIAGNOSTICS = 20;
+  let lastStopReason: string | undefined;
+  const toolStartedAt = new Map<string, number>();
+  let lastRetryMaxAttempts: number | undefined;
+  let sdkCounts: { toolCalls?: number; toolResults?: number; userMessages?: number; assistantMessages?: number } | undefined;
+
+  try {
   const toolNames = tools.split(",").map((t) => t.trim()).filter(Boolean);
   // Type-scoped tools (e.g. submit_review_verdict) are granted by agent type,
   // not the tools list, so keep them even when the agent does not enumerate
@@ -270,8 +339,6 @@ export async function dispatchAgent(
   const hiveTools = buildHiveTools(state, runtime.config.name).filter((t) => toolNames.includes(t.name) || TYPE_SCOPED_TOOL_NAMES.has(t.name));
   const skillPaths = resolveWorkerSkillPaths(ctx.cwd, runtime.config.skills as unknown[]);
 
-  const chunks: string[] = [];
-  let streamedSnapshot = "";
   const sessionManager = SessionManager.open(runtime.sessionFile);
 
   // createAgentSession only calls reload() when it creates its own resource
@@ -284,7 +351,7 @@ export async function dispatchAgent(
   const workerLoader = workerResourceLoader(state, ctx.cwd, runtime.config.name, skillPaths);
   await workerLoader.reload();
 
-  const { session } = await createSession({
+  const created = await createSession({
     cwd: ctx.cwd,
     model: resolvedModel,
     modelRegistry: (ctx as any).modelRegistry,
@@ -294,17 +361,16 @@ export async function dispatchAgent(
     sessionManager,
     resourceLoader: workerLoader,
   });
-  runtime.session = session;
+  session = created.session;
+  lifecycle.attachSession(session);
 
-  let abortedByParent = false;
   const abortWorker = (): void => {
     abortedByParent = true;
     runtime.lastWork = "cancelling";
     addHiveActivity(state, { kind: "delegation_end", parent: caller, agent: runtime.config.name, status: "error", text: "cancel requested" });
     void session.abort?.().catch((): undefined => undefined);
   };
-  if (abortSignal?.aborted) abortWorker();
-  else abortSignal?.addEventListener("abort", abortWorker, { once: true });
+  lifecycle.watchParentAbort(abortWorker);
 
   // Authoritative per-model thinking levels for this worker's effective model.
   // This is the SDK's own answer — no ModelRegistry plumbing needed (A10).
@@ -358,26 +424,13 @@ export async function dispatchAgent(
   runtime.timer.unref?.();
 
   // Distinct actual models seen across this run's assistant messages (A3).
-  const modelsSeen = new Set<string>();
   // Per-message identity the SDK exposes on AssistantMessage (Item 9 / R3-1.4):
   // `.provider`, `.api`, `.responseId?`, `.diagnostics?` all ride the same
   // message_end object. Capture the distinct providers/apis, the first+last
   // responseId (bookends of the run), and a bounded set of diagnostics.
-  const providersSeen = new Set<string>();
-  const apisSeen = new Set<string>();
-  let firstResponseId: string | undefined;
-  let lastResponseId: string | undefined;
-  const diagnostics: Array<{ type?: string; message?: string }> = [];
-  const MAX_DIAGNOSTICS = 20;
-  let lastStopReason: string | undefined;
   // toolCallId → startedAt, for per-call durationMs (A4). Bounded by in-flight
-  // calls: deleted on tool_execution_end.
-  const toolStartedAt = new Map<string, number>();
-  // The SDK's `auto_retry_end` event does NOT carry `maxAttempts`; only the
-  // matching `auto_retry_start` does. Remember the last seen value so the
-  // retry-end telemetry can report it instead of always emitting `undefined`.
-  let lastRetryMaxAttempts: number | undefined;
-
+  // calls: deleted on tool_execution_end. Retry metadata is retained only for
+  // this reserved run and cleared by the outer lifecycle cleanup.
   const unsubscribe = session.subscribe((event: any) => {
     if (event.type === "message_update") {
       const delta = event.assistantMessageEvent;
@@ -515,8 +568,8 @@ export async function dispatchAgent(
     publishRuntimeUpdate(state);
     writeHiveStateSnapshot(state);
   });
+  lifecycle.attachSubscription(unsubscribe);
 
-  let errorMessage: string | undefined;
   try {
     // Scoped so currentAgentName() resolves to this worker for everything
     // causally downstream of prompt() — subscribed event handlers, tool
@@ -565,7 +618,6 @@ export async function dispatchAgent(
   // stats throws, the incremental values already on the runtime are kept.
   // Item 9: SessionStats also carries authoritative message/tool counts —
   // preferred over the hand-tallied toolCount so the numbers match the SDK's own.
-  let sdkCounts: { toolCalls?: number; toolResults?: number; userMessages?: number; assistantMessages?: number } | undefined;
   try {
     const stats: any = session.getSessionStats?.();
     if (stats) {
@@ -610,15 +662,15 @@ export async function dispatchAgent(
     }
   } catch { /* keep incremental values if stats is unavailable */ }
 
-  abortSignal?.removeEventListener("abort", abortWorker);
-  unsubscribe();
-  if (runtime.timer) clearInterval(runtime.timer);
-  runtime.elapsedMs = runtime.startedAt ? Date.now() - runtime.startedAt : runtime.elapsedMs;
-  runtime.status = errorMessage ? "error" : "done";
+  } catch (error: any) {
+    errorMessage = errorMessage || error?.message || String(error);
+  } finally {
+    toolStartedAt.clear();
+    await lifecycle.close(Boolean(errorMessage));
+    runtime.elapsedMs = runtime.startedAt ? Date.now() - runtime.startedAt : runtime.elapsedMs;
+    runtime.status = errorMessage ? "error" : "done";
+  }
   const exitCode = errorMessage ? 1 : 0;
-  state.activeRuns = Math.max(0, state.activeRuns - 1);
-  session.dispose();
-  runtime.session = undefined;
 
   const output = chunks.join("").trim() || streamedSnapshot.trim() || errorMessage || "[no output]";
   runtime.lastWork = output.split("\n").filter((line) => line.trim()).pop() || runtime.status;
@@ -742,6 +794,7 @@ export async function runDistillerProcess(state: HiveState, ctx: ExtensionContex
 
   const chunks: string[] = [];
   let streamedSnapshot = "";
+  (state.backgroundDistillerSessions ||= new Set()).add(session);
   session.subscribe((event: any) => {
     if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
       const delta = event.assistantMessageEvent;
@@ -760,6 +813,7 @@ export async function runDistillerProcess(state: HiveState, ctx: ExtensionContex
   } catch {
     return "";
   } finally {
+    state.backgroundDistillerSessions?.delete(session);
     session.dispose();
   }
   return chunks.join("").trim() || streamedSnapshot.trim();
@@ -791,32 +845,63 @@ export async function distillMentalModel(state: HiveState, ctx: ExtensionContext
   } catch { /* no session yet */ }
   if (!conversation) { try { rmSync(snapshotPath, { force: true }); } catch { /* noop */ } return; }
 
+  let changed = false;
+  let errorMessage: string | undefined;
+  emitHiveEvent(state, "distill_start", { agent: runtime.config.name, target: target.path, model: state.config.settings.distiller.model }, "Distiller");
   try {
     const currentModel = safeRead(targetPath);
     const today = new Date().toISOString().slice(0, 10);
     const prompt = buildDistillerPrompt(runtime.config.name, currentModel, conversation, today);
-    emitHiveEvent(state, "distill_start", { agent: runtime.config.name, target: target.path, model: state.config.settings.distiller.model }, "Distiller");
     const output = await runDistillerProcess(state, ctx, prompt, state.config.settings.distiller.model);
     const extracted = extractTagged(output, "mental_model");
     // Mechanical safety net: guarantee the hard spine (owner/updated/spine keys)
     // even if the distiller's output drifts. The soft body is left byte-exact.
     const distilled = extracted ? normalizeMentalModelSpine(extracted, runtime.config.name).trim() : null;
-    if (distilled && distilled !== currentModel.trim()) {
-      let changed = false;
+    if (distilled && distilled !== currentModel.trim() && !state.shuttingDown) {
       await withFileMutationQueue(targetPath, async () => {
         // Re-read inside the queued mutation window. If another tool updated the
         // model while distillation was running, do not overwrite fresher state
         // with a result derived from the old snapshot.
         const latestModel = safeRead(targetPath);
-        if (latestModel.trim() !== currentModel.trim()) return;
+        if (state.shuttingDown || latestModel.trim() !== currentModel.trim()) return;
         writeFileSync(targetPath, `${distilled}\n`);
         changed = true;
       });
       if (changed) {
         logRecord(state, { from: "Distiller", to: runtime.config.name, type: "mental_model_distilled", message: `Updated ${target.path}`, path: target.path });
-        emitHiveEvent(state, "distill_end", { agent: runtime.config.name, target: target.path, changed: true }, "Distiller");
       }
     }
-  } catch { /* distillation is best-effort; never fail the delegation */ }
-  finally { try { rmSync(snapshotPath, { force: true }); } catch { /* noop */ } }
+  } catch (error: any) {
+    errorMessage = truncateMiddle(error?.message || String(error), 500);
+  } finally {
+    emitHiveEvent(state, "distill_end", { agent: runtime.config.name, target: target.path, changed, errorMessage }, "Distiller");
+    try { rmSync(snapshotPath, { force: true }); } catch { /* noop */ }
+  }
+}
+
+export function scheduleMentalModelDistillation(
+  state: HiveState,
+  ctx: ExtensionContext,
+  runtime: AgentRuntime,
+  runDistiller: typeof distillMentalModel = distillMentalModel,
+): Promise<void> {
+  const target = agentMentalModelTarget(runtime);
+  if (!target || state.shuttingDown) return Promise.resolve();
+  const runCount = runtime.runCount;
+  const queues = state.distillQueues ||= new Map<string, Promise<void>>();
+  const background = state.backgroundTasks ||= new Set<Promise<void>>();
+  const previous = queues.get(target.path) || Promise.resolve();
+  const task = previous.catch((): void => undefined).then(async () => {
+    // A newer run for the same runtime supersedes this queued snapshot. Skipping
+    // it prevents an old conversation from overwriting a newer mental model.
+    if (state.shuttingDown || runtime.runCount !== runCount) return;
+    await runDistiller(state, ctx, runtime);
+  }).catch((): void => undefined);
+  queues.set(target.path, task);
+  background.add(task);
+  void task.finally(() => {
+    background.delete(task);
+    if (queues.get(target.path) === task) queues.delete(target.path);
+  });
+  return task;
 }

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -18,6 +18,11 @@ export function createState(pi: ExtensionAPI): HiveState {
     sddStatus: null,
     obsSeq: 0,
     latestVerdicts: new Map(),
+    shuttingDown: false,
+    lifecycleGeneration: 0,
+    backgroundTasks: new Set(),
+    distillQueues: new Map(),
+    backgroundDistillerSessions: new Set(),
     orchestratorRuntime: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, reasoningTokens: 0, costUsd: 0, toolCount: 0, status: "idle", elapsedMs: 0 },
   };
 }

--- a/src/integration/hooks.ts
+++ b/src/integration/hooks.ts
@@ -351,6 +351,8 @@ ${catalog}`,
   });
 
   pi.on("session_start", async (_event: any, ctx: ExtensionContext) => {
+    state.shuttingDown = false;
+    const lifecycleGeneration = state.lifecycleGeneration = (state.lifecycleGeneration || 0) + 1;
     state.widgetCtx = ctx;
     // Capture the ModelRegistry from the full session_start ctx — the reliable
     // handle. The mode-switch ctx that used to feed emitModelCatalog could lack
@@ -373,6 +375,12 @@ ${catalog}`,
       // sessions adopt the running one. No browser tab opens automatically — the
       // header shows the URL. It is NOT torn down on session shutdown (shared).
       void ensureDashboard(state, ctx, EXTENSION_ROOT, { open: false }).then((result) => {
+        // The async health-check/spawn may finish after session_shutdown. Ignore
+        // that stale completion instead of reinstalling UI on a dead session.
+        if (state.shuttingDown || state.lifecycleGeneration !== lifecycleGeneration) {
+          state.obsServer = undefined;
+          return;
+        }
         if (result.running && ctx.mode === "tui") installHeader(state, ctx);
       }).catch(() => { /* best-effort; the dashboard is optional */ });
       const missingSkills = Array.from(state.runtimes.values()).flatMap((runtime) =>
@@ -396,10 +404,38 @@ ${catalog}`,
   });
 
   pi.on("session_shutdown", async (_event: any, ctx: ExtensionContext) => {
+    state.shuttingDown = true;
+    state.lifecycleGeneration = (state.lifecycleGeneration || 0) + 1;
+    if (orchestratorSnapshotTimer) clearTimeout(orchestratorSnapshotTimer);
+    orchestratorSnapshotTimer = undefined;
+    orchestratorToolStartedAt.clear();
+    turnStartedAt.clear();
     for (const runtime of state.runtimes.values()) {
       if (runtime.timer) clearInterval(runtime.timer);
-      if (runtime.session) { try { runtime.session.dispose(); } catch { /* noop */ } runtime.session = undefined; }
+      runtime.timer = undefined;
+      if (runtime.session) {
+        try { void Promise.resolve(runtime.session.abort?.()).catch((): void => undefined); } catch { /* noop */ }
+        try { runtime.session.dispose(); } catch { /* noop */ }
+        runtime.session = undefined;
+      }
     }
+    // Distillers are tracked separately from worker runtimes. Abort their
+    // in-memory sessions and give their promises a bounded chance to settle;
+    // their write guard also refuses any completion after shuttingDown is set.
+    for (const session of state.backgroundDistillerSessions || []) {
+      try { void Promise.resolve(session.abort?.()).catch((): void => undefined); } catch { /* noop */ }
+      try { session.dispose?.(); } catch { /* noop */ }
+    }
+    const background = [...(state.backgroundTasks || [])];
+    if (background.length) {
+      await Promise.race([
+        Promise.allSettled(background),
+        new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+      ]);
+    }
+    state.backgroundDistillerSessions?.clear();
+    state.backgroundTasks?.clear();
+    state.distillQueues?.clear();
     // The telemetry dashboard is a SHARED global daemon — other sessions may be
     // using it — so we do NOT kill it here. Just drop this session's reference.
     // Explicit teardown is /hive-observe-stop.

--- a/src/observability/server/db.ts
+++ b/src/observability/server/db.ts
@@ -168,7 +168,11 @@ CREATE TABLE IF NOT EXISTS ingest_sources (
   path TEXT PRIMARY KEY,
   session_id TEXT,
   offset INTEGER NOT NULL,
-  updated_at TEXT NOT NULL
+  updated_at TEXT NOT NULL,
+  device INTEGER,
+  inode INTEGER,
+  checkpoint TEXT,
+  last_successful_ingest TEXT
 );
 
 -- Versioned topology (Phase C). One immutable row per unique team configuration,
@@ -281,6 +285,12 @@ try { db.run(`ALTER TABLE project_overrides ADD COLUMN canonical_root TEXT`); } 
 try { db.run(`ALTER TABLE delegations ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 0`); } catch { /* column already exists */ }
 // Phase 4.8: reasoning ("thinking") tokens per delegation run.
 try { db.run(`ALTER TABLE delegations ADD COLUMN reasoning_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* column already exists */ }
+// T08: persist the file identity beside its committed newline offset so a
+// rotated path is replayed from byte zero even across daemon restarts.
+try { db.run(`ALTER TABLE ingest_sources ADD COLUMN device INTEGER`); } catch { /* column already exists */ }
+try { db.run(`ALTER TABLE ingest_sources ADD COLUMN inode INTEGER`); } catch { /* column already exists */ }
+try { db.run(`ALTER TABLE ingest_sources ADD COLUMN checkpoint TEXT`); } catch { /* column already exists */ }
+try { db.run(`ALTER TABLE ingest_sources ADD COLUMN last_successful_ingest TEXT`); } catch { /* column already exists */ }
 // Phase 2.5: drop the unused (session_id, ts, seq) events index — no query
 // orders by (session_id, ts); session-filtered reads order by rowid and are
 // served by idx_hive_events_session_seq. Dropping frees write/space overhead.
@@ -593,21 +603,77 @@ export function deleteSessionRows(ids: string[]): void {
 // ── Incremental-ingest offsets (B4) ──────────────────────────────────────────
 
 const upsertIngestSourceStmt = db.query(`
-  INSERT INTO ingest_sources (path, session_id, offset, updated_at)
-  VALUES ($path, $session_id, $offset, $updated_at)
+  INSERT INTO ingest_sources (path, session_id, offset, updated_at, device, inode, checkpoint, last_successful_ingest)
+  VALUES ($path, $session_id, $offset, $updated_at, $device, $inode, $checkpoint, $last_successful_ingest)
   ON CONFLICT(path) DO UPDATE SET
     session_id = COALESCE(excluded.session_id, ingest_sources.session_id),
     offset = excluded.offset,
-    updated_at = excluded.updated_at
+    updated_at = excluded.updated_at,
+    device = COALESCE(excluded.device, ingest_sources.device),
+    inode = COALESCE(excluded.inode, ingest_sources.inode),
+    checkpoint = COALESCE(excluded.checkpoint, ingest_sources.checkpoint),
+    last_successful_ingest = COALESCE(excluded.last_successful_ingest, ingest_sources.last_successful_ingest)
 `);
 
-export function getIngestOffset(sourcePath: string): number {
-  const row = db.query(`SELECT offset FROM ingest_sources WHERE path = $path`).get({ $path: sourcePath }) as any;
-  return Number(row?.offset || 0);
+export interface IngestSourceCursor {
+  offset: number;
+  updatedAt?: string;
+  device?: number;
+  inode?: number;
+  checkpoint?: string;
 }
 
-export function setIngestOffset(sourcePath: string, offset: number, sessionId: string | undefined, updatedAt: string): void {
-  upsertIngestSourceStmt.run({ $path: sourcePath, $session_id: sessionId ?? null, $offset: offset, $updated_at: updatedAt });
+export function getIngestSource(sourcePath: string): IngestSourceCursor {
+  const row = db.query(`SELECT offset, last_successful_ingest, device, inode, checkpoint FROM ingest_sources WHERE path = $path`).get({ $path: sourcePath }) as any;
+  return {
+    offset: Number(row?.offset || 0),
+    updatedAt: row?.last_successful_ingest || undefined,
+    device: row?.device == null ? undefined : Number(row.device),
+    inode: row?.inode == null ? undefined : Number(row.inode),
+    checkpoint: row?.checkpoint || undefined,
+  };
+}
+
+export function getIngestOffset(sourcePath: string): number {
+  return getIngestSource(sourcePath).offset;
+}
+
+export function setIngestOffset(
+  sourcePath: string,
+  offset: number,
+  sessionId: string | undefined,
+  updatedAt: string,
+  identity: { device?: number; inode?: number; checkpoint?: string } = {},
+): void {
+  upsertIngestSourceStmt.run({
+    $path: sourcePath,
+    $session_id: sessionId ?? null,
+    $offset: offset,
+    $updated_at: updatedAt,
+    $device: identity.device ?? null,
+    $inode: identity.inode ?? null,
+    $checkpoint: identity.checkpoint ?? null,
+    $last_successful_ingest: updatedAt,
+  });
+}
+
+export function setIngestIdentity(
+  sourcePath: string,
+  offset: number,
+  sessionId: string | undefined,
+  updatedAt: string,
+  identity: { device?: number; inode?: number; checkpoint?: string },
+): void {
+  upsertIngestSourceStmt.run({
+    $path: sourcePath,
+    $session_id: sessionId ?? null,
+    $offset: offset,
+    $updated_at: updatedAt,
+    $device: identity.device ?? null,
+    $inode: identity.inode ?? null,
+    $checkpoint: identity.checkpoint ?? null,
+    $last_successful_ingest: null,
+  });
 }
 
 // ── Typed projections: delegations / tool_calls (B3) ──────────────────────────

--- a/src/observability/server/index.ts
+++ b/src/observability/server/index.ts
@@ -7,6 +7,7 @@ import {
   allSnapshots,
   deleteProject,
   deleteSessions,
+  ingestionHealth,
   listModels,
   listTopologies,
   maxEventCursor,
@@ -160,6 +161,7 @@ Bun.serve({
       registry: REGISTRY_PATH,
       db: DB_PATH,
       sources: sourcePaths(),
+      ingestion: ingestionHealth(),
     });
     // Paginated, cursor-ordered event feed (B5). `?after=<cursor>` returns only
     // newer events (lossless SSE catch-up); no more single 20k-event body.

--- a/src/observability/server/jsonl-reader.ts
+++ b/src/observability/server/jsonl-reader.ts
@@ -1,0 +1,135 @@
+import * as fs from "node:fs";
+
+export interface JsonlReaderOptions {
+  chunkBytes?: number;
+  batchBytes?: number;
+  maxRecordBytes?: number;
+}
+
+export interface JsonlBatch {
+  lines: string[];
+  endOffset: number;
+  oversizedLines: number;
+}
+
+export interface JsonlScanResult {
+  fileSize: number;
+  committedOffset: number;
+  pendingTailBytes: number;
+  bytesRead: number;
+  maxBufferedBytes: number;
+  oversizedLines: number;
+}
+
+const DEFAULT_CHUNK_BYTES = 64 * 1024;
+const DEFAULT_BATCH_BYTES = 1024 * 1024;
+const DEFAULT_MAX_RECORD_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Scan a stable byte snapshot of a JSONL file with bounded memory.
+ *
+ * Bytes after the final newline are deliberately left uncommitted. Callers
+ * persist each batch's endOffset only after processing that batch succeeds,
+ * then pass the persisted offset back on the next scan. UTF-8 is decoded only
+ * after a complete line has been assembled, so multi-byte characters may cross
+ * any read-chunk boundary safely.
+ */
+export function scanJsonlFile(
+  file: string,
+  startOffset: number,
+  onBatch: (batch: JsonlBatch) => void,
+  options: JsonlReaderOptions = {},
+): JsonlScanResult {
+  const chunkBytes = Math.max(1, Math.floor(options.chunkBytes || DEFAULT_CHUNK_BYTES));
+  const batchBytes = Math.max(1, Math.floor(options.batchBytes || DEFAULT_BATCH_BYTES));
+  const maxRecordBytes = Math.max(1, Math.floor(options.maxRecordBytes || DEFAULT_MAX_RECORD_BYTES));
+  const stat = fs.statSync(file);
+  const fileSize = stat.size;
+  const start = Math.max(0, Math.min(Math.floor(startOffset), fileSize));
+  const fd = fs.openSync(file, "r");
+
+  let readOffset = start;
+  let committedOffset = start;
+  let recordStart = start;
+  let recordBytes = 0;
+  let recordParts: Buffer[] = [];
+  let skippingOversized = false;
+  let batchLines: string[] = [];
+  let batchSize = 0;
+  let batchOversized = 0;
+  let totalOversized = 0;
+  let maxBufferedBytes = 0;
+
+  const flush = (endOffset: number) => {
+    if (!batchLines.length && batchOversized === 0) return;
+    onBatch({ lines: batchLines, endOffset, oversizedLines: batchOversized });
+    batchLines = [];
+    batchSize = 0;
+    batchOversized = 0;
+  };
+
+  const appendPart = (part: Buffer) => {
+    if (!part.length || skippingOversized) return;
+    recordBytes += part.length;
+    if (recordBytes > maxRecordBytes) {
+      skippingOversized = true;
+      recordParts = [];
+      return;
+    }
+    recordParts.push(Buffer.from(part));
+    maxBufferedBytes = Math.max(maxBufferedBytes, recordBytes + batchSize);
+  };
+
+  try {
+    while (readOffset < fileSize) {
+      const wanted = Math.min(chunkBytes, fileSize - readOffset);
+      const chunk = Buffer.allocUnsafe(wanted);
+      const bytesRead = fs.readSync(fd, chunk, 0, wanted, readOffset);
+      if (bytesRead <= 0) break;
+      const data = bytesRead === chunk.length ? chunk : chunk.subarray(0, bytesRead);
+      let cursor = 0;
+      while (cursor < data.length) {
+        const newline = data.indexOf(0x0a, cursor);
+        if (newline < 0) {
+          appendPart(data.subarray(cursor));
+          break;
+        }
+        appendPart(data.subarray(cursor, newline));
+        const lineEndOffset = readOffset + newline + 1;
+        if (skippingOversized) {
+          totalOversized++;
+          batchOversized++;
+        } else {
+          const raw = recordParts.length === 0
+            ? Buffer.alloc(0)
+            : recordParts.length === 1
+              ? recordParts[0]
+              : Buffer.concat(recordParts, recordBytes);
+          const normalized = raw.length && raw[raw.length - 1] === 0x0d ? raw.subarray(0, -1) : raw;
+          batchLines.push(normalized.toString("utf8"));
+          batchSize += raw.length;
+          maxBufferedBytes = Math.max(maxBufferedBytes, batchSize);
+        }
+        committedOffset = lineEndOffset;
+        recordStart = lineEndOffset;
+        recordBytes = 0;
+        recordParts = [];
+        skippingOversized = false;
+        cursor = newline + 1;
+        if (batchSize >= batchBytes || batchLines.length >= 1000 || batchOversized > 0) flush(committedOffset);
+      }
+      readOffset += bytesRead;
+    }
+    flush(committedOffset);
+    return {
+      fileSize,
+      committedOffset,
+      pendingTailBytes: fileSize - recordStart,
+      bytesRead: readOffset - start,
+      maxBufferedBytes,
+      oversizedLines: totalOversized,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/src/observability/server/runtime.ts
+++ b/src/observability/server/runtime.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import { agentRuns, parseAgentLog } from "../agent-log";
 import { projectName } from "../../shared/project";
 import { tryResolveProjectIdentity } from "../../shared/project-identity";
@@ -18,7 +19,7 @@ import {
   knownCwds,
   type StorageBreakdown,
   ensureSession,
-  getIngestOffset,
+  getIngestSource,
   insertEvent,
   insertPlanVerdict,
   loadPersistedStates,
@@ -29,6 +30,7 @@ import {
   maxEventCursor,
   querySessionSummaries,
   recentEvents,
+  setIngestIdentity,
   setIngestOffset,
   updateSessionStats,
   upsertSession,
@@ -47,6 +49,7 @@ import {
 import { canonicalTopologyJson, explodeTopology, topologyHash } from "./topology-hash";
 import { broadcastEvent, broadcastEventWithId } from "./sse";
 import type { Source } from "./types";
+import { scanJsonlFile } from "./jsonl-reader";
 
 const sources = new Map<string, Source>();
 // Hot cache: latest snapshot per session, for contextPct/lastWork ephemera and
@@ -55,8 +58,41 @@ const sources = new Map<string, Source>();
 const snapshots = new Map<string, HiveStateSnapshot>();
 let started = false;
 
+function fileCheckpoint(file: string, offset: number): string | undefined {
+  if (offset <= 0) return undefined;
+  const length = Math.min(64, offset);
+  const buffer = Buffer.allocUnsafe(length);
+  const fd = fs.openSync(file, "r");
+  try {
+    const bytesRead = fs.readSync(fd, buffer, 0, length, offset - length);
+    if (bytesRead !== length) return undefined;
+    return `${length}:${createHash("sha256").update(buffer).digest("hex")}`;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 export function sourcePaths(): string[] {
   return Array.from(sources.keys());
+}
+
+export function ingestionHealth() {
+  const rows = Array.from(sources.values()).map((source) => ({
+    path: source.logPath,
+    offset: source.offset,
+    corrupt_lines: source.corruptLines,
+    pending_tail_bytes: source.pendingTailBytes,
+    source_lag_bytes: source.sourceLagBytes,
+    last_successful_ingest: source.lastSuccessfulIngest,
+    last_error: source.lastError,
+  }));
+  return {
+    corrupt_lines: rows.reduce((sum, row) => sum + row.corrupt_lines, 0),
+    pending_tail_bytes: rows.reduce((sum, row) => sum + row.pending_tail_bytes, 0),
+    source_lag_bytes: rows.reduce((sum, row) => sum + row.source_lag_bytes, 0),
+    last_successful_ingest: rows.map((row) => row.last_successful_ingest).filter(Boolean).sort().at(-1),
+    sources: rows,
+  };
 }
 
 // Cursor-ordered event reads, SQL-backed and paginated (B5). No in-memory
@@ -76,9 +112,23 @@ export function addSource(logPath: string, meta: TelemetryRegistryRow = {}) {
     return;
   }
   const statePath = path.resolve(meta.state_file || path.join(path.dirname(abs), "hive-state.json"));
-  // Resume from the persisted byte offset (B4) so boot re-reads only new bytes
-  // instead of replaying the whole JSONL. INSERT OR IGNORE heals any overlap.
-  sources.set(abs, { logPath: abs, offset: getIngestOffset(abs), meta, statePath, stateMtimeMs: 0 });
+  // Resume from the last COMPLETE newline. The persisted device/inode pair lets
+  // readSource distinguish append from rotation, including after daemon restart.
+  const cursor = getIngestSource(abs);
+  sources.set(abs, {
+    logPath: abs,
+    offset: cursor.offset,
+    meta,
+    statePath,
+    stateMtimeMs: 0,
+    device: cursor.device,
+    inode: cursor.inode,
+    checkpoint: cursor.checkpoint,
+    corruptLines: 0,
+    pendingTailBytes: 0,
+    sourceLagBytes: 0,
+    lastSuccessfulIngest: cursor.updatedAt,
+  });
   try {
     fs.mkdirSync(path.dirname(abs), { recursive: true });
     fs.closeSync(fs.openSync(abs, "a"));
@@ -109,40 +159,85 @@ export function readRegistry() {
 export function readSource(logPath: string) {
   const source = sources.get(path.resolve(logPath));
   if (!source || !fs.existsSync(source.logPath)) return;
-  const stat = fs.statSync(source.logPath);
-  // Truncation/rewrite (offset past EOF) resets to 0; INSERT OR IGNORE heals the
-  // re-read idempotently.
-  if (stat.size < source.offset) source.offset = 0;
-  if (stat.size === source.offset) return;
-  const fd = fs.openSync(source.logPath, "r");
-  let endOffset = source.offset;
-  try {
-    const len = stat.size - source.offset;
-    const buf = Buffer.alloc(len);
-    fs.readSync(fd, buf, 0, len, source.offset);
-    endOffset = stat.size;
-    const parsed: HiveTelemetryEvent[] = [];
-    for (const line of buf.toString("utf8").split("\n")) {
-      if (!line.trim()) continue;
-      try { parsed.push(enrichEvent(JSON.parse(line), source)); } catch { /* ignore partial/corrupt lines */ }
+  let stat: fs.Stats;
+  try { stat = fs.statSync(source.logPath); }
+  catch (error: any) { source.lastError = String(error?.message || error); return; }
+
+  const missingIdentity = source.device == null || source.inode == null;
+  const rotated = !missingIdentity && (source.device !== stat.dev || source.inode !== stat.ino);
+  const truncated = stat.size < source.offset;
+  let rewritten = false;
+  if (!rotated && source.checkpoint && source.offset > 0 && stat.size >= source.offset) {
+    try { rewritten = fileCheckpoint(source.logPath, source.offset) !== source.checkpoint; }
+    catch { rewritten = true; }
+  }
+  if (rotated || rewritten || truncated) {
+    source.offset = 0;
+    source.checkpoint = undefined;
+  }
+  source.device = stat.dev;
+  source.inode = stat.ino;
+  source.sourceLagBytes = Math.max(0, stat.size - source.offset);
+  source.pendingTailBytes = source.sourceLagBytes;
+
+  // Persist identity even when there are no unread bytes. This makes a future
+  // same-path rotation detectable after a daemon restart without pretending an
+  // event offset advanced outside its insertion transaction.
+  if (stat.size === source.offset) {
+    const needsIdentityPersist = missingIdentity || rotated || rewritten || truncated || (source.offset > 0 && !source.checkpoint);
+    if (!needsIdentityPersist) {
+      source.lastError = undefined;
+      source.pendingTailBytes = 0;
+      source.sourceLagBytes = 0;
+      return;
     }
-    // One transaction per batch: all event writes + projections + the offset
-    // advance commit or roll back together (B4). This makes boot O(new bytes)
-    // and cuts per-event fsync on bursts. New events are collected for SSE and
-    // broadcast after the transaction commits.
-    const fresh: Array<{ event: HiveTelemetryEvent; cursor: number }> = [];
-    const sessionId = source.meta?.session_id;
-    db.transaction(() => {
-      for (const event of parsed) {
-        const res = ingestEvent(event);
-        if (res) fresh.push(res);
+    try {
+      const updatedAt = source.lastSuccessfulIngest || new Date().toISOString();
+      source.checkpoint = fileCheckpoint(source.logPath, source.offset);
+      db.transaction(() => setIngestIdentity(source.logPath, source.offset, source.meta?.session_id, updatedAt, { device: stat.dev, inode: stat.ino, checkpoint: source.checkpoint }))();
+      source.lastError = undefined;
+      source.pendingTailBytes = 0;
+      source.sourceLagBytes = 0;
+    } catch (error: any) {
+      source.lastError = String(error?.message || error);
+    }
+    return;
+  }
+
+  try {
+    const result = scanJsonlFile(source.logPath, source.offset, (batch) => {
+      const parsed: HiveTelemetryEvent[] = [];
+      let corrupt = batch.oversizedLines;
+      for (const line of batch.lines) {
+        if (!line.trim()) continue;
+        try { parsed.push(enrichEvent(JSON.parse(line), source)); }
+        catch { corrupt++; }
       }
-      setIngestOffset(source.logPath, endOffset, sessionId, new Date().toISOString());
-    })();
-    source.offset = endOffset;
-    for (const { event, cursor } of fresh) broadcastEventWithId("hive", event, cursor);
-  } finally {
-    fs.closeSync(fd);
+      // Every batch's event writes, projections, and COMPLETE-newline offset are
+      // atomic. A throw leaves that batch replayable from its previous offset.
+      const fresh: Array<{ event: HiveTelemetryEvent; cursor: number }> = [];
+      const ingestedAt = new Date().toISOString();
+      const checkpoint = fileCheckpoint(source.logPath, batch.endOffset);
+      db.transaction(() => {
+        for (const event of parsed) {
+          const inserted = ingestEvent(event);
+          if (inserted) fresh.push(inserted);
+        }
+        setIngestOffset(source.logPath, batch.endOffset, source.meta?.session_id, ingestedAt, { device: stat.dev, inode: stat.ino, checkpoint });
+      })();
+      source.offset = batch.endOffset;
+      source.checkpoint = checkpoint;
+      source.corruptLines += corrupt;
+      source.lastSuccessfulIngest = ingestedAt;
+      source.lastError = undefined;
+      for (const { event, cursor } of fresh) broadcastEventWithId("hive", event, cursor);
+    });
+    source.pendingTailBytes = result.pendingTailBytes;
+    source.sourceLagBytes = Math.max(0, result.fileSize - source.offset);
+  } catch (error: any) {
+    source.lastError = String(error?.message || error);
+    source.sourceLagBytes = Math.max(0, stat.size - source.offset);
+    source.pendingTailBytes = source.sourceLagBytes;
   }
 }
 

--- a/src/observability/server/types.ts
+++ b/src/observability/server/types.ts
@@ -8,4 +8,12 @@ export type Source = {
   meta: TelemetryRegistryRow;
   statePath: string;
   stateMtimeMs: number;
+  device?: number;
+  inode?: number;
+  checkpoint?: string;
+  corruptLines: number;
+  pendingTailBytes: number;
+  sourceLagBytes: number;
+  lastSuccessfulIngest?: string;
+  lastError?: string;
 };

--- a/src/ui/tui/widget.ts
+++ b/src/ui/tui/widget.ts
@@ -138,12 +138,13 @@ export function applyMode(state: HiveState, ctx: ExtensionContext, mode: HiveMod
 
   const previous = state.mode;
 
-  // Phase 5.4 drain guard: switching plan⇄hive rebuilds state.runtimes, which
-  // disposes the previous team's live worker sessions. Doing that mid-dispatch
-  // would kill an in-flight worker and leak its run. Refuse the switch while any
-  // worker is running and tell the user to wait; keep the current mode intact.
-  const rebuildsTeam = mode !== "normal" && state.config && canonicalMode(previous) !== mode;
-  if (rebuildsTeam && state.activeRuns > 0) {
+  // Drain guard: no mode transition is safe while a worker is running. Team
+  // switches rebuild runtimes, while switching to normal removes enforcement
+  // from a still-live worker hierarchy. Keep the current mode intact until every
+  // reserved run slot has completed its unconditional cleanup.
+  const changesMode = canonicalMode(previous) !== mode;
+  const rebuildsTeam = mode !== "normal" && state.config && changesMode;
+  if (changesMode && state.activeRuns > 0) {
     if (shouldNotify && ctx.hasUI) {
       ctx.ui.notify(`Cannot switch mode while ${state.activeRuns} agent${state.activeRuns === 1 ? " is" : "s are"} running. Wait for the current work to finish, then switch.`, "error");
     }

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { dispatchAgent, inferArtifactFromReviewTask, inferChangeIdFromReviewTask, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, type CreateAgentSession } from "../src/engine/dispatch.ts";
+import { dispatchAgent, distillMentalModel, inferArtifactFromReviewTask, inferChangeIdFromReviewTask, isPendingArtifactRevisionTask, resolveWorkerSkillPaths, scheduleMentalModelDistillation, type CreateAgentSession } from "../src/engine/dispatch.ts";
 import { restoreRuntimeCounters } from "../src/engine/session.ts";
 import type { AgentRuntime, HiveState } from "../src/core/types.ts";
 
@@ -142,6 +142,101 @@ test("dispatchAgent treats message_update.text as snapshot, not appended delta",
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.output, "- Please approve");
+});
+
+test("mental-model distillers serialize per target and release background tracking", async () => {
+  const worker = runtimeFor("Builder", "/tmp/builder.jsonl");
+  worker.config.context = [{ path: ".pi/hive/agents/builder-model.yaml", updatable: true }];
+  worker.runCount = 1;
+  const state = {} as HiveState;
+  let active = 0;
+  let maxActive = 0;
+  let calls = 0;
+  let releaseFirst: (() => void) | undefined;
+  const runner = async (): Promise<void> => {
+    calls++;
+    active++;
+    maxActive = Math.max(maxActive, active);
+    if (calls === 1) await new Promise<void>((resolve) => { releaseFirst = resolve; });
+    active--;
+  };
+
+  const first = scheduleMentalModelDistillation(state, {} as any, worker, runner as any);
+  await new Promise((resolve) => setImmediate(resolve));
+  const second = scheduleMentalModelDistillation(state, {} as any, worker, runner as any);
+  assert.equal(calls, 1, "second distiller must wait behind the first target queue");
+  releaseFirst?.();
+  await Promise.all([first, second]);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls, 2);
+  assert.equal(maxActive, 1);
+  assert.equal(state.backgroundTasks?.size, 0);
+  assert.equal(state.distillQueues?.size, 0);
+});
+
+test("distiller always emits distill_end after a started no-output run", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-distill-end-"));
+  const agentsDir = join(dir, ".pi", "hive", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  worker.config.context = [{ path: ".pi/hive/agents/builder-model.yaml", updatable: true }];
+  writeFileSync(worker.sessionFile, '{"type":"message","text":"learned fact"}\n');
+  writeFileSync(join(agentsDir, "builder-model.yaml"), "owner: Builder\nupdated: 2026-01-01\n");
+  const obsLog = join(dir, "e.jsonl");
+  const state = {
+    config: { settings: { distiller: { enabled: true, model: "missing/model", conversationLines: 10 } } },
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: obsLog },
+    obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: (): undefined => undefined } } as any;
+
+  await distillMentalModel(state, ctx, worker);
+
+  const events = readEmittedEvents(obsLog).filter((event) => event.type.startsWith("distill_"));
+  assert.deepEqual(events.map((event) => event.type), ["distill_start", "distill_end"]);
+  assert.equal(events[1].payload.changed, false);
+});
+
+test("dispatchAgent setup failure releases the reserved slot and emits terminal telemetry", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-setup-failure-"));
+  const worker = runtimeFor("Builder", join(dir, "builder.jsonl"));
+  const obsLog = join(dir, "e.jsonl");
+  const state: HiveState = {
+    pi: {} as any,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md" },
+      agents: [worker.config], sharedContext: [],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 2, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    } as any,
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "c.jsonl"), observabilityLog: obsLog },
+    runtimes: new Map([["builder", worker]]), widgetCtx: null, activeRuns: 0,
+    mode: "hive", normalToolNames: [], sddStatus: null, obsSeq: 0,
+  } as any;
+  const ctx = { cwd: dir, modelRegistry: { find: () => ({ provider: "test", id: "model" }) } } as any;
+  let aborted = 0;
+  let disposed = 0;
+  const create: CreateAgentSession = (async () => ({ session: {
+    subscribe(): () => void { throw new Error("subscription setup failed"); },
+    async abort(): Promise<void> { aborted++; },
+    dispose(): void { disposed++; },
+    state: { errorMessage: undefined },
+  } } as any)) as any;
+
+  const result = await dispatchAgent(state, "Builder", "fail during setup", ctx, false, create);
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.output, /subscription setup failed/);
+  assert.equal(state.activeRuns, 0);
+  assert.equal(worker.status, "error");
+  assert.equal(worker.session, undefined);
+  assert.equal(worker.timer, undefined);
+  assert.equal(aborted, 1, "a partially-created session must be aborted on setup failure");
+  assert.equal(disposed, 1, "a partially-created session must be disposed on setup failure");
+  const terminal = readEmittedEvents(obsLog).find((event) => event.type === "delegation_end");
+  assert.ok(terminal, "setup failure must still emit bounded terminal telemetry");
+  assert.equal(terminal.payload.exitCode, 1);
+  assert.match(terminal.payload.errorMessage, /subscription setup failed/);
 });
 
 test("dispatchAgent abort signal cancels the worker session", async () => {

--- a/tests/ingestion.spec.ts
+++ b/tests/ingestion.spec.ts
@@ -1,0 +1,111 @@
+import { beforeAll, expect, test } from "bun:test";
+import { mkdtempSync, renameSync, truncateSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.HIVE_TELEMETRY_DB ||= join(mkdtempSync(join(tmpdir(), "pi-hive-ingest-db-")), "telemetry.db");
+
+let runtime: typeof import("../src/observability/server/runtime");
+let database: typeof import("../src/observability/server/db");
+
+beforeAll(async () => {
+  database = await import("../src/observability/server/db");
+  runtime = await import("../src/observability/server/runtime");
+});
+
+function event(id: string, session: string, seq: number, text = id) {
+  return JSON.stringify({
+    event_id: id,
+    session_id: session,
+    seq,
+    ts: `2026-07-14T00:00:${String(seq).padStart(2, "0")}.000Z`,
+    type: "user_message",
+    actor: "User",
+    pid: 1,
+    payload: { text },
+  });
+}
+
+function source(name: string) {
+  const dir = mkdtempSync(join(tmpdir(), `pi-hive-ingest-${name}-`));
+  return { dir, file: join(dir, "hive-events.jsonl") };
+}
+
+test("runtime ingests complete lines exactly once and retains partial tail across reads", () => {
+  const { file } = source("partial");
+  const session = "ingest-partial";
+  const first = event("ip-1", session, 1, "héllo 🐝");
+  const second = event("ip-2", session, 2);
+  const split = Math.floor(Buffer.byteLength(second) / 2);
+  const secondBytes = Buffer.from(second);
+  writeFileSync(file, Buffer.concat([Buffer.from(`${first}\n`), secondBytes.subarray(0, split)]));
+
+  runtime.addSource(file, { session_id: session });
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["ip-1"]);
+  let health = runtime.ingestionHealth().sources.find((row) => row.path === file)!;
+  expect(health.pending_tail_bytes).toBe(split);
+  expect(health.source_lag_bytes).toBe(split);
+
+  appendFileSync(file, Buffer.concat([secondBytes.subarray(split), Buffer.from("\n")]));
+  runtime.readSource(file);
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["ip-1", "ip-2"]);
+  runtime.readSource(file);
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["ip-1", "ip-2"]);
+  health = runtime.ingestionHealth().sources.find((row) => row.path === file)!;
+  expect(health.pending_tail_bytes).toBe(0);
+  expect(health.source_lag_bytes).toBe(0);
+  expect(health.last_successful_ingest).toBeTruthy();
+});
+
+test("runtime advances past corrupt complete lines and reports ingestion health", () => {
+  const { file } = source("corrupt");
+  const session = "ingest-corrupt";
+  writeFileSync(file, `{not-json}\n${event("ic-1", session, 1)}\npartial`);
+
+  runtime.addSource(file, { session_id: session });
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["ic-1"]);
+  const health = runtime.ingestionHealth().sources.find((row) => row.path === file)!;
+  expect(health.corrupt_lines).toBe(1);
+  expect(health.pending_tail_bytes).toBe(Buffer.byteLength("partial"));
+});
+
+test("event insertion and complete-line offset advancement roll back together", () => {
+  const { file } = source("transaction");
+  const session = "ingest-transaction";
+  writeFileSync(file, `${event("itx-1", session, 1)}\n`);
+  database.db.run(`CREATE TRIGGER fail_itx BEFORE INSERT ON events WHEN NEW.event_id = 'itx-1' BEGIN SELECT RAISE(ABORT, 'forced ingest failure'); END`);
+  try {
+    runtime.addSource(file, { session_id: session });
+    expect(runtime.queryEvents({ session }).length).toBe(0);
+    expect(database.getIngestOffset(file)).toBe(0);
+  } finally {
+    database.db.run("DROP TRIGGER IF EXISTS fail_itx");
+  }
+
+  runtime.readSource(file);
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["itx-1"]);
+  expect(database.getIngestOffset(file)).toBe(Buffer.byteLength(`${event("itx-1", session, 1)}\n`));
+});
+
+test("runtime resets safely on truncation and same-path rotation; duplicate replay stays idempotent", () => {
+  const { dir, file } = source("rotate");
+  const session = "ingest-rotate";
+  writeFileSync(file, `${event("ir-1", session, 1, "first-long-record")}\n`);
+  runtime.addSource(file, { session_id: session });
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id)).toEqual(["ir-1"]);
+
+  // Truncate and rewrite the same inode between polls, growing it beyond the
+  // prior offset. The persisted checkpoint (not size alone) detects replacement.
+  truncateSync(file, 0);
+  writeFileSync(file, `${event("ir-2", session, 2, "x".repeat(500))}\n`);
+  runtime.readSource(file);
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id).sort()).toEqual(["ir-1", "ir-2"]);
+
+  // Rotate to a new inode at the same path. Replay one duplicate plus one fresh
+  // event: the identity reset reads both, while event_id uniqueness stores each
+  // logical event exactly once.
+  renameSync(file, join(dir, "hive-events.old.jsonl"));
+  writeFileSync(file, `${event("ir-2", session, 2, "x".repeat(500))}\n${event("ir-3", session, 3)}\n`);
+  runtime.readSource(file);
+  expect(runtime.queryEvents({ session }).map((row) => row.event_id).sort()).toEqual(["ir-1", "ir-2", "ir-3"]);
+});

--- a/tests/jsonl-reader.test.ts
+++ b/tests/jsonl-reader.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { appendFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { scanJsonlFile } from "../src/observability/server/jsonl-reader.ts";
+
+function tempFile(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), "pi-hive-jsonl-")), name);
+}
+
+function scan(file: string, offset: number, options: Parameters<typeof scanJsonlFile>[3] = {}) {
+  const lines: string[] = [];
+  const batches: Array<{ endOffset: number; oversizedLines: number }> = [];
+  const result = scanJsonlFile(file, offset, (batch) => {
+    lines.push(...batch.lines);
+    batches.push({ endOffset: batch.endOffset, oversizedLines: batch.oversizedLines });
+  }, options);
+  return { lines, batches, result };
+}
+
+test("JSONL reader preserves a UTF-8 event split at every byte boundary", () => {
+  const line = JSON.stringify({ event_id: "split", text: "héllo 🐝 漢字" });
+  const bytes = Buffer.from(`${line}\n`);
+
+  for (let split = 0; split <= bytes.length; split++) {
+    const file = tempFile(`split-${split}.jsonl`);
+    writeFileSync(file, bytes.subarray(0, split));
+    const first = scan(file, 0, { chunkBytes: 3 });
+    assert.deepEqual(first.lines, split === bytes.length ? [line] : [], `first scan at byte ${split}`);
+    assert.equal(first.result.committedOffset, split === bytes.length ? bytes.length : 0);
+    assert.equal(first.result.pendingTailBytes, split === bytes.length ? 0 : split);
+
+    appendFileSync(file, bytes.subarray(split));
+    const second = scan(file, first.result.committedOffset, { chunkBytes: 3 });
+    assert.deepEqual(
+      [...first.lines, ...second.lines],
+      [line],
+      `event split at byte ${split} must be emitted exactly once`,
+    );
+    assert.equal(second.result.committedOffset, bytes.length);
+    assert.equal(second.result.pendingTailBytes, 0);
+  }
+});
+
+test("JSONL reader commits complete records and leaves a multi-event partial tail pending across restart", () => {
+  const one = JSON.stringify({ event_id: "one" });
+  const two = JSON.stringify({ event_id: "two", text: "second" });
+  const three = JSON.stringify({ event_id: "three" });
+  const twoBytes = Buffer.from(two);
+  const cut = Math.floor(twoBytes.length / 2);
+  const file = tempFile("partial-tail.jsonl");
+  writeFileSync(file, Buffer.concat([Buffer.from(`${one}\n`), twoBytes.subarray(0, cut)]));
+
+  const first = scan(file, 0, { chunkBytes: 5 });
+  assert.deepEqual(first.lines, [one]);
+  assert.equal(first.result.committedOffset, Buffer.byteLength(`${one}\n`));
+  assert.equal(first.result.pendingTailBytes, cut);
+
+  // Simulate daemon restart: only the persisted complete-newline offset survives.
+  appendFileSync(file, Buffer.concat([twoBytes.subarray(cut), Buffer.from(`\n${three}`)]));
+  const restarted = scan(file, first.result.committedOffset, { chunkBytes: 4 });
+  assert.deepEqual(restarted.lines, [two]);
+  assert.equal(restarted.result.pendingTailBytes, Buffer.byteLength(three));
+
+  appendFileSync(file, "\n");
+  const final = scan(file, restarted.result.committedOffset, { chunkBytes: 2 });
+  assert.deepEqual(final.lines, [three]);
+  assert.equal(final.result.pendingTailBytes, 0);
+});
+
+test("JSONL reader handles large records across chunks and skips oversized complete records", () => {
+  const large = JSON.stringify({ event_id: "large", text: "x".repeat(256 * 1024) });
+  const good = JSON.stringify({ event_id: "after-oversized" });
+  const file = tempFile("large.jsonl");
+  writeFileSync(file, `${large}\n${good}\n`);
+
+  const accepted = scan(file, 0, { chunkBytes: 257, batchBytes: 4096, maxRecordBytes: 512 * 1024 });
+  assert.deepEqual(accepted.lines, [large, good]);
+  assert.equal(accepted.result.oversizedLines, 0);
+  assert.ok(accepted.result.maxBufferedBytes <= 512 * 1024 + 4096);
+
+  const bounded = scan(file, 0, { chunkBytes: 257, batchBytes: 4096, maxRecordBytes: 64 * 1024 });
+  assert.deepEqual(bounded.lines, [good]);
+  assert.equal(bounded.result.oversizedLines, 1);
+  assert.equal(bounded.result.committedOffset, Buffer.byteLength(`${large}\n${good}\n`));
+});
+
+test("JSONL reader bounds batch memory for a large log", () => {
+  const file = tempFile("many.jsonl");
+  const rows = Array.from({ length: 20_000 }, (_, i) => JSON.stringify({ event_id: `e-${i}`, text: "x".repeat(100) }));
+  writeFileSync(file, `${rows.join("\n")}\n`);
+  let seen = 0;
+  let largestBatch = 0;
+  const result = scanJsonlFile(file, 0, (batch) => {
+    seen += batch.lines.length;
+    largestBatch = Math.max(largestBatch, batch.lines.reduce((sum, line) => sum + Buffer.byteLength(line), 0));
+  }, { chunkBytes: 1024, batchBytes: 8192, maxRecordBytes: 1024 * 1024 });
+
+  assert.equal(seen, rows.length);
+  assert.equal(result.committedOffset, result.fileSize);
+  assert.ok(largestBatch < 10 * 1024, `largest batch was ${largestBatch} bytes`);
+  assert.ok(result.maxBufferedBytes < 10 * 1024, `reader buffered ${result.maxBufferedBytes} bytes`);
+});

--- a/tests/modes.test.ts
+++ b/tests/modes.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import { canonicalMode } from "../src/core/types.ts";
 import { loadConfig, teamForMode, allConfiguredAgents } from "../src/core/config.ts";
 import { auditAgentTypes } from "../src/core/agent-type-audit.ts";
-import { nextMode, modeLabel } from "../src/ui/tui/widget.ts";
+import { applyMode, nextMode, modeLabel } from "../src/ui/tui/widget.ts";
 
 // ── canonicalMode + cycle ────────────────────────────────────────────────────
 
@@ -28,6 +28,16 @@ test("modeLabel renders uppercase labels", () => {
   assert.equal(modeLabel("normal"), "NORMAL");
   assert.equal(modeLabel("plan"), "PLAN");
   assert.equal(modeLabel("hive"), "HIVE");
+});
+
+test("applyMode blocks switching to normal while a worker run is reserved", () => {
+  const notifications: string[] = [];
+  const state = { mode: "hive", activeRuns: 1, config: {}, runtimes: new Map() } as any;
+  const ctx = { hasUI: true, ui: { notify: (message: string) => notifications.push(message) } } as any;
+
+  assert.equal(applyMode(state, ctx, "normal"), false);
+  assert.equal(state.mode, "hive");
+  assert.match(notifications[0], /Cannot switch mode while 1 agent is running/);
 });
 
 // ── config: planning + hive blocks ──────────────────────────────────────────

--- a/tests/storage-b.spec.ts
+++ b/tests/storage-b.spec.ts
@@ -144,8 +144,15 @@ test("ingest offsets persist and resume (B4)", () => {
   expect(db.getIngestOffset("/tmp/does-not-exist.jsonl")).toBe(0);
   db.setIngestOffset("/tmp/log.jsonl", 4096, "s1", "2026-07-01T04:00:00.000Z");
   expect(db.getIngestOffset("/tmp/log.jsonl")).toBe(4096);
-  db.setIngestOffset("/tmp/log.jsonl", 8192, "s1", "2026-07-01T04:01:00.000Z");
+  db.setIngestOffset("/tmp/log.jsonl", 8192, "s1", "2026-07-01T04:01:00.000Z", { device: 12, inode: 34, checkpoint: "4:abcd" });
   expect(db.getIngestOffset("/tmp/log.jsonl")).toBe(8192);
+  expect(db.getIngestSource("/tmp/log.jsonl")).toEqual({
+    offset: 8192,
+    updatedAt: "2026-07-01T04:01:00.000Z",
+    device: 12,
+    inode: 34,
+    checkpoint: "4:abcd",
+  });
 });
 
 test("plan-table cwd is backfilled from the owning session (J2)", () => {


### PR DESCRIPTION
## Summary
- make delegated worker cleanup unconditional across setup, prompt, abort, and shutdown failures
- block mode transitions while workers are active and ignore stale dashboard startup completion
- track and serialize background mental-model distillers with shutdown-safe writes
- replace whole-file telemetry ingestion with bounded chunked JSONL scanning
- commit only complete-line offsets atomically with event inserts
- detect truncation, rewrites, and rotation while preserving partial UTF-8 tails
- expose ingestion corruption, pending-tail, lag, and last-success health metrics

## Testing
- `just verify`
- 192 Node tests passed
- 44 Bun tests passed
- dashboard dist freshness and package verification passed