### PR TITLE
fix: enforce strict hive configuration validation

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -133,7 +133,9 @@ This file declares **only**: the orchestrator, the agent tree (`name` / `color` 
 | `secret-paths` | Additional project-relative or absolute paths reserved from every worker | `[]` |
 | `distiller.enabled` | Run the mental-model distiller after each worker | `true` |
 | `distiller.model` | `provider/id` for distillation (required if enabled) | — |
-| `distiller.conversation-lines` | Tail of the session fed to the distiller | `200` |
+| `distiller.conversation-lines` | Tail of the session fed to the distiller (`1..10000`) | `200` |
+
+Numeric limits are strict positive integers: `subagent-output-limit` is capped at `1000000` and `max-parallel` at `64`. Quoted numbers, fractions, zero, negatives, `NaN`, infinity, and unknown keys are rejected during config load with a path-aware error.
 
 ### Template (copy, then edit to the confirmed tree)
 
@@ -219,8 +221,10 @@ hive:
 > **Both blocks are required.** `hive-config.yaml` must define *both* a `hive:` team block and a `planning:` team block — the loader hard-throws otherwise. There is no top-level `orchestrator:` / `agents:` shape: keeping the two hierarchies explicit is deliberate so a project cannot silently run plan mode against its coding tree.
 
 Rules:
-- Every `name` must be **unique** across the whole tree (case-insensitive). Duplicates are dropped. Names are shared across both blocks' namespace — do not reuse a name between `planning:` and `hive:` unless it is deliberately the same agent.
-- `path` is repo-relative and must point at an existing `.md` you create in §6–§7.
+- Every name/slug must be **unique across both team trees** (case-insensitive). Duplicates hard-fail; planning and hive do not have separate namespaces.
+- `path` is project-relative and must point at an existing regular `.md` file you create in §6–§7. Context, skill, and domain paths are project-relative by default too. An intentional external path must set `allow-outside-project: true` on that agent/ref/scope; use this sparingly because it expands the worker trust boundary.
+- The config is capped at 512 KiB, 128 configured agents, tree depth 8, 256 context/skill refs, and 2 MiB of configured prompt/context source bytes.
+- Unknown top-level, settings, team, agent, ref, domain, and nested distiller keys hard-fail with their full path.
 - `color` is `#rrggbb` (used in the tree widget and inline labels). Give each agent a distinct color.
 
 YAML subset supported by pi-hive:

--- a/src/agents/tools.ts
+++ b/src/agents/tools.ts
@@ -45,6 +45,11 @@ function boundedToolRender(lines: string[] | (() => string[]), ellipsis: string)
   };
 }
 
+function boundedPositiveInteger(value: unknown, fallback: number, max: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.min(max, Math.floor(number)) : fallback;
+}
+
 function formatTokens(count: number): string {
   if (!Number.isFinite(count) || count < 0) return "?";
   if (count < 1000) return Math.round(count).toString();
@@ -109,7 +114,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
     }),
     async execute(_toolCallId: string, params: unknown) {
       const { task, limit } = params as { task: string; limit?: number };
-      const recommendations = routeAgents(state, task, Math.max(1, Math.min(10, Number(limit || 5))));
+      const recommendations = routeAgents(state, task, boundedPositiveInteger(limit, 5, 10));
       const text = recommendations.length
         ? recommendations.map((entry, index) => `${index + 1}. ${entry.slug} — ${entry.name}${entry.group ? ` (${entry.group})` : ""} — score ${entry.score}${entry.reasons.length ? ` — ${entry.reasons.join(", ")}` : ""}`).join("\n")
         : "No strong route found. Delegate to the team lead whose consultWhen best matches, or ask the user to clarify scope.";
@@ -229,7 +234,7 @@ export function buildHiveTools(state: HiveState, callerName: string): ToolDefini
     }),
     async execute(_toolCallId: string, params: unknown) {
       if (!state.session) return { content: [{ type: "text", text: "hive session not initialized" }], details: { ok: false } };
-      const lines = Math.max(1, Math.min(1000, Number((params as any).lines || 80)));
+      const lines = boundedPositiveInteger((params as any).lines, 80, 1000);
       const agentName = String((params as any).agent || "").trim();
       // Scoped-only: an empty agent (including a lines-only call) is rejected.
       // Reading the shared log dumped its entire interleaved tail — individual

--- a/src/core/config-validation.ts
+++ b/src/core/config-validation.ts
@@ -1,0 +1,203 @@
+import { lstatSync, statSync } from "node:fs";
+import * as path from "node:path";
+import { hasForeignAbsoluteSyntax, resolveCanonicalPath, resolveProjectPath } from "./safe-path";
+import { slug } from "./format";
+
+export const CONFIG_LIMITS = {
+  configBytes: 512 * 1024,
+  agents: 128,
+  treeDepth: 8,
+  contextRefs: 256,
+  injectedContextBytes: 2 * 1024 * 1024,
+  subagentOutputLimit: 1_000_000,
+  maxParallel: 64,
+  conversationLines: 10_000,
+} as const;
+
+function object(value: unknown, label: string): asserts value is Record<string, any> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+}
+
+function keys(value: Record<string, any>, allowed: readonly string[], label: string): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) throw new Error(`${label}.${key} is not a recognized configuration key.`);
+  }
+}
+
+function string(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string.`);
+}
+
+function optionalBoolean(value: unknown, label: string): void {
+  if (value !== undefined && typeof value !== "boolean") throw new Error(`${label} must be true or false when provided.`);
+}
+
+function positiveInteger(value: unknown, label: string, max: number): void {
+  if (value === undefined) return;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0 || value > max) {
+    throw new Error(`${label} must be a positive integer between 1 and ${max}.`);
+  }
+}
+
+function stringList(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${label} must be a list of strings.`);
+  value.forEach((entry, index) => string(entry, `${label}[${index}]`));
+}
+
+function configuredPath(cwd: string, value: string, label: string, allowOutside: boolean, options: { mustExistMarkdown?: boolean; allowMissing?: boolean } = {}): string | undefined {
+  if (hasForeignAbsoluteSyntax(value)) throw new Error(`${label} uses absolute path syntax for another platform: ${value}`);
+  if (!allowOutside && path.isAbsolute(value)) throw new Error(`${label} must be project-relative; absolute paths require allow-outside-project: true.`);
+  const lexical = path.isAbsolute(value) ? value : path.resolve(cwd, value);
+  const relative = path.relative(cwd, lexical);
+  if (!allowOutside && (relative === ".." || relative.startsWith(`..${path.sep}`))) {
+    throw new Error(`${label} must stay inside the project; outside paths require allow-outside-project: true.`);
+  }
+  const resolved = allowOutside
+    ? resolveCanonicalPath(lexical, { allowMissing: options.allowMissing })
+    : resolveProjectPath(cwd, value, { allowMissing: options.allowMissing });
+  if (!resolved) throw new Error(`${label} is missing, unreadable, or escapes its allowed root: ${value}`);
+  if (options.mustExistMarkdown) {
+    if (!/\.md$/i.test(value)) throw new Error(`${label} must reference a Markdown (.md) file.`);
+    let stat;
+    try { stat = lstatSync(resolved.canonicalPath); } catch { throw new Error(`${label} must exist: ${value}`); }
+    if (!stat.isFile()) throw new Error(`${label} must be a regular Markdown file: ${value}`);
+  }
+  return resolved.exists ? resolved.canonicalPath : undefined;
+}
+
+const REF_KEYS = ["path", "useWhen", "updatable", "allowOutsideProject"] as const;
+const DOMAIN_KEYS = ["path", "read", "upsert", "delete", "include", "exclude", "description", "allowOutsideProject"] as const;
+const AGENT_KEYS = [
+  "name", "slug", "path", "color", "model", "tools", "thinking", "consultWhen",
+  "routingTags", "responsibilities", "context", "skills", "domain", "members", "children",
+  "allowedAgents", "agentType", "stages", "network", "commit", "allowOutsideProject",
+] as const;
+
+interface ValidationTotals {
+  agents: number;
+  refs: number;
+  injectedBytes: number;
+  seen: Map<string, string>;
+}
+
+function addFileBytes(file: string | undefined, totals: ValidationTotals): void {
+  if (!file) return;
+  try { totals.injectedBytes += statSync(file).size; } catch { /* optional refs may not exist */ }
+}
+
+function refs(cwd: string, value: unknown, label: string, totals: ValidationTotals): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${label} must be a list.`);
+  for (let index = 0; index < value.length; index++) {
+    const entry = value[index];
+    object(entry, `${label}[${index}]`);
+    keys(entry, REF_KEYS, `${label}[${index}]`);
+    string(entry.path, `${label}[${index}].path`);
+    if (entry.useWhen !== undefined) string(entry.useWhen, `${label}[${index}].useWhen`);
+    optionalBoolean(entry.updatable, `${label}[${index}].updatable`);
+    optionalBoolean(entry.allowOutsideProject, `${label}[${index}].allowOutsideProject`);
+    const resolved = configuredPath(cwd, entry.path, `${label}[${index}].path`, entry.allowOutsideProject === true, { allowMissing: true });
+    addFileBytes(resolved, totals);
+    totals.refs++;
+    if (totals.refs > CONFIG_LIMITS.contextRefs) throw new Error(`Configured context/skill refs exceed the limit of ${CONFIG_LIMITS.contextRefs}.`);
+  }
+}
+
+function domains(cwd: string, value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${label} must be a list.`);
+  value.forEach((entry, index) => {
+    object(entry, `${label}[${index}]`);
+    keys(entry, DOMAIN_KEYS, `${label}[${index}]`);
+    string(entry.path, `${label}[${index}].path`);
+    optionalBoolean(entry.allowOutsideProject, `${label}[${index}].allowOutsideProject`);
+    configuredPath(cwd, entry.path, `${label}[${index}].path`, entry.allowOutsideProject === true, { allowMissing: true });
+  });
+}
+
+function agent(cwd: string, value: unknown, label: string, depth: number, totals: ValidationTotals): void {
+  object(value, label);
+  keys(value, AGENT_KEYS, label);
+  if (depth > CONFIG_LIMITS.treeDepth) throw new Error(`${label} exceeds the maximum agent tree depth of ${CONFIG_LIMITS.treeDepth}.`);
+  totals.agents++;
+  if (totals.agents > CONFIG_LIMITS.agents) throw new Error(`Configured agents exceed the limit of ${CONFIG_LIMITS.agents}.`);
+  string(value.name, `${label}.name`);
+  string(value.path, `${label}.path`);
+  optionalBoolean(value.allowOutsideProject, `${label}.allowOutsideProject`);
+  const prompt = configuredPath(cwd, value.path, `${label}.path`, value.allowOutsideProject === true, { mustExistMarkdown: true });
+  addFileBytes(prompt, totals);
+  const key = slug(String(value.slug || value.name));
+  const prior = totals.seen.get(key);
+  if (prior) throw new Error(`Duplicate agent slug "${key}" at ${label}; already used at ${prior}.`);
+  totals.seen.set(key, label);
+  stringList(value.routingTags, `${label}.routingTags`);
+  stringList(value.responsibilities, `${label}.responsibilities`);
+  refs(cwd, value.context, `${label}.context`, totals);
+  refs(cwd, value.skills, `${label}.skills`, totals);
+  domains(cwd, value.domain, `${label}.domain`);
+  for (const childKey of ["members", "children"] as const) {
+    const children = value[childKey];
+    if (children === undefined) continue;
+    if (!Array.isArray(children)) throw new Error(`${label}.${childKey} must be a list.`);
+    children.forEach((child, index) => agent(cwd, child, `${label}.${childKey}[${index}]`, depth + 1, totals));
+  }
+}
+
+function team(cwd: string, value: unknown, label: string, totals: ValidationTotals): void {
+  object(value, label);
+  keys(value, ["main", "orchestrator", "agents"], label);
+  if (value.main && value.orchestrator) throw new Error(`${label} must not define both main and orchestrator.`);
+  const main = value.main || value.orchestrator;
+  if (!main) throw new Error(`${label}.main is required.`);
+  agent(cwd, main, `${label}.main`, 1, totals);
+  if (value.agents !== undefined && !Array.isArray(value.agents)) throw new Error(`${label}.agents must be a list.`);
+  (value.agents || []).forEach((entry: unknown, index: number) => agent(cwd, entry, `${label}.agents[${index}]`, 1, totals));
+}
+
+export function validateConfigSize(raw: string): void {
+  if (Buffer.byteLength(raw) > CONFIG_LIMITS.configBytes) throw new Error(`hive-config.yaml exceeds the ${CONFIG_LIMITS.configBytes}-byte size limit.`);
+}
+
+export function validateRawConfig(cwd: string, raw: string, parsed: unknown): void {
+  validateConfigSize(raw);
+  object(parsed, "hive-config.yaml");
+  keys(parsed, ["settings", "sharedContext", "shared_context", "planning", "hive", "orchestrator", "agents"], "hive-config.yaml");
+  if (parsed.sharedContext !== undefined && parsed.shared_context !== undefined) throw new Error("Define only one of shared-context or shared_context.");
+
+  const settings = parsed.settings;
+  if (settings !== undefined) {
+    object(settings, "settings");
+    keys(settings, ["subagentOutputLimit", "defaultTools", "maxParallel", "secretPaths", "distiller"], "settings");
+    positiveInteger(settings.subagentOutputLimit, "settings.subagentOutputLimit", CONFIG_LIMITS.subagentOutputLimit);
+    positiveInteger(settings.maxParallel, "settings.maxParallel", CONFIG_LIMITS.maxParallel);
+    if (settings.defaultTools !== undefined) string(settings.defaultTools, "settings.defaultTools");
+    stringList(settings.secretPaths, "settings.secretPaths");
+    if (settings.distiller !== undefined) {
+      object(settings.distiller, "settings.distiller");
+      keys(settings.distiller, ["enabled", "model", "conversationLines"], "settings.distiller");
+      optionalBoolean(settings.distiller.enabled, "settings.distiller.enabled");
+      if (settings.distiller.model !== undefined) string(settings.distiller.model, "settings.distiller.model");
+      positiveInteger(settings.distiller.conversationLines, "settings.distiller.conversationLines", CONFIG_LIMITS.conversationLines);
+    }
+  }
+
+  const totals: ValidationTotals = { agents: 0, refs: 0, injectedBytes: 0, seen: new Map() };
+  if (parsed.planning !== undefined) team(cwd, parsed.planning, "planning", totals);
+  if (parsed.hive !== undefined) team(cwd, parsed.hive, "hive", totals);
+
+  const shared = parsed.shared_context ?? parsed.sharedContext;
+  if (shared !== undefined) {
+    if (!Array.isArray(shared)) throw new Error("shared_context must be a list of strings.");
+    shared.forEach((entry: unknown, index: number) => {
+      if (typeof entry !== "string") throw new Error(`shared_context[${index}] must be a string; got ${Array.isArray(entry) ? "array" : typeof entry}.`);
+      if (!entry.trim()) throw new Error(`shared_context[${index}] must be a non-empty string.`);
+      const looksLikePath = /[\\/]|\.[A-Za-z0-9]+$/.test(entry) && !/\s/.test(entry);
+      if (looksLikePath) addFileBytes(configuredPath(cwd, entry, `shared_context[${index}]`, false, { allowMissing: true }), totals);
+      else totals.injectedBytes += Buffer.byteLength(entry);
+    });
+  }
+  if (totals.injectedBytes > CONFIG_LIMITS.injectedContextBytes) {
+    throw new Error(`Configured prompt/context content is ${totals.injectedBytes} bytes; limit is ${CONFIG_LIMITS.injectedContextBytes} bytes.`);
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,11 @@
+import { statSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentConfig, HiveConfig, HiveMode, HiveTeam } from "./types";
 import { parseYamlLite, parseFrontmatter } from "./yaml";
 import { agentSlug, configuredChildAgents, flatAgentConfig, normalizeAgentType, normalizeCommit, normalizePlanStages, safeRead, slug } from "./utils";
 import { validateAgentTypes, validateHiveConfigShape } from "./schema";
-import { resolveProjectPath } from "./safe-path";
+import { CONFIG_LIMITS, validateConfigSize, validateRawConfig } from "./config-validation";
+import { resolveConfiguredPath, resolveProjectPath } from "./safe-path";
 
 // Read an agent's .md frontmatter and copy model/thinking onto the config node
 // when the config itself does not set them. The config tree (from hive-config.
@@ -89,7 +91,7 @@ function enrichFromFrontmatter(cwd: string, agent: AgentConfig | undefined): voi
   // onto the config node whenever the node itself does not already set them.
   const needsEnrich = !agent.slug || !agent.model || !agent.thinking || agent.agentType === undefined || agent.stages === undefined || agent.network === undefined || agent.commit === undefined;
   if (agent.path && needsEnrich) {
-    const promptPath = resolveProjectPath(cwd, agent.path);
+    const promptPath = resolveConfiguredPath(cwd, agent.path, agent.allowOutsideProject === true);
     const raw = promptPath ? safeRead(promptPath.canonicalPath) : "";
     if (raw) {
       const { attrs } = parseFrontmatter(raw);
@@ -135,9 +137,17 @@ function enrichTeam(cwd: string, team: HiveTeam | undefined): void {
 export function loadConfig(cwd: string): HiveConfig {
   const configPath = join(cwd, ".pi", "hive", "hive-config.yaml");
   const safeConfigPath = resolveProjectPath(cwd, configPath);
+  if (safeConfigPath) {
+    const size = statSync(safeConfigPath.canonicalPath).size;
+    if (size > CONFIG_LIMITS.configBytes) throw new Error(`hive-config.yaml exceeds the ${CONFIG_LIMITS.configBytes}-byte size limit.`);
+  }
   const raw = safeConfigPath ? safeRead(safeConfigPath.canonicalPath) : "";
   if (!raw) throw new Error(`Missing config: ${configPath}`);
+  validateConfigSize(raw);
   const parsed = parseYamlLite(raw) as any;
+  // Validate the complete user-authored shape before defaults or frontmatter
+  // enrichment can erase invalid values or make malformed input look valid.
+  validateRawConfig(cwd, raw, parsed);
 
   // H1 (Decision 7): allowedAgents is no longer a user config field — the
   // delegation hierarchy is derived from members/children. A user-set value was
@@ -184,14 +194,14 @@ export function loadConfig(cwd: string): HiveConfig {
     // camelizing snake_case parser-wide (plan-store reads `session_id` raw).
     sharedContext: normalizeSharedContext(parsed.shared_context ?? parsed.sharedContext),
     settings: {
-      subagentOutputLimit: Number(settings.subagentOutputLimit || 12_000),
-      defaultTools: String(settings.defaultTools || "read, grep, find, ls"),
-      maxParallel: Number(settings.maxParallel || 3),
+      subagentOutputLimit: settings.subagentOutputLimit ?? 12_000,
+      defaultTools: settings.defaultTools ?? "read, grep, find, ls",
+      maxParallel: settings.maxParallel ?? 3,
       secretPaths: Array.isArray(settings.secretPaths) ? settings.secretPaths.map((entry: unknown) => String(entry).trim()).filter(Boolean) : [],
       distiller: {
         enabled: distillerEnabled,
         model: distillerModel,
-        conversationLines: Number(distiller.conversationLines || 200),
+        conversationLines: distiller.conversationLines ?? 200,
       },
     },
   };

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -55,10 +55,15 @@ export function textOfResult(result: any): string {
   return safeJson(result);
 }
 
+function safeLimit(value: number, fallback: number, ceiling = 1_000_000): number {
+  return Number.isFinite(value) && value > 0 ? Math.min(ceiling, Math.floor(value)) : fallback;
+}
+
 export function truncateMiddle(text: string, max: number): string {
-  if (text.length <= max) return text;
-  const head = Math.floor(max * 0.65);
-  const tail = Math.max(0, max - head - 32);
+  const limit = safeLimit(max, 12_000);
+  if (text.length <= limit) return text;
+  const head = Math.floor(limit * 0.65);
+  const tail = Math.max(0, limit - head - 32);
   return `${text.slice(0, head)}\n\n... [truncated] ...\n\n${text.slice(text.length - tail)}`;
 }
 
@@ -72,8 +77,9 @@ export function boundedDiagnostics(
 ): Array<{ type?: string; message?: string }> | undefined {
   if (!Array.isArray(diagnostics) || !diagnostics.length) return undefined;
   const out: Array<{ type?: string; message?: string }> = [];
+  const limit = safeLimit(max, 20, 100);
   for (const d of diagnostics) {
-    if (out.length >= max) break;
+    if (out.length >= limit) break;
     const type = (d as any)?.type ? String((d as any).type) : undefined;
     const message = (d as any)?.error?.message ? truncateMiddle(String((d as any).error.message), 300) : undefined;
     if (!type && !message) continue;
@@ -89,13 +95,15 @@ export function boundedDiagnostics(
 // stamp a machine-readable `truncated` flag on the telemetry payload (J6) rather
 // than having downstream code re-infer truncation from a length threshold.
 export function clip(text: string, max: number): { text: string; truncated: boolean } {
-  if (text.length <= max) return { text, truncated: false };
-  return { text: text.slice(0, max), truncated: true };
+  const limit = safeLimit(max, 8_000);
+  if (text.length <= limit) return { text, truncated: false };
+  return { text: text.slice(0, limit), truncated: true };
 }
 
 export function tailLines(text: string, limit: number): string {
   const lines = text.split("\n").filter(Boolean);
-  return lines.slice(Math.max(0, lines.length - limit)).join("\n");
+  const count = safeLimit(limit, 80, 10_000);
+  return lines.slice(Math.max(0, lines.length - count)).join("\n");
 }
 
 export function extractFinalAnswer(text: string): string | null {

--- a/src/core/fs.ts
+++ b/src/core/fs.ts
@@ -14,8 +14,9 @@ export function safeRead(path: string): string {
 
 export function readIfSmall(path: string, maxBytes = 64_000): string {
   try {
+    const limit = Number.isFinite(maxBytes) && maxBytes > 0 ? Math.min(2 * 1024 * 1024, Math.floor(maxBytes)) : 64_000;
     const stat = statSync(path);
-    if (!stat.isFile() || stat.size > maxBytes) return "";
+    if (!stat.isFile() || stat.size > limit) return "";
     return readFileSync(path, "utf-8");
   } catch {
     return "";

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -63,6 +63,7 @@ export function normalizeKnowledgeRefs(value: any): KnowledgeRef[] {
       path: String(entry.path),
       useWhen: entry.useWhen ? String(entry.useWhen) : undefined,
       updatable: Boolean(entry.updatable),
+      allowOutsideProject: entry.allowOutsideProject === true,
     }));
 }
 
@@ -96,6 +97,7 @@ export function normalizeDomainScopes(value: any, label = "domain"): DomainScope
         include: optionalPatternList(entry.include, `${entryLabel}.include`),
         exclude: optionalPatternList(entry.exclude, `${entryLabel}.exclude`),
         description: entry.description ? String(entry.description) : undefined,
+        allowOutsideProject: entry.allowOutsideProject === true,
       };
     });
 }

--- a/src/core/prompting.ts
+++ b/src/core/prompting.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { DomainScope, HiveState, KnowledgeRef } from "./types";
 import { readIfSmall } from "./utils";
-import { resolveProjectPath } from "./safe-path";
+import { resolveConfiguredPath, resolveProjectPath } from "./safe-path";
 
 export function buildSharedContext(state: HiveState, ctx: ExtensionContext): string {
   if (!state.config) return "";
@@ -25,7 +25,7 @@ export function buildSharedContext(state: HiveState, ctx: ExtensionContext): str
 export function renderKnowledgeRefs(ctx: ExtensionContext, title: string, refs: KnowledgeRef[] | undefined): string {
   if (!refs?.length) return `## ${title}\nNo configured ${title.toLowerCase()}.`;
   const blocks = refs.map((ref) => {
-    const safePath = resolveProjectPath(ctx.cwd, ref.path);
+    const safePath = resolveConfiguredPath(ctx.cwd, ref.path, ref.allowOutsideProject === true);
     const content = safePath ? readIfSmall(safePath.canonicalPath, 96_000) : "";
     const body = content || `[not readable: ${ref.path}]`;
     const meta = [

--- a/src/core/safe-path.ts
+++ b/src/core/safe-path.ts
@@ -89,6 +89,13 @@ export function resolveContainedPath(root: string, candidate: string, options: C
   return canonicalCandidate;
 }
 
+export function resolveConfiguredPath(projectRoot: string, requestedPath: string, allowOutsideProject = false, options: ContainedPathOptions = {}): ContainedPath | null {
+  if (!requestedPath || hasForeignAbsoluteSyntax(requestedPath)) return null;
+  if (!allowOutsideProject) return resolveProjectPath(projectRoot, requestedPath, options);
+  const candidate = path.isAbsolute(requestedPath) ? requestedPath : path.resolve(projectRoot, requestedPath);
+  return resolveCanonicalPath(candidate, options);
+}
+
 export function resolveProjectPath(projectRoot: string, requestedPath: string, options: ContainedPathOptions = {}): ContainedPath | null {
   if (!requestedPath || hasForeignAbsoluteSyntax(requestedPath)) return null;
   const candidate = path.isAbsolute(requestedPath) ? requestedPath : path.resolve(projectRoot, requestedPath);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -36,6 +36,7 @@ export interface KnowledgeRef {
   path: string;
   useWhen?: string;
   updatable?: boolean;
+  allowOutsideProject?: boolean;
 }
 
 // A reviewer's structured verdict on a change. green = clean approval; yellow =
@@ -84,6 +85,7 @@ export interface DomainScope {
   include?: string[];
   exclude?: string[];
   description?: string;
+  allowOutsideProject?: boolean;
 }
 
 export interface AgentConfig {
@@ -93,6 +95,7 @@ export interface AgentConfig {
   slug?: string;
   name: string;
   path: string;
+  allowOutsideProject?: boolean;
   color?: string;
   model?: string;
   tools?: string;

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -2,8 +2,8 @@ import { withFileMutationQueue, type ExtensionContext } from "@earendil-works/pi
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { spawnManaged } from "./process";
 import { copyFileSync, existsSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
-import { HIVE_AGENTS_DIR, TYPE_SCOPED_TOOL_NAMES } from "../core/constants";
+import { basename, dirname, join } from "node:path";
+import { TYPE_SCOPED_TOOL_NAMES } from "../core/constants";
 import { normalizeMentalModelSpine } from "../core/mental-model";
 import type { AgentRuntime, HiveState } from "../core/types";
 import {
@@ -31,7 +31,7 @@ import { normalizeWorkerSkillPaths, workerResourceLoader } from "./worker-extens
 import { approvalRecordPath, isExecutionGateOpen, isAwaitingHumanApproval, setAgentReviewVerdict, type AgentReviewVerdict, type ArtifactId } from "./openspec";
 import { agentRoster, resolveRuntime } from "./agent-lookup";
 import { addHiveActivity } from "../ui/tui/activity";
-import { resolveContainedPath, resolveProjectPath } from "../core/safe-path";
+import { resolveConfiguredPath } from "../core/safe-path";
 
 // Dashboard activity should show reviewer/worker conclusions without confusing
 // middle elision in normal cases. Keep a high hard cap to avoid unbounded shared
@@ -136,8 +136,10 @@ class WorkerRunLifecycle {
 }
 
 export function resolveWorkerSkillPaths(cwd: string, refs: unknown[] = []): string[] {
-  return normalizeWorkerSkillPaths(refs).flatMap((skillPath) => {
-    const safe = resolveProjectPath(cwd, skillPath);
+  return normalizeWorkerSkillPaths(refs).flatMap((skillPath, index) => {
+    const raw = refs[index] as any;
+    const allowOutside = raw?.allowOutsideProject === true || raw?.path?.allowOutsideProject === true;
+    const safe = resolveConfiguredPath(cwd, skillPath, allowOutside);
     return safe ? [safe.canonicalPath] : [];
   });
 }
@@ -824,10 +826,9 @@ export async function distillMentalModel(state: HiveState, ctx: ExtensionContext
   const target = agentMentalModelTarget(runtime);
   if (!target) return;
 
-  // Write guard: the mental-model file must live under the agents/ root.
-  const agentsRoot = resolve(ctx.cwd, HIVE_AGENTS_DIR);
-  if (!resolveProjectPath(ctx.cwd, HIVE_AGENTS_DIR, { allowMissing: true })) return;
-  const safeTarget = resolveContainedPath(agentsRoot, resolve(ctx.cwd, target.path), { allowMissing: true });
+  // Config validation already requires an explicit opt-in for targets outside
+  // the project. Re-apply that rule at the write site before queueing mutation.
+  const safeTarget = resolveConfiguredPath(ctx.cwd, target.path, target.allowOutsideProject === true, { allowMissing: true });
   if (!safeTarget) return;
   const targetPath = safeTarget.canonicalPath;
 

--- a/src/engine/doctor.ts
+++ b/src/engine/doctor.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { HiveState } from "../core/types";
 import { HIVE_ROOT } from "../core/constants";
 import { auditAgentTypes } from "../core/agent-type-audit";
+import { loadConfig } from "../core/config";
 import { hiveTelemetryRegistryPath } from "./observability";
 
 export type DoctorSeverity = "info" | "warning";
@@ -33,11 +34,15 @@ export function renderHiveDoctor(state: HiveState, cwd: string, extensionDir: st
   const observabilityServer = join(extensionDir, "src", "observability", "server", "index.ts");
   const registryPath = hiveTelemetryRegistryPath();
   const bunVersion = commandVersion("bun", ["--version"]);
+  let configError: string | undefined;
+  if (existsSync(configPath) && !state.config) {
+    try { loadConfig(cwd); } catch (error: any) { configError = error?.message || String(error); }
+  }
 
   const lines = [
     "pi-hive doctor",
     checkLine(existsSync(configPath), `Opt-in config ${existsSync(configPath) ? "present" : "missing"}: ${configPath}`),
-    checkLine(Boolean(state.config), `Hive config ${state.config ? "loaded" : "not loaded"}`),
+    checkLine(Boolean(state.config) || !configError, configError ? `Hive config invalid: ${configError}` : `Hive config ${state.config ? "loaded and valid" : "valid but not initialized"}`),
     checkLine(state.runtimes.size > 0, `Agent runtimes ${state.runtimes.size ? `${state.runtimes.size} loaded` : "not initialized"}`),
     checkLine(Boolean(state.session), `Session ${state.session ? state.session.sessionId : "not initialized"}`, true),
     checkLine(existsSync(observabilityServer), `Telemetry server ${existsSync(observabilityServer) ? "present" : "missing"}: ${observabilityServer}`),
@@ -62,6 +67,7 @@ export function renderHiveDoctor(state: HiveState, cwd: string, extensionDir: st
   }
 
   if (!existsSync(configPath)) lines.push(`remedy: create ${HIVE_ROOT}/hive-config.yaml to activate pi-hive in this project`);
+  if (configError) lines.push("remedy: fix the path-aware hive-config.yaml validation error, then restart pi");
   if (audit.offenders.length) lines.push("remedy: add the suggested 'agent-type:' to each agent's frontmatter, then restart pi (validation hard-fails without it)");
   if (!bunVersion) lines.push("remedy: install Bun or avoid /hive-observe dashboard commands");
   if (!existsSync(dashboardIndex) || !existsSync(dashboardStamp)) lines.push("remedy: run just dashboard-build before packaging");

--- a/src/engine/domain.ts
+++ b/src/engine/domain.ts
@@ -7,7 +7,7 @@ import { agentMatches } from "../core/utils";
 import { globToRegExp, globSpecificity, toPosixPath } from "./glob";
 import { classify } from "./file-class";
 import { checkPlannerStages, checkTypePolicy, type PolicyAction, type PolicyDecision } from "./policy";
-import { hasForeignAbsoluteSyntax, isPathInside, resolveContainedPath, resolveProjectPath } from "../core/safe-path";
+import { hasForeignAbsoluteSyntax, isPathInside, resolveConfiguredPath, resolveContainedPath } from "../core/safe-path";
 import { checkReservedPath, type ReservedPathAccess } from "./reserved-paths";
 
 function runtimeForCaller(state: HiveState, callerName: string): AgentRuntime | undefined {
@@ -51,8 +51,9 @@ function excludedBy(scope: DomainScope, relativePath: string): boolean {
 }
 
 function domainScopeMatch(ctx: ExtensionContext, scope: DomainScope, target: string, allowMissing: boolean): { matches: boolean; specificity: number } {
-  const scopePath = resolve(ctx.cwd, scope.path);
-  if (!resolveProjectPath(ctx.cwd, scope.path, { allowMissing: true })) return { matches: false, specificity: 0 };
+  const resolvedScope = resolveConfiguredPath(ctx.cwd, scope.path, scope.allowOutsideProject === true, { allowMissing: true });
+  if (!resolvedScope) return { matches: false, specificity: 0 };
+  const scopePath = resolvedScope.canonicalPath;
   const contained = resolveContainedPath(scopePath, target, { allowMissing });
   if (!contained) return { matches: false, specificity: 0 };
   const relativePath = toPosixPath(relative(scopePath, contained.lexicalPath) || ".");

--- a/src/engine/routing.ts
+++ b/src/engine/routing.ts
@@ -4,6 +4,7 @@ import { currentAgentName } from "./session";
 import { canDelegateTo } from "./domain";
 
 export function routeAgents(state: HiveState, task: string, limit = 5): Array<{ slug: string; name: string; group: string; score: number; reasons: string[] }> {
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(100, Math.floor(limit)) : 5;
   const terms = task.toLowerCase().split(/[^a-z0-9_-]+/).filter((term) => term.length > 2);
   const caller = currentAgentName();
   const scored = Array.from(state.runtimes.values())
@@ -72,5 +73,5 @@ export function routeAgents(state: HiveState, task: string, limit = 5): Array<{ 
     .filter((entry) => entry.score > 0)
     .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
 
-  return scored.slice(0, limit);
+  return scored.slice(0, safeLimit);
 }

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -20,7 +20,7 @@ import {
 import { allConfiguredAgents, loadConfig, teamForMode } from "../core/config";
 import { canonicalMode } from "../core/types";
 import { runtimeKey } from "./agent-lookup";
-import { resolveProjectPath } from "../core/safe-path";
+import { resolveConfiguredPath } from "../core/safe-path";
 
 export function restoreOrCreateSession(state: HiveState, ctx: ExtensionContext, _cfg: HiveConfig): SessionState {
   const existing = ctx.sessionManager
@@ -49,7 +49,7 @@ export function restoreOrCreateSession(state: HiveState, ctx: ExtensionContext, 
 }
 
 export function loadAgentRuntime(state: HiveState, ctx: ExtensionContext, cfg: HiveConfig, agent: AgentConfig): AgentRuntime {
-  const safePromptPath = resolveProjectPath(ctx.cwd, agent.path);
+  const safePromptPath = resolveConfiguredPath(ctx.cwd, agent.path, agent.allowOutsideProject === true);
   if (!safePromptPath) throw new Error(`Agent prompt is missing or escapes the project root: ${agent.path}`);
   const fullPath = safePromptPath.canonicalPath;
   const parsed = parseFrontmatter(safeRead(fullPath));
@@ -73,12 +73,12 @@ export function loadAgentRuntime(state: HiveState, ctx: ExtensionContext, cfg: H
   // targets it). No need to declare it in frontmatter.
   const explicitContext = normalizeKnowledgeRefs(attrs.context || (agent as any).context);
   const mentalModelPath = agent.path.replace(/\.md$/, "-mental-model.yaml");
-  const safeMentalModel = resolveProjectPath(ctx.cwd, mentalModelPath);
+  const safeMentalModel = resolveConfiguredPath(ctx.cwd, mentalModelPath, agent.allowOutsideProject === true);
   const alreadyListed = safeMentalModel
-    ? explicitContext.some((ref) => resolveProjectPath(ctx.cwd, ref.path)?.canonicalPath === safeMentalModel.canonicalPath)
+    ? explicitContext.some((ref) => resolveConfiguredPath(ctx.cwd, ref.path, ref.allowOutsideProject === true)?.canonicalPath === safeMentalModel.canonicalPath)
     : false;
   const context = safeMentalModel && !alreadyListed
-    ? [{ path: mentalModelPath, useWhen: "Your durable mental model for this role.", updatable: true }, ...explicitContext]
+    ? [{ path: mentalModelPath, useWhen: "Your durable mental model for this role.", updatable: true, allowOutsideProject: agent.allowOutsideProject === true }, ...explicitContext]
     : explicitContext;
   const mergedConfig: AgentConfig = {
     ...agent,

--- a/src/integration/hooks.ts
+++ b/src/integration/hooks.ts
@@ -13,7 +13,7 @@ import { resolveHiveSddStatus } from "../engine/sdd";
 import { ensureDashboard } from "../engine/dashboard";
 import { resolveRuntime } from "../engine/agent-lookup";
 import { emitHiveEvent, emitModelCatalog, writeHiveStateSnapshot } from "../engine/observability";
-import { resolveProjectPath } from "../core/safe-path";
+import { resolveConfiguredPath } from "../core/safe-path";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -385,7 +385,7 @@ ${catalog}`,
       }).catch(() => { /* best-effort; the dashboard is optional */ });
       const missingSkills = Array.from(state.runtimes.values()).flatMap((runtime) =>
         (runtime.config.skills || [])
-          .filter((ref) => !resolveProjectPath(ctx.cwd, ref.path))
+          .filter((ref) => !resolveConfiguredPath(ctx.cwd, ref.path, ref.allowOutsideProject === true))
           .map((ref) => `${runtime.config.name}: ${ref.path}`),
       );
       const missing = missingSkills.length ? `\nMissing configured skills: ${missingSkills.slice(0, 5).join(", ")}${missingSkills.length > 5 ? "..." : ""}` : "";

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -424,6 +424,128 @@ test("loadConfig rejects a non-boolean network capability", () => {
   assert.throws(() => loadConfig(cwd), /network must be true or false/);
 });
 
+test("loadConfig rejects unknown settings and nested keys with path-aware errors", () => {
+  const cwd = fixtureProject();
+  const file = join(cwd, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(file, readFileSync(file, "utf8").replace("  max-parallel: 2", "  max-parallel: 2\n  max-paralell: 3"));
+  assert.throws(() => loadConfig(cwd), /settings\.maxParalell is not a recognized configuration key/);
+
+  const cwd2 = fixtureProject();
+  const file2 = join(cwd2, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(file2, readFileSync(file2, "utf8").replace("    enabled: false", "    enabled: false\n    conversation-linez: 12"));
+  assert.throws(() => loadConfig(cwd2), /settings\.distiller\.conversationLinez is not a recognized configuration key/);
+
+  const cwd3 = fixtureProject();
+  const file3 = join(cwd3, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(file3, readFileSync(file3, "utf8").replace("      routing-tags: [frontend, react]", "      routing-tags: [frontend, react]\n      mystery-capability: true"));
+  assert.throws(() => loadConfig(cwd3), /hive\.agents\[0\]\.mysteryCapability is not a recognized configuration key/);
+});
+
+test("loadConfig validates raw bounded positive integers before defaults", () => {
+  for (const value of ["0", "-1", "1.5", "\"2\"", "NaN", "65"]) {
+    const cwd = fixtureProject();
+    const file = join(cwd, ".pi", "hive", "hive-config.yaml");
+    writeFileSync(file, readFileSync(file, "utf8").replace("max-parallel: 2", `max-parallel: ${value}`));
+    assert.throws(() => loadConfig(cwd), /settings\.maxParallel must be a positive integer between 1 and 64/, `value ${value}`);
+  }
+
+  const cwd = fixtureProject();
+  const file = join(cwd, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(file, readFileSync(file, "utf8").replace("  default-tools:", "  subagent-output-limit: -5\n  default-tools:"));
+  assert.throws(() => loadConfig(cwd), /settings\.subagentOutputLimit must be a positive integer/);
+});
+
+test("loadConfig requires regular Markdown prompt files", () => {
+  const missing = fixtureProject();
+  const missingFile = join(missing, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(missingFile, readFileSync(missingFile, "utf8").replace(".pi/hive/agents/frontend.md", ".pi/hive/agents/missing.md"));
+  assert.throws(() => loadConfig(missing), /hive\.agents\[0\]\.path.*missing|hive\.agents\[0\]\.path must exist/);
+
+  const directory = fixtureProject();
+  const directoryFile = join(directory, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(directoryFile, readFileSync(directoryFile, "utf8").replace(".pi/hive/agents/frontend.md", ".pi/hive/agents"));
+  assert.throws(() => loadConfig(directory), /hive\.agents\[0\]\.path must reference a Markdown/);
+});
+
+test("configured paths are project-relative unless explicitly opted outside", () => {
+  const cwd = fixtureProject();
+  const file = join(cwd, ".pi", "hive", "hive-config.yaml");
+  const absoluteInside = join(cwd, ".pi", "hive", "agents", "frontend.md");
+  writeFileSync(file, readFileSync(file, "utf8").replace(".pi/hive/agents/frontend.md", absoluteInside));
+  assert.throws(() => loadConfig(cwd), /hive\.agents\[0\]\.path must be project-relative/);
+
+  const outsideDir = mkdtempSync(join(tmpdir(), "pi-hive-outside-agent-"));
+  const outsidePrompt = join(outsideDir, "external.md");
+  writeFileSync(outsidePrompt, "---\nmodel: openai/gpt-5\nthinking: off\nagent-type: coder\n---\nExternal.");
+  const opted = fixtureProject();
+  const optedFile = join(opted, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(optedFile, readFileSync(optedFile, "utf8").replace(
+    "      path: .pi/hive/agents/frontend.md",
+    `      path: ${outsidePrompt}\n      allow-outside-project: true`,
+  ));
+  assert.equal(loadConfig(opted).agents[0].path, outsidePrompt);
+});
+
+test("context, skill, and domain paths require explicit outside-project opt-in", () => {
+  for (const block of [
+    "      context:\n        - path: ../outside-context.md",
+    "      skills:\n        - path: ../outside-skill.md",
+  ]) {
+    const cwd = fixtureProject();
+    const file = join(cwd, ".pi", "hive", "hive-config.yaml");
+    writeFileSync(file, readFileSync(file, "utf8").replace("      routing-tags: [frontend, react]", `      routing-tags: [frontend, react]\n${block}`));
+    assert.throws(() => loadConfig(cwd), /must stay inside the project; outside paths require allow-outside-project: true/, block);
+  }
+  const domain = fixtureProject();
+  const domainFile = join(domain, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(domainFile, readFileSync(domainFile, "utf8").replace("        - path: ui", "        - path: ../outside-domain"));
+  assert.throws(() => loadConfig(domain), /hive\.agents\[0\]\.domain\[0\]\.path must stay inside the project/);
+});
+
+test("loadConfig enforces global duplicate slugs, tree depth, config size, refs, and injected bytes", () => {
+  const duplicate = fixtureProject();
+  const duplicateFile = join(duplicate, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(duplicateFile, readFileSync(duplicateFile, "utf8").replace(
+    "  agents: []",
+    "  agents:\n    - name: Frontend Dev\n      path: .pi/hive/agents/frontend.md",
+  ));
+  assert.throws(() => loadConfig(duplicate), /Duplicate agent slug "frontend-dev".*hive\.agents\[0\].*planning\.agents\[0\]/);
+
+  const deep = fixtureProject();
+  const deepFile = join(deep, ".pi", "hive", "hive-config.yaml");
+  const deepMember = (level: number, indent: number): string => {
+    const pad = " ".repeat(indent);
+    const fields = `${pad}- name: Deep ${level}\n${pad}  path: .pi/hive/agents/frontend.md`;
+    return level >= 8 ? fields : `${fields}\n${pad}  members:\n${deepMember(level + 1, indent + 4)}`;
+  };
+  writeFileSync(deepFile, readFileSync(deepFile, "utf8").replace("      members:\n        - name: QA Engineer\n          path: .pi/hive/agents/qa.md\n          routing-tags: [test]", `      members:\n${deepMember(0, 8)}`));
+  assert.throws(() => loadConfig(deep), /maximum agent tree depth/);
+
+  const huge = fixtureProject();
+  const hugeFile = join(huge, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(hugeFile, `${readFileSync(hugeFile, "utf8")}\n# ${"x".repeat(512 * 1024)}\n`);
+  assert.throws(() => loadConfig(huge), /exceeds the 524288-byte size limit/);
+
+  const tooManyRefs = fixtureProject();
+  const refsFile = join(tooManyRefs, ".pi", "hive", "hive-config.yaml");
+  const refs = Array.from({ length: 257 }, (_, index) => `        - path: missing-${index}.md`).join("\n");
+  writeFileSync(refsFile, readFileSync(refsFile, "utf8").replace("      routing-tags: [frontend, react]", `      routing-tags: [frontend, react]\n      context:\n${refs}`));
+  assert.throws(() => loadConfig(tooManyRefs), /context\/skill refs exceed the limit of 256/);
+
+  const tooManyAgents = fixtureProject();
+  const agentsFile = join(tooManyAgents, ".pi", "hive", "hive-config.yaml");
+  const agents = Array.from({ length: 129 }, (_, index) => `    - name: Agent ${index}\n      path: .pi/hive/agents/frontend.md`).join("\n");
+  writeFileSync(agentsFile, readFileSync(agentsFile, "utf8").replace("  agents: []", `  agents:\n${agents}`));
+  assert.throws(() => loadConfig(tooManyAgents), /Configured agents exceed the limit of 128/);
+
+  const context = fixtureProject();
+  const largeContext = join(context, "large-context.md");
+  writeFileSync(largeContext, "x".repeat(2 * 1024 * 1024 + 1));
+  const contextFile = join(context, ".pi", "hive", "hive-config.yaml");
+  writeFileSync(contextFile, readFileSync(contextFile, "utf8").replace("      routing-tags: [frontend, react]", "      routing-tags: [frontend, react]\n      context:\n        - path: large-context.md"));
+  assert.throws(() => loadConfig(context), /Configured prompt\/context content .* limit is 2097152 bytes/);
+});
+
 test("inferAgentType applies name/report heuristics", () => {
   assert.equal(inferAgentType("Security Reviewer", false, false), "reviewer");
   assert.equal(inferAgentType("QA Tester", false, false), "tester");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -59,6 +59,19 @@ test("renderHiveDoctor flags agents missing agent-type with a suggestion", () =>
   assert.match(result.text, /remedy: add the suggested 'agent-type:'/);
 });
 
+test("renderHiveDoctor reports path-aware malformed configuration diagnostics", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-doctor-invalid-"));
+  const extensionDir = mkdtempSync(join(tmpdir(), "pi-hive-doctor-ext-"));
+  mkdirSync(join(cwd, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(cwd, ".pi", "hive", "hive-config.yaml"), "settings:\n  max-paralell: nope\n");
+
+  const result = renderHiveDoctor(state({ config: null, runtimes: new Map() }), cwd, extensionDir);
+
+  assert.equal(result.severity, "warning");
+  assert.match(result.text, /fail: Hive config invalid: settings\.maxParalell is not a recognized configuration key/);
+  assert.match(result.text, /remedy: fix the path-aware hive-config\.yaml validation error/);
+});
+
 test("renderHiveDoctor includes remedies for missing required assets", () => {
   const result = renderHiveDoctor(state({ config: null, runtimes: new Map(), session: null, sddStatus: null }), "/missing-cwd", "/missing-extension");
 

--- a/tests/domain-routing.test.ts
+++ b/tests/domain-routing.test.ts
@@ -145,6 +145,12 @@ test("routeAgents scores specialists and respects delegation hierarchy", () => {
   const matches = runAsAgent("Orchestrator", () => routeAgents(state, "fix the React CSS component", 3));
   assert.equal(matches[0].name, "Frontend Dev");
   assert.equal(matches.some((match) => match.name === "Security Reviewer"), false);
+
+  for (const unsafe of [Number.NaN, Number.POSITIVE_INFINITY, -5]) {
+    const bounded = runAsAgent("Orchestrator", () => routeAgents(state, "fix the React CSS component", unsafe));
+    assert.equal(bounded[0].name, "Frontend Dev");
+    assert.ok(bounded.length <= 5, `unsafe limit ${unsafe} must fall back to a bounded result`);
+  }
 });
 
 test("buildOrchestratorPrompt routes to the ACTUAL configured leads, nothing hardcoded (H3/L4)", () => {

--- a/tests/limits.test.ts
+++ b/tests/limits.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { clip, tailLines, truncateMiddle } from "../src/core/format.ts";
+import { readIfSmall } from "../src/core/fs.ts";
+
+test("truncation and tail helpers fail safely on non-finite and negative limits", () => {
+  const text = "x".repeat(50_000);
+  assert.ok(truncateMiddle(text, Number.NaN).length < 13_000);
+  assert.equal(clip(text, Number.POSITIVE_INFINITY).text.length, 8_000);
+  assert.equal(tailLines(Array.from({ length: 200 }, (_, i) => `line-${i}`).join("\n"), -1).split("\n").length, 80);
+});
+
+test("readIfSmall does not turn a NaN limit into an unbounded read", () => {
+  const file = join(mkdtempSync(join(tmpdir(), "pi-hive-limit-")), "large.txt");
+  writeFileSync(file, "x".repeat(100_000));
+  assert.equal(readIfSmall(file, Number.NaN), "");
+});


### PR DESCRIPTION
## Summary
- validate the complete raw hive configuration before applying defaults
- reject unknown keys with path-aware diagnostics
- enforce bounded positive integers and limits for config size, agent count, tree depth, refs, and injected context
- require project-relative agent, context, skill, and domain paths unless explicitly opted outside
- require agent prompts to be existing regular Markdown files
- reject duplicate names/slugs across planning and hive teams
- harden truncation, tail, route, tool, and file-read limits against invalid numbers
- surface malformed configuration through `/hive-doctor`

## Testing
- `just verify`
- 201 Node tests passed
- 44 Bun tests passed
- dashboard dist freshness and package verification passed