### PR TITLE
fix(dashboard): authenticate daemon shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The extension must stay safe to install globally: it should do nothing unless th
 ## Extension behavior
 
 - Do not register commands, tools, hooks, background servers, file watchers, or UI widgets unless `.pi/hive/hive-config.yaml` exists in the active project.
-- Do not start long-lived processes from the extension factory. Start them from commands/session hooks and clean them up on session shutdown.
+- Do not start long-lived processes from the extension factory. Start them from commands/session hooks. Clean up session-owned processes on session shutdown; deliberately shared daemons must provide authenticated explicit teardown and a bounded idle timeout.
 - Guard TUI-specific behavior with `ctx.mode === "tui"`; guard user prompts/notifications with `ctx.hasUI`.
 - Custom tools that mutate files must use Pi's file mutation queue.
 - Tool output must be bounded/truncated so it cannot flood model context.

--- a/Justfile
+++ b/Justfile
@@ -101,23 +101,26 @@ pi-dev:
 # ui/web/src/** and see changes live (Ctrl+C stops both). Vite binds to
 # localhost/::1, not 127.0.0.1. Usage: `just run`  or  `PROJECT=/path just run`.
 # Run EVERYTHING: Bun server (API + /pl-review) + Vite HMR frontend. Open http://localhost:43192.
+# The server always mints/reuses a bearer credential; manual development never
+# disables mutation authentication.
 [group('dashboard')]
 run:
   cd {{dashboard_dir}} && npm install
   @printf "{{BLUE}}pi-hive dashboard (dev){{NC}}\n"
   @printf "  project:  %s\n" "{{project}}"
   @printf "  frontend: http://localhost:43192  (HMR — open this)\n"
-  @printf "  api:      http://{{telemetry_host}}:{{telemetry_port}}\n"
+  @printf "  api:      http://{{telemetry_host}}:{{telemetry_port}} (authenticated writes)\n"
   npx concurrently --kill-others --names "api,web" --prefix-colors "blue,green" \
     "HIVE_TELEMETRY_HOST={{telemetry_host}} HIVE_TELEMETRY_PORT={{telemetry_port}} HIVE_PROJECT_CWD={{project}} HIVE_TELEMETRY_DB={{project}}/.telemetry/telemetry.db bun src/observability/server/index.ts" \
     "cd {{dashboard_dir}} && HIVE_TELEMETRY_PORT={{telemetry_port}} npm run dev"
 
-# Serve the dashboard standalone: ONE Bun process (API + built dist/ + /pl-review), no Vite/HMR. For a quick check of the built UI.
+# Serve the dashboard standalone: ONE authenticated Bun process (API + built
+# dist/ + /pl-review), no Vite/HMR. For a quick check of the built UI.
 [group('dashboard')]
 dashboard-serve:
   @printf "{{BLUE}}pi-hive dashboard (serve){{NC}}\n"
   @printf "  project:   %s\n" "{{project}}"
-  @printf "  dashboard: http://{{telemetry_host}}:{{telemetry_port}}  (Plans tab)\n"
+  @printf "  dashboard: http://{{telemetry_host}}:{{telemetry_port}}  (authenticated writes)\n"},{
   HIVE_TELEMETRY_HOST="{{telemetry_host}}" HIVE_TELEMETRY_PORT="{{telemetry_port}}" \
     HIVE_PROJECT_CWD="{{project}}" HIVE_TELEMETRY_DB="{{project}}/.telemetry/telemetry.db" \
     bun src/observability/server/index.ts

--- a/README.md
+++ b/README.md
@@ -214,5 +214,8 @@ Runtime knobs are hive-specific:
 - `HIVE_TELEMETRY_NO_OPEN=1` — start the server without opening a browser
 - `HIVE_TELEMETRY_REGISTRY` — override the global session registry path
 - `HIVE_TELEMETRY_DB` — override the local SQLite database path
+- `HIVE_DAEMON_IDLE_TIMEOUT_MS` — stop an unused daemon after this interval, default `900000` (15 minutes; allowed `1000..86400000`)
 
 Dashboard startup is serialized across Pi processes. A session adopts a daemon only when `/health` reports the same protocol, package/build, registry, and database identity; compatible upgrades restart stale same-storage daemons, while a daemon using different storage is never adopted. Host headers must exactly match the configured listener origin.
+
+The dashboard uses an explicit shared-daemon lifecycle: it survives individual Pi session shutdowns because other sessions may still use it. It stops through `/hive-observe-stop`, an authenticated restart, normal OS/process supervision, or automatically after 15 minutes with no HTTP activity and no active browser event stream. Shutdown requests must carry both the daemon bearer token and its current startup nonce. PID metadata is informational only—pi-hive never signals a process merely because its PID appears in a file, and it does not discover termination targets with `lsof`. Managed child-process handles may be terminated directly when startup fails because the live handle, rather than persisted metadata, supplies process identity. Manual `just run` and `just dashboard-serve` starts also keep write authentication enabled by minting an ephemeral credential when no private stored token exists.

--- a/scripts/restart-dashboard.mjs
+++ b/scripts/restart-dashboard.mjs
@@ -1,83 +1,85 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 const extensionRoot = resolve(process.argv[2] || ".");
 const port = Number(process.env.HIVE_TELEMETRY_PORT || 43191);
 const host = process.env.HIVE_TELEMETRY_HOST || "127.0.0.1";
-const url = `http://${host}:${port}`;
+const urlHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+const url = `http://${urlHost}:${port}`;
 const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 const hiveDir = join(agentDir, "hive");
-const pidFile = join(hiveDir, "telemetry-server.json");
-const registryPath = process.env.HIVE_TELEMETRY_REGISTRY || join(hiveDir, "telemetry-sessions.jsonl");
+const metadataPath = join(hiveDir, "telemetry-server.json");
+const tokenPath = join(hiveDir, "daemon-token");
+const registryPath = resolve(process.env.HIVE_TELEMETRY_REGISTRY || join(hiveDir, "telemetry-sessions.jsonl"));
+const dbPath = resolve(process.env.HIVE_TELEMETRY_DB || join(hiveDir, "telemetry.db"));
 const serverPath = join(extensionRoot, "src", "observability", "server", "index.ts");
+const protocolVersion = 1;
+const packageVersion = JSON.parse(readFileSync(join(extensionRoot, "package.json"), "utf8")).version || "unknown";
+let buildHash = "unknown";
+try { buildHash = readFileSync(join(extensionRoot, "ui", "web", "dist", ".build-hash"), "utf8").trim() || "unknown"; } catch { /* use unknown */ }
 
 const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 
-function readPidFile() {
-  try { return JSON.parse(readFileSync(pidFile, "utf8")); } catch { return null; }
+function readToken() {
+  try { return readFileSync(tokenPath, "utf8").trim(); } catch { return ""; }
 }
 
-function killPid(pid, killed) {
-  if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return;
-  try {
-    process.kill(pid, "SIGTERM");
-    killed.add(pid);
-  } catch {
-    // Process already exited or is not ours.
-  }
-}
-
-async function isHiveDashboard() {
+async function probe() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 700);
   try {
     const response = await fetch(`${url}/health`, { signal: controller.signal });
-    if (!response.ok) return false;
+    if (!response.ok) return null;
     const body = await response.json();
-    return body?.ok === true && body?.mode === "global" && typeof body?.registry === "string" && typeof body?.db === "string";
+    return body?.ok === true && body?.mode === "global" ? body : null;
   } catch {
-    return false;
+    return null;
   } finally {
     clearTimeout(timer);
   }
 }
 
 async function stopExistingDashboard() {
-  const killed = new Set();
-  const info = readPidFile();
-  if (Number(info?.port) === port) killPid(Number(info.pid), killed);
-
-  // Only kill a port listener after proving it is pi-hive. This avoids killing
-  // unrelated local services that happen to use the configured port.
-  if (await isHiveDashboard()) {
-    const out = spawnSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], { encoding: "utf8" });
-    if (out.status === 0) {
-      for (const raw of out.stdout.split("\n")) killPid(Number(raw.trim()), killed);
-    }
+  const health = await probe();
+  if (!health) return undefined;
+  if (resolve(String(health.registryPath || "")) !== registryPath || resolve(String(health.dbPath || "")) !== dbPath) {
+    throw new Error("A dashboard using different telemetry storage is running; refusing to stop it.");
   }
-
-  if (killed.size) {
-    await sleep(300);
-    rmSync(pidFile, { force: true });
+  const token = readToken();
+  if (!token || typeof health.startupNonce !== "string") {
+    throw new Error("A dashboard is running but lacks authenticated shutdown metadata; refusing unsafe PID-based termination.");
   }
-  return Array.from(killed);
+  const response = await fetch(`${url}/shutdown`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json", origin: url },
+    body: JSON.stringify({ startupNonce: health.startupNonce }),
+  });
+  if (response.status !== 202) throw new Error(`Dashboard refused authenticated shutdown (HTTP ${response.status}).`);
+  for (let i = 0; i < 40; i++) {
+    if (!(await probe())) return Number(health.pid) || undefined;
+    await sleep(50);
+  }
+  throw new Error("Dashboard acknowledged shutdown but did not exit.");
 }
 
-async function waitForHealth() {
-  for (let i = 0; i < 20; i++) {
-    if (await isHiveDashboard()) return true;
-    await sleep(100);
-  }
-  return false;
+function atomicPrivateWrite(path, content) {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  chmodSync(dirname(path), 0o700);
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(temporary, content, { mode: 0o600, flag: "wx" });
+  renameSync(temporary, path);
+  chmodSync(path, 0o600);
 }
 
 if (!existsSync(serverPath)) {
   console.log(`Skipping dashboard restart: missing ${serverPath}`);
   process.exit(0);
 }
+if (!Number.isSafeInteger(port) || port < 1 || port > 65535) throw new Error(`Invalid HIVE_TELEMETRY_PORT: ${port}`);
 
 const bun = spawnSync("bun", ["--version"], { encoding: "utf8" });
 if (bun.error || bun.status !== 0) {
@@ -85,9 +87,14 @@ if (bun.error || bun.status !== 0) {
   process.exit(0);
 }
 
-const killed = await stopExistingDashboard();
-mkdirSync(hiveDir, { recursive: true });
+const stoppedPid = await stopExistingDashboard();
+rmSync(metadataPath, { force: true });
+rmSync(tokenPath, { force: true });
+mkdirSync(hiveDir, { recursive: true, mode: 0o700 });
+chmodSync(hiveDir, 0o700);
 
+const token = (randomUUID() + randomUUID()).replace(/-/g, "");
+const startupNonce = randomUUID();
 const proc = spawn("bun", [serverPath], {
   cwd: process.cwd(),
   detached: true,
@@ -96,21 +103,54 @@ const proc = spawn("bun", [serverPath], {
     ...process.env,
     HIVE_TELEMETRY_PORT: String(port),
     HIVE_TELEMETRY_HOST: host,
+    HIVE_TELEMETRY_TOKEN: token,
     HIVE_TELEMETRY_REGISTRY: registryPath,
+    HIVE_TELEMETRY_DB: dbPath,
+    HIVE_DAEMON_PROTOCOL_VERSION: String(protocolVersion),
+    HIVE_DAEMON_PACKAGE_VERSION: packageVersion,
+    HIVE_DAEMON_BUILD_HASH: buildHash,
+    HIVE_DAEMON_STARTUP_NONCE: startupNonce,
     HIVE_PROJECT_CWD: process.cwd(),
   },
 });
 proc.unref();
 
-writeFileSync(pidFile, `${JSON.stringify({
-  pid: proc.pid,
+let health = null;
+for (let i = 0; i < 70; i++) {
+  const candidate = await probe();
+  if (candidate?.startupNonce === startupNonce
+    && candidate.protocolVersion === protocolVersion
+    && candidate.packageVersion === packageVersion
+    && candidate.buildHash === buildHash
+    && resolve(candidate.registryPath) === registryPath
+    && resolve(candidate.dbPath) === dbPath) {
+    health = candidate;
+    break;
+  }
+  await sleep(100);
+}
+if (!health) {
+  // This ChildProcess handle identifies the process spawned above; no persisted
+  // PID is trusted as termination authority.
+  try { proc.kill("SIGTERM"); } catch { /* already exited */ }
+  throw new Error("Dashboard failed identity-checked health readiness; no metadata was published.");
+}
+
+atomicPrivateWrite(tokenPath, `${token}\n`);
+atomicPrivateWrite(metadataPath, `${JSON.stringify({
+  pid: health.pid,
   host,
   port,
   url,
   cwd: process.cwd(),
   startedAt: new Date().toISOString(),
+  protocolVersion,
+  packageVersion,
+  buildHash,
+  registryPath,
+  dbPath,
+  startupNonce,
 }, null, 2)}\n`);
 
-const healthy = await waitForHealth();
-const stopped = killed.length ? ` (stopped ${killed.length} old process${killed.length === 1 ? "" : "es"})` : "";
-console.log(`${healthy ? "Restarted" : "Started"} pi-hive telemetry dashboard: ${url}${stopped}`);
+const stopped = stoppedPid ? ` (stopped authenticated daemon ${stoppedPid})` : "";
+console.log(`Restarted pi-hive telemetry dashboard: ${url}${stopped}`);

--- a/src/engine/dashboard.ts
+++ b/src/engine/dashboard.ts
@@ -98,10 +98,6 @@ export interface DashboardPidFile extends Partial<DaemonIdentity> {
   startedAt?: string;
 }
 
-function readDashboardPidFile(): DashboardPidFile | null {
-  try { return JSON.parse(readFileSync(dashboardMetadataPath(), "utf8")) as DashboardPidFile; } catch { return null; }
-}
-
 function publishDaemonMetadata(info: DashboardPidFile, token: string): void {
   // Publish credentials and process identity only after the new listener has
   // answered a matching health probe. Both files are atomic and private.
@@ -122,11 +118,6 @@ function removeDashboardPidFile(): void {
 function removePublishedDaemonMetadata(): void {
   removeDashboardPidFile();
   try { rmSync(daemonTokenPath(), { force: true }); } catch { /* noop */ }
-}
-
-function killPid(pid: number | undefined, killed: Set<number>): void {
-  if (!Number.isFinite(pid) || !pid || pid <= 0 || pid === process.pid) return;
-  try { process.kill(pid, "SIGTERM"); killed.add(pid); } catch { /* noop */ }
 }
 
 export interface DashboardProbe extends Partial<DaemonHealth> {
@@ -227,6 +218,42 @@ export interface EnsureDeps {
   open?: (url: string) => void;
 }
 
+export interface StopDeps {
+  probe?: (host: string, port: number) => Promise<DashboardProbe | null>;
+  requestShutdown?: (host: string, port: number, health: DaemonHealth, token: string) => Promise<boolean>;
+  killManaged?: typeof killProcess;
+  withLock?: <T>(path: string, fn: () => Promise<T>) => Promise<T>;
+}
+
+export async function requestDaemonShutdown(
+  host: string,
+  port: number,
+  health: DaemonHealth,
+  token: string,
+): Promise<boolean> {
+  if (!token) return false;
+  const url = dashboardUrl(host, port);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1_500);
+  try {
+    const response = await fetch(`${url}/shutdown`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        origin: url,
+      },
+      body: JSON.stringify({ startupNonce: health.startupNonce }),
+    });
+    return response.status === 202;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function waitForReady(host: string, port: number, expected: DaemonIdentity, probe = probeDashboard): Promise<DaemonHealth | null> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -259,7 +286,7 @@ export async function ensureDashboard(
   const probe = deps.probe ?? probeDashboard;
   const hasBun = deps.bunAvailable ?? bunAvailable;
   const doSpawn = deps.spawn ?? spawnDashboard;
-  const doStop = deps.stop ?? stopDashboard;
+  const doStop = deps.stop ?? stopDashboardUnlocked;
   const ready = deps.waitForReady ?? ((h, p, expected) => waitForReady(h, p, expected, probe));
   const lock = deps.withLock ?? ((path, fn) => withCrossProcessFileLockAsync(path, fn, { timeoutMs: 15_000, staleMs: 30_000 }));
   const doOpen = deps.open ?? ((target: string) => maybeOpen(target, true));
@@ -272,7 +299,10 @@ export async function ensureDashboard(
       let health = await probe(host, port);
       if (opts.forceRestart) {
         await doStop(state, host, port);
-        health = null;
+        health = await probe(host, port);
+        if (health) {
+          return { running: false, url, adopted: false, spawned: false, error: "Dashboard is still running and could not be stopped safely." };
+        }
       } else if (health) {
         const sameStorage = resolve(health.registryPath) === registryPath && resolve(health.dbPath) === dbPath;
         if (!sameStorage) {
@@ -286,7 +316,10 @@ export async function ensureDashboard(
         // Same storage but an old protocol/package/build: replace it so an
         // extension upgrade cannot silently adopt an incompatible daemon.
         await doStop(state, host, port);
-        health = null;
+        health = await probe(host, port);
+        if (health) {
+          return { running: false, url, adopted: false, spawned: false, error: "Incompatible dashboard is still running and could not be stopped safely." };
+        }
       }
 
       if (!hasBun()) {
@@ -334,27 +367,55 @@ function maybeOpen(url: string, open?: boolean): void {
   try { spawnManaged("open", [url], { detached: true, stdio: "ignore" }); } catch { /* noop */ }
 }
 
-// Explicit teardown remains centralized here. Process-identity strengthening and
-// authenticated shutdown are handled by the following lifecycle remediation.
-export async function stopDashboard(state: HiveState, host = dashboardHost(), port = dashboardPort()): Promise<number[]> {
-  const killed = new Set<number>();
-  if (state.obsServer?.proc && !state.obsServer.proc.killed) {
-    const pid = killProcess(state.obsServer.proc);
-    if (typeof pid === "number") killed.add(pid);
-  }
-  state.obsServer = undefined;
+async function stopDashboardUnlocked(
+  state: HiveState,
+  host: string,
+  port: number,
+  deps: StopDeps = {},
+): Promise<number[]> {
+  const probe = deps.probe ?? probeDashboard;
+  const shutdown = deps.requestShutdown ?? requestDaemonShutdown;
+  const killManaged = deps.killManaged ?? killProcess;
+  const stopped = new Set<number>();
+  const managed = state.obsServer?.proc;
+  const health = await probe(host, port);
 
-  const pidFile = readDashboardPidFile();
-  if (pidFile?.port === port) killPid(pidFile.pid, killed);
-  if (await isHiveDashboard(host, port)) {
-    try {
-      const out = execFileSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], { encoding: "utf8" });
-      for (const raw of out.split("\n")) killPid(Number(raw.trim()), killed);
-    } catch { /* no listener */ }
+  if (isCompleteHealth(health)) {
+    const sameStorage = resolve(health.registryPath) === dashboardRegistryPath()
+      && resolve(health.dbPath) === dashboardDbPath();
+    if (sameStorage && await shutdown(host, port, health, readDaemonToken() || "")) {
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline && await probe(host, port)) await sleep(50);
+      if (!(await probe(host, port))) stopped.add(health.pid);
+    } else if (managed && managed.pid === health.pid && !managed.killed) {
+      // A ChildProcess handle created by this process is direct process identity;
+      // unlike a persisted PID, it cannot be stale metadata for an unrelated PID.
+      const pid = killManaged(managed);
+      if (typeof pid === "number") stopped.add(pid);
+    }
+  } else if (managed && !managed.killed) {
+    const pid = killManaged(managed);
+    if (typeof pid === "number") stopped.add(pid);
   }
-  if (killed.size) {
-    await sleep(300);
-    removeDashboardPidFile();
+
+  state.obsServer = undefined;
+  if (stopped.size) {
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline && await probe(host, port)) await sleep(50);
   }
-  return Array.from(killed);
+  if (!(await probe(host, port))) removePublishedDaemonMetadata();
+  return Array.from(stopped);
+}
+
+// The global daemon intentionally survives individual Pi sessions. Explicit
+// teardown is serialized with startup and uses authenticated, nonce-bound
+// shutdown. Persisted PID metadata is informational and is never kill authority.
+export async function stopDashboard(
+  state: HiveState,
+  host = dashboardHost(),
+  port = dashboardPort(),
+  deps: StopDeps = {},
+): Promise<number[]> {
+  const lock = deps.withLock ?? ((path, fn) => withCrossProcessFileLockAsync(path, fn, { timeoutMs: 15_000, staleMs: 30_000 }));
+  return lock(dashboardStartupLockPath(), () => stopDashboardUnlocked(state, host, port, deps));
 }

--- a/src/integration/hooks.ts
+++ b/src/integration/hooks.ts
@@ -438,7 +438,8 @@ ${catalog}`,
     state.distillQueues?.clear();
     // The telemetry dashboard is a SHARED global daemon — other sessions may be
     // using it — so we do NOT kill it here. Just drop this session's reference.
-    // Explicit teardown is /hive-observe-stop.
+    // Explicit teardown is /hive-observe-stop; the server also self-terminates
+    // after its bounded idle timeout when no browser event stream remains.
     state.obsServer = undefined;
     if (state.dashboardActionTimer) clearInterval(state.dashboardActionTimer);
     state.dashboardActionTimer = undefined;

--- a/src/observability/server/config.ts
+++ b/src/observability/server/config.ts
@@ -32,6 +32,14 @@ export const DB_PATH = path.resolve(process.env.HIVE_TELEMETRY_DB || path.join(H
 export const CONVERSATION_LOG = process.env.HIVE_CONVERSATION_LOG || "";
 export const BOOT_SESSION_ID = process.env.HIVE_SESSION_ID || "global";
 export const PROJECT_CWD = process.env.HIVE_PROJECT_CWD || process.cwd();
+export const IDLE_TIMEOUT_MS: number = (() => {
+  const raw = process.env.HIVE_DAEMON_IDLE_TIMEOUT_MS || "900000";
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1_000 || value > 86_400_000) {
+    throw new Error(`Invalid HIVE_DAEMON_IDLE_TIMEOUT_MS: ${raw}`);
+  }
+  return value;
+})();
 
 const EXTENSION_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 export const PROTOCOL_VERSION = Number(process.env.HIVE_DAEMON_PROTOCOL_VERSION || DAEMON_PROTOCOL_VERSION);
@@ -39,14 +47,18 @@ export const PACKAGE_VERSION = process.env.HIVE_DAEMON_PACKAGE_VERSION || packag
 export const BUILD_HASH = process.env.HIVE_DAEMON_BUILD_HASH || dashboardBuildHash(EXTENSION_ROOT);
 export const STARTUP_NONCE = process.env.HIVE_DAEMON_STARTUP_NONCE || randomUUID();
 
-// Empty credentials always fail closed. The extension passes a fresh token to a
-// managed spawn and publishes it only after identity-checked health readiness.
-// An out-of-band start may reuse an existing private token but never mints one
-// before the listener is known healthy.
+// Authentication is mandatory for every startup path. Managed extension starts
+// pass a fresh token and publish it only after identity-checked readiness. Manual
+// and development starts reuse a private published token when available, or keep
+// a newly minted token in memory (the same-origin bootstrap exposes it to the UI).
 export const DAEMON_TOKEN: string = (() => {
   const configured = process.env.HIVE_TELEMETRY_TOKEN?.trim();
   if (configured) return configured;
-  try { return fs.readFileSync(path.join(path.dirname(REGISTRY_PATH), "daemon-token"), "utf8").trim(); } catch { return ""; }
+  try {
+    const stored = fs.readFileSync(path.join(path.dirname(REGISTRY_PATH), "daemon-token"), "utf8").trim();
+    if (stored) return stored;
+  } catch { /* mint an ephemeral credential below */ }
+  return (randomUUID() + randomUUID()).replace(/-/g, "");
 })();
 
 export function expectedHostHeader(): string {

--- a/src/observability/server/index.ts
+++ b/src/observability/server/index.ts
@@ -2,7 +2,7 @@ import { hasExpectedHost, isSameOriginRequest, writeGateResponse } from "../secu
 import { dashboardFile, dashboardHtml } from "../static";
 import {
   BOOT_SESSION_ID, BUILD_HASH, CONVERSATION_LOG, DAEMON_TOKEN, DB_PATH, HOST,
-  PACKAGE_VERSION, PORT, PROJECT_CWD, PROTOCOL_VERSION, REGISTRY_PATH,
+  IDLE_TIMEOUT_MS, PACKAGE_VERSION, PORT, PROJECT_CWD, PROTOCOL_VERSION, REGISTRY_PATH,
   STARTUP_NONCE, expectedHostHeader,
 } from "./config";
 import { broadcastPing, encoder, eventFrame, subscribers } from "./sse";
@@ -47,9 +47,23 @@ startTelemetryRuntime();
 // browser/proxy, the client's EventSource fires `error`, and the dashboard
 // flickers to "reconnecting". A comment (": ping") keeps the socket alive and
 // is ignored by EventSource.
-setInterval(broadcastPing, 15_000);
+const heartbeatTimer = setInterval(broadcastPing, 15_000);
+let lastActivityAt = Date.now();
+let shuttingDown = false;
+let idleTimer: ReturnType<typeof setInterval>;
 
-Bun.serve({
+function scheduleServerStop(): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  setTimeout(() => {
+    clearInterval(heartbeatTimer);
+    clearInterval(idleTimer);
+    server.stop(true);
+    process.exit(0);
+  }, 50);
+}
+
+const server = Bun.serve({
   hostname: HOST,
   port: PORT,
   // Disable the per-connection idle timeout. SSE (/stream) connections are
@@ -59,6 +73,7 @@ Bun.serve({
   // secondary guard for any proxy in front of us.
   idleTimeout: 0,
   async fetch(req: Request) {
+    lastActivityAt = Date.now();
     const url = new URL(req.url);
 
     // Reject DNS-rebinding and alternate-host requests before any route,
@@ -77,6 +92,16 @@ Bun.serve({
     // would land outside a per-route check.
     const gated = writeGateResponse(req, url, DAEMON_TOKEN, (error, status) => json({ error }, status), reviewCapability);
     if (gated) return gated;
+
+    if (req.method === "POST" && url.pathname === "/shutdown") {
+      let body: any;
+      try { body = await req.json(); } catch { return json({ error: "invalid json body" }, 400); }
+      if (body?.startupNonce !== STARTUP_NONCE) return json({ error: "daemon identity mismatch" }, 409);
+      // Return the acknowledgement before closing the listener. The bearer token
+      // and startup nonce jointly prove authority over this exact daemon instance.
+      scheduleServerStop();
+      return json({ ok: true, pid: process.pid, startupNonce: STARTUP_NONCE }, 202);
+    }
 
     // Review HTML, session minting, and the vendored client's /api/* requests
     // are routed only after the method gate. Non-review /api requests fall through.
@@ -300,6 +325,13 @@ Bun.serve({
     return json({ error: "not found" }, 404);
   },
 });
+
+// The daemon is shared across Pi sessions, so a single session shutdown cannot
+// safely terminate it. Bound its lifetime instead: no active browser stream and
+// no HTTP activity for the configured interval triggers graceful self-shutdown.
+idleTimer = setInterval(() => {
+  if (subscribers.size === 0 && Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) scheduleServerStop();
+}, Math.min(60_000, Math.max(1_000, Math.floor(IDLE_TIMEOUT_MS / 4))));
 
 console.log(`pi-hive telemetry dashboard: http://${HOST}:${PORT}`);
 console.log(`registry: ${REGISTRY_PATH}`);

--- a/tests/daemon-lifecycle.spec.ts
+++ b/tests/daemon-lifecycle.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("shutdown requires the bearer token and exact startup nonce", async () => {
+  const reservation = Bun.serve({ port: 0, fetch: () => new Response("reserved") });
+  const port = reservation.port;
+  reservation.stop(true);
+
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-daemon-lifecycle-"));
+  const token = "t".repeat(64);
+  const startupNonce = "daemon-lifecycle-test";
+  const origin = `http://127.0.0.1:${port}`;
+  const proc = Bun.spawn(["bun", "src/observability/server/index.ts"], {
+    cwd: process.cwd(),
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {
+      ...process.env,
+      HIVE_TELEMETRY_PORT: String(port),
+      HIVE_TELEMETRY_TOKEN: token,
+      HIVE_DAEMON_STARTUP_NONCE: startupNonce,
+      HIVE_DAEMON_IDLE_TIMEOUT_MS: "60000",
+      HIVE_TELEMETRY_REGISTRY: join(dir, "registry.jsonl"),
+      HIVE_TELEMETRY_DB: join(dir, "telemetry.db"),
+    },
+  });
+
+  const shutdown = (authorization: string | undefined, nonce: string) => fetch(`${origin}/shutdown`, {
+    method: "POST",
+    headers: {
+      ...(authorization ? { authorization: `Bearer ${authorization}` } : {}),
+      "content-type": "application/json",
+      origin,
+    },
+    body: JSON.stringify({ startupNonce: nonce }),
+  });
+
+  try {
+    let ready = false;
+    for (let attempt = 0; attempt < 80; attempt++) {
+      try {
+        const response = await fetch(`${origin}/health`);
+        if (response.ok) { ready = true; break; }
+      } catch { /* server is still starting */ }
+      await sleep(50);
+    }
+    expect(ready).toBe(true);
+    expect((await shutdown(undefined, startupNonce)).status).toBe(401);
+    expect((await shutdown(token, "wrong-daemon")).status).toBe(409);
+    expect((await shutdown(token, startupNonce)).status).toBe(202);
+
+    const exitCode = await Promise.race([
+      proc.exited,
+      sleep(2_000).then(() => null),
+    ]);
+    expect(exitCode).not.toBeNull();
+  } finally {
+    if (proc.exitCode === null) proc.kill("SIGKILL");
+    await proc.exited;
+  }
+});

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -12,6 +12,7 @@ import {
   dashboardUrl,
   daemonTokenPath,
   ensureDashboard,
+  stopDashboard,
   type EnsureDeps,
 } from "../src/engine/dashboard.ts";
 import { daemonIdentity, type DaemonHealth, type DaemonIdentity } from "../src/shared/daemon-protocol.ts";
@@ -185,6 +186,62 @@ test("is Bun-gated and browser opening remains explicit", async () => {
   const explicit = deps();
   await ensureDashboard(state(), ctx, ROOT, { open: true }, explicit.deps);
   assert.equal(explicit.calls.opened, 1);
+});
+
+test("stale PID metadata is never used as process-kill authority", async () => {
+  const isolated = mkdtempSync(join(tmpdir(), "pi-hive-dashboard-stale-pid-"));
+  process.env.HIVE_TELEMETRY_REGISTRY = join(isolated, "registry.jsonl");
+  try {
+    mkdirSync(isolated, { recursive: true });
+    writeFileSync(dashboardMetadataPath(), JSON.stringify({ pid: 999_999, port: dashboardPort(), startupNonce: "stale" }));
+    let shutdownCalls = 0;
+    let managedKills = 0;
+    const stopped = await stopDashboard(state(), dashboardHost(), dashboardPort(), {
+      probe: async () => null,
+      requestShutdown: async () => { shutdownCalls++; return true; },
+      killManaged: () => { managedKills++; return 999_999; },
+      withLock: async (_path, fn) => fn(),
+    });
+    assert.deepEqual(stopped, []);
+    assert.equal(shutdownCalls, 0);
+    assert.equal(managedKills, 0);
+    assert.equal(existsSync(dashboardMetadataPath()), false);
+  } finally {
+    delete process.env.HIVE_TELEMETRY_REGISTRY;
+  }
+});
+
+test("stops an adopted daemon only through token and startup-nonce authentication", async () => {
+  installAdoptionToken();
+  const current = healthy(expectedIdentity("exact-daemon"), { pid: 54321 });
+  let running = true;
+  let requestedNonce = "";
+  const stopped = await stopDashboard(state(), dashboardHost(), dashboardPort(), {
+    probe: async () => running ? current : null,
+    requestShutdown: async (_host, _port, health, token) => {
+      requestedNonce = health.startupNonce;
+      assert.equal(token, "adoption-token");
+      running = false;
+      return true;
+    },
+    killManaged: () => { throw new Error("must not signal an adopted process"); },
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.deepEqual(stopped, [54321]);
+  assert.equal(requestedNonce, "exact-daemon");
+});
+
+test("refuses to stop a daemon belonging to different storage", async () => {
+  const other = healthy({ ...expectedIdentity(), registryPath: "/other/registry.jsonl" }, { pid: 65432 });
+  let shutdownCalls = 0;
+  const stopped = await stopDashboard(state(), dashboardHost(), dashboardPort(), {
+    probe: async () => other,
+    requestShutdown: async () => { shutdownCalls++; return true; },
+    killManaged: () => { throw new Error("must not signal an unowned process"); },
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.deepEqual(stopped, []);
+  assert.equal(shutdownCalls, 0);
 });
 
 test("host and port validation fail closed; non-loopback requires dangerous opt-in", () => {


### PR DESCRIPTION
## Summary
- replace PID-file and `lsof` termination with bearer-authenticated, startup-nonce-bound shutdown
- make daemon metadata informational, serialize stop/start transitions, and fail safely when a listener cannot be verified
- add bounded idle shutdown for the shared daemon and keep manual/dev write authentication enabled
- harden the restart helper to publish private token and identity metadata only after readiness
- document the lifecycle and add stale-PID plus live shutdown regression coverage

## Verification
- `just ci`
- authenticated shutdown integration: unauthenticated 401, wrong nonce 409, valid request 202 and process exit
