### PR TITLE
test: cover command and session lifecycles

### DIFF
--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -682,7 +682,11 @@ export async function dispatchAgent(
     // Deliberate non-goal: distiller re-injection into resumed workers (P4).
     const isNewSession = fresh || !sessionFileExisted;
     await runAtDelegationDepth(delegationDepth, () => runAsAgent(runtime.config.name, () => runWithChange(scopedChangeId, () => session.prompt(isNewSession ? prompt : task))));
-    errorMessage = abortedByParent ? (timedOut ? `Worker timed out after ${governance.timeoutMs}ms` : "aborted") : session.state.errorMessage;
+    errorMessage = abortedByParent
+      ? (timedOut ? `Worker timed out after ${governance.timeoutMs}ms` : "aborted")
+      : state.shuttingDown
+        ? "aborted during session shutdown"
+        : session.state.errorMessage;
     // The 1s timer polls this too, but relying on it alone can miss the final,
     // most accurate reading if the last tick landed moments before completion.
     // Refresh the raw tokens/window alongside the percent (Phase 4.7) so the

--- a/src/integration/commands.ts
+++ b/src/integration/commands.ts
@@ -9,13 +9,32 @@ import { dashboardUrl, ensureDashboard, readDaemonToken, stopDashboard } from ".
 import * as openspec from "../engine/openspec";
 import { truncateMiddle } from "../core/utils";
 
-function listChangeIds(cwd: string): string[] {
-  return openspec.listChanges(cwd).map((c) => c.name);
+function listChangeIds(cwd: string, api: typeof openspec): string[] {
+  return api.listChanges(cwd).map((c) => c.name);
 }
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
-export function registerCommands(pi: ExtensionAPI, state: HiveState) {
+export interface CommandDeps {
+  openspec: typeof openspec;
+  ensureDashboard: typeof ensureDashboard;
+  stopDashboard: typeof stopDashboard;
+  dashboardUrl: typeof dashboardUrl;
+  readDaemonToken: typeof readDaemonToken;
+  fetch: typeof globalThis.fetch;
+}
+
+const defaultCommandDeps: CommandDeps = {
+  openspec,
+  ensureDashboard,
+  stopDashboard,
+  dashboardUrl,
+  readDaemonToken,
+  fetch: globalThis.fetch.bind(globalThis),
+};
+
+export function registerCommands(pi: ExtensionAPI, state: HiveState, overrides: Partial<CommandDeps> = {}) {
+  const deps: CommandDeps = { ...defaultCommandDeps, ...overrides };
   // Three explicit mode commands + a cycle key (normal → plan → hive → normal).
   pi.registerCommand("hive-normal", {
     description: "Switch to normal Pi chat (no hive, no enforcement)",
@@ -52,30 +71,30 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
     description: "Execute a plan change's tasks.md through the hive (usage: /hive-execute <change-id>)",
     getArgumentCompletions: (prefix: string) => {
       const cwd = state.widgetCtx?.cwd || process.cwd();
-      return listChangeIds(cwd)
+      return listChangeIds(cwd, deps.openspec)
         .filter((id) => id.startsWith(prefix))
         .map((id) => ({ value: id, label: id }));
     },
     handler: async (args: string, ctx: ExtensionContext) => {
       const changeId = args.trim().split(/\s+/)[0] || "";
       if (!changeId) {
-        const available = listChangeIds(ctx.cwd);
+        const available = listChangeIds(ctx.cwd, deps.openspec);
         if (ctx.hasUI) ctx.ui.notify(`Usage: /hive-execute <change-id>. Available: ${available.join(", ") || "none (create one first)"}`, "warning");
         return;
       }
-      if (!openspec.changeExists(ctx.cwd, changeId)) {
-        if (ctx.hasUI) ctx.ui.notify(`No OpenSpec change "${changeId}" under openspec/changes/. Available: ${listChangeIds(ctx.cwd).join(", ") || "none"}`, "error");
+      if (!deps.openspec.changeExists(ctx.cwd, changeId)) {
+        if (ctx.hasUI) ctx.ui.notify(`No OpenSpec change "${changeId}" under openspec/changes/. Available: ${listChangeIds(ctx.cwd, deps.openspec).join(", ") || "none"}`, "error");
         return;
       }
-      if (!openspec.hasTasks(ctx.cwd, changeId)) {
+      if (!deps.openspec.hasTasks(ctx.cwd, changeId)) {
         if (ctx.hasUI) ctx.ui.notify(`Change "${changeId}" has no tasks.md yet. Author the change (proposal → design/specs → tasks) via /opsx-propose first.`, "error");
         return;
       }
-      if (!openspec.isReadyToExecute(ctx.cwd, changeId)) {
+      if (!deps.openspec.isReadyToExecute(ctx.cwd, changeId)) {
         if (ctx.hasUI) ctx.ui.notify(`Change "${changeId}" is not ready: tasks.md must be authored and \`openspec validate\` must pass.`, "error");
         return;
       }
-      if (!openspec.isApprovedForExecution(ctx.cwd, changeId)) {
+      if (!deps.openspec.isApprovedForExecution(ctx.cwd, changeId)) {
         if (ctx.hasUI) ctx.ui.notify(`Change "${changeId}" is not approved for execution yet. Current human approvals are required for proposal, design, specs, and tasks.`, "error");
         return;
       }
@@ -94,7 +113,7 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
         else console.warn(`[pi-hive] ${msg}`);
         return;
       }
-      const tasks = truncateMiddle(openspec.readArtifact(ctx.cwd, changeId, "tasks.md"), 12_000);
+      const tasks = truncateMiddle(deps.openspec.readArtifact(ctx.cwd, changeId, "tasks.md"), 12_000);
       pi.sendUserMessage(
         `Execute the approved plan for change "${changeId}" (openspec/changes/${changeId}/). This is the active change; delegate each task to the appropriate coder/tester lead. After verifying a task's implementation evidence, call plan_task_complete with its checkbox ID and evidence. Do not edit tasks.md or any project files yourself.\n\n## tasks.md\n${tasks}`,
       );
@@ -106,9 +125,9 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
     description: "List plan changes, or show the active one (usage: /hive-plan [change-id])",
     handler: async (args: string, ctx: ExtensionContext) => {
       const requested = args.trim().split(/\s+/)[0] || "";
-      const available = listChangeIds(ctx.cwd);
+      const available = listChangeIds(ctx.cwd, deps.openspec);
       if (requested) {
-        if (!openspec.changeExists(ctx.cwd, requested)) {
+        if (!deps.openspec.changeExists(ctx.cwd, requested)) {
           if (ctx.hasUI) ctx.ui.notify(`No OpenSpec change "${requested}". Available: ${available.join(", ") || "none"}`, "error");
           return;
         }
@@ -117,7 +136,7 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
         return;
       }
       const lines = available.length
-        ? available.map((id) => `- ${id}${state.activeChangeId === id ? " (active)" : ""}${openspec.hasTasks(ctx.cwd, id) ? " — tasks ready" : ""}`).join("\n")
+        ? available.map((id) => `- ${id}${state.activeChangeId === id ? " (active)" : ""}${deps.openspec.hasTasks(ctx.cwd, id) ? " — tasks ready" : ""}`).join("\n")
         : "No OpenSpec changes yet. Ask the orchestrator to plan a change, or a lead to run plan_new.";
       if (ctx.hasUI) ctx.ui.notify(`OpenSpec changes under openspec/changes/:\n${lines}`, "info");
     },
@@ -131,7 +150,7 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
         return;
       }
       // Explicit command: force a clean restart and open the browser tab.
-      const result = await ensureDashboard(state, ctx, EXTENSION_ROOT, { open: true, forceRestart: true });
+      const result = await deps.ensureDashboard(state, ctx, EXTENSION_ROOT, { open: true, forceRestart: true });
       if (!ctx.hasUI) return;
       if (result.running) ctx.ui.notify(`pi-hive telemetry restarted: ${result.url}`, "info");
       else ctx.ui.notify(result.bunMissing ? "Cannot start dashboard: Bun is not installed." : `Failed to start dashboard: ${result.error || "unknown error"}`, "error");
@@ -141,7 +160,7 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
   pi.registerCommand("hive-observe-stop", {
     description: "Stop the global pi-hive telemetry dashboard",
     handler: async (_args: string, ctx: ExtensionContext) => {
-      const killed = await stopDashboard(state);
+      const killed = await deps.stopDashboard(state);
       if (ctx.hasUI) ctx.ui.notify(killed.length ? `Stopped pi-hive telemetry dashboard (${killed.join(", ")})` : "No pi-hive telemetry dashboard was running.", "info");
     },
   });
@@ -157,9 +176,9 @@ export function registerCommands(pi: ExtensionAPI, state: HiveState) {
       try {
         // Goes through the daemon's auth-gated POST /prune using the shared
         // token file (Decision 2) — the same endpoint the Settings tab calls.
-        const res = await fetch(`${dashboardUrl()}/prune`, {
+        const res = await deps.fetch(`${deps.dashboardUrl()}/prune`, {
           method: "POST",
-          headers: { "content-type": "application/json", authorization: `Bearer ${readDaemonToken() || ""}` },
+          headers: { "content-type": "application/json", authorization: `Bearer ${deps.readDaemonToken() || ""}` },
           body: JSON.stringify({ olderThanDays: days }),
         });
         if (!res.ok) {

--- a/tests/command-integration.test.ts
+++ b/tests/command-integration.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import * as openspec from "../src/engine/openspec.ts";
+import { createState } from "../src/engine/state.ts";
+import { registerCommands, type CommandDeps } from "../src/integration/commands.ts";
+
+function harness() {
+  const commands = new Map<string, any>();
+  const shortcuts: any[] = [];
+  const messages: string[] = [];
+  let activeTools = ["read", "bash"];
+  const pi = {
+    registerCommand(name: string, command: any) { commands.set(name, command); },
+    registerShortcut(key: any, shortcut: any) { shortcuts.push({ key, ...shortcut }); },
+    sendUserMessage(message: string) { messages.push(message); },
+    getActiveTools() { return activeTools; },
+    getAllTools() { return ["read", "bash", "route_agent"].map((name) => ({ name })); },
+    setActiveTools(tools: string[]) { activeTools = [...tools]; },
+  } as any;
+  return { pi, commands, shortcuts, messages, activeTools: () => activeTools };
+}
+
+function context(cwd = mkdtempSync(join(tmpdir(), "pi-hive-command-"))) {
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const ctx = {
+    cwd,
+    mode: "rpc",
+    hasUI: true,
+    ui: {
+      notify(message: string, level?: string) { notifications.push({ message, level }); },
+      setStatus() {},
+      setWidget() {},
+      setHeader() {},
+      setWorkingVisible() {},
+    },
+  } as any;
+  return { ctx, notifications };
+}
+
+function fakeOpenSpec(overrides: Partial<typeof openspec> = {}): typeof openspec {
+  return {
+    ...openspec,
+    listChanges: () => [{ name: "approved-change", status: "in-progress", completedTasks: 0, totalTasks: 1 }],
+    changeExists: () => true,
+    hasTasks: () => true,
+    isReadyToExecute: () => true,
+    isApprovedForExecution: () => true,
+    readArtifact: () => "# Tasks\n\n- [ ] 1.1 Build it\n",
+    ...overrides,
+  } as typeof openspec;
+}
+
+function commandDeps(overrides: Partial<CommandDeps> = {}): Partial<CommandDeps> {
+  return {
+    openspec: fakeOpenSpec(),
+    ensureDashboard: async () => ({ running: true, url: "http://127.0.0.1:43191", adopted: false, spawned: true }),
+    stopDashboard: async () => [],
+    dashboardUrl: () => "http://127.0.0.1:43191",
+    readDaemonToken: () => "test-token",
+    fetch: async () => new Response(JSON.stringify({ events: 0, sessions: 0 }), { status: 200, headers: { "content-type": "application/json" } }),
+    ...overrides,
+  };
+}
+
+test("registered mode commands drive the real mode state machine and drain guard", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  state.normalToolNames = ["read", "bash"];
+  const { ctx, notifications } = context();
+  registerCommands(h.pi, state, commandDeps());
+
+  assert.deepEqual(
+    ["hive-normal", "hive-plan-mode", "hive", "hive-toggle"].map((name) => h.commands.has(name)),
+    [true, true, true, true],
+  );
+  assert.equal(h.shortcuts.length, 1);
+
+  await h.commands.get("hive-plan-mode").handler("", ctx);
+  assert.equal(state.mode, "plan");
+  assert.ok(h.activeTools().includes("plan_new"));
+
+  await h.commands.get("hive").handler("", ctx);
+  assert.equal(state.mode, "hive");
+  assert.ok(h.activeTools().includes("plan_task_complete"));
+  assert.ok(!h.activeTools().includes("plan_new"));
+
+  state.activeRuns = 1;
+  await h.commands.get("hive-normal").handler("", ctx);
+  assert.equal(state.mode, "hive");
+  assert.match(notifications.at(-1)?.message || "", /Cannot switch mode while 1 agent is running/);
+
+  state.activeRuns = 0;
+  await h.commands.get("hive-normal").handler("", ctx);
+  assert.equal(state.mode, "normal");
+  assert.deepEqual(h.activeTools(), ["read", "bash"]);
+});
+
+test("hive-execute selects an approved change, enters hive mode, and sends the execution turn", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  state.mode = "plan";
+  state.normalToolNames = ["read"];
+  const { ctx, notifications } = context();
+  registerCommands(h.pi, state, commandDeps());
+
+  await h.commands.get("hive-execute").handler("approved-change", ctx);
+
+  assert.equal(state.activeChangeId, "approved-change");
+  assert.equal(state.mode, "hive");
+  assert.equal(h.messages.length, 1);
+  assert.match(h.messages[0], /Execute the approved plan/);
+  assert.match(h.messages[0], /1\.1 Build it/);
+  assert.match(notifications.at(-1)?.message || "", /Executing plan "approved-change"/);
+});
+
+test("hive-execute does not send work when a running planner blocks the mode switch", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  state.mode = "plan";
+  state.activeRuns = 1;
+  const { ctx, notifications } = context();
+  registerCommands(h.pi, state, commandDeps());
+
+  await h.commands.get("hive-execute").handler("approved-change", ctx);
+
+  assert.equal(state.mode, "plan");
+  assert.equal(h.messages.length, 0);
+  assert.match(notifications.at(-1)?.message || "", /Cannot execute.*1 agent is running/);
+});
+
+test("dashboard commands cover uninitialized, restart, stop, and authenticated prune flows", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  const { ctx, notifications } = context();
+  let starts = 0;
+  let stops = 0;
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  registerCommands(h.pi, state, commandDeps({
+    ensureDashboard: async (_state, _ctx, _root, options) => {
+      starts++;
+      assert.deepEqual(options, { open: true, forceRestart: true });
+      return { running: true, url: "http://127.0.0.1:43191", adopted: false, spawned: true };
+    },
+    stopDashboard: async () => { stops++; return [43210]; },
+    fetch: async (input, init) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify({ events: 7, sessions: 2 }), { headers: { "content-type": "application/json" } });
+    },
+  }));
+
+  await h.commands.get("hive-observe").handler("", ctx);
+  assert.equal(starts, 0);
+  assert.match(notifications.at(-1)?.message || "", /not initialized/);
+
+  state.session = { sessionId: "s1", sessionDir: ctx.cwd, conversationLog: join(ctx.cwd, "conversation.jsonl"), observabilityLog: join(ctx.cwd, "events.jsonl") };
+  await h.commands.get("hive-observe").handler("", ctx);
+  assert.equal(starts, 1);
+  assert.match(notifications.at(-1)?.message || "", /telemetry restarted/);
+
+  await h.commands.get("hive-observe-stop").handler("", ctx);
+  assert.equal(stops, 1);
+  assert.match(notifications.at(-1)?.message || "", /43210/);
+
+  await h.commands.get("hive-observe-prune").handler("not-a-number", ctx);
+  assert.equal(requests.length, 0);
+  assert.match(notifications.at(-1)?.message || "", /Usage/);
+
+  await h.commands.get("hive-observe-prune").handler("30", ctx);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "http://127.0.0.1:43191/prune");
+  assert.equal(new Headers(requests[0].init?.headers).get("authorization"), "Bearer test-token");
+  assert.deepEqual(JSON.parse(String(requests[0].init?.body)), { olderThanDays: 30 });
+  assert.match(notifications.at(-1)?.message || "", /Pruned 7 events and 2 sessions/);
+});

--- a/tests/session-lifecycle.integration.test.ts
+++ b/tests/session-lifecycle.integration.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { dispatchAgent, type CreateAgentSession } from "../src/engine/dispatch.ts";
+import { createState } from "../src/engine/state.ts";
+import { registerHooks } from "../src/integration/hooks.ts";
+import { applyMode } from "../src/ui/tui/widget.ts";
+
+function hiveProject(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-session-lifecycle-"));
+  const agents = join(cwd, ".pi", "hive", "agents");
+  mkdirSync(agents, { recursive: true });
+  const prompt = (type: string, text: string) => `---\nmodel: test/model\nthinking: off\nagent-type: ${type}\n---\n${text}\n`;
+  writeFileSync(join(agents, "planner.md"), prompt("planner", "Plan changes."));
+  writeFileSync(join(agents, "lead.md"), prompt("lead", "Coordinate execution."));
+  writeFileSync(join(agents, "builder.md"), prompt("lead", "Build delegated work."));
+  writeFileSync(join(cwd, ".pi", "hive", "hive-config.yaml"), `
+settings:
+  telemetry:
+    enabled: false
+    dashboard-auto-start: false
+  distiller:
+    enabled: false
+planning:
+  main:
+    name: Planning Lead
+    path: .pi/hive/agents/planner.md
+  agents: []
+hive:
+  main:
+    name: Execution Lead
+    path: .pi/hive/agents/lead.md
+  agents:
+    - name: Builder
+      path: .pi/hive/agents/builder.md
+`);
+  return cwd;
+}
+
+function extensionHarness() {
+  const handlers = new Map<string, Array<(event: any, ctx: any) => any>>();
+  const sent: string[] = [];
+  const entries: any[] = [];
+  let activeTools = ["read", "bash"];
+  const pi = {
+    on(event: string, handler: (event: any, ctx: any) => any) {
+      const current = handlers.get(event) || [];
+      current.push(handler);
+      handlers.set(event, current);
+    },
+    async fire(event: string, payload: any, ctx: any) {
+      for (const handler of handlers.get(event) || []) await handler(payload, ctx);
+    },
+    getActiveTools: () => activeTools,
+    getAllTools: () => ["read", "bash", "route_agent"].map((name) => ({ name })),
+    setActiveTools(tools: string[]) { activeTools = [...tools]; },
+    sendUserMessage(message: string) { sent.push(message); },
+    appendEntry(customType: string, data: any) { entries.push({ type: "custom", customType, data }); },
+  } as any;
+  return { pi, handlers, sent, entries, activeTools: () => activeTools };
+}
+
+function lifecycleContext(cwd: string, entries: any[]) {
+  const notifications: any[] = [];
+  const statuses: any[] = [];
+  const widgets: any[] = [];
+  const ctx = {
+    cwd,
+    mode: "rpc",
+    hasUI: true,
+    modelRegistry: { find: () => ({ provider: "test", id: "model", modelId: "model" }), getAll: (): any[] => [] },
+    sessionManager: { getEntries: () => entries },
+    ui: {
+      notify(...args: any[]) { notifications.push(args); },
+      setStatus(...args: any[]) { statuses.push(args); },
+      setWidget(...args: any[]) { widgets.push(args); },
+      setHeader() {},
+      setWorkingVisible() {},
+    },
+  } as any;
+  return { ctx, notifications, statuses, widgets };
+}
+
+test("session start loads an opted-in team and shutdown aborts an active worker through final cleanup", async () => {
+  const cwd = hiveProject();
+  const h = extensionHarness();
+  const state = createState(h.pi);
+  const { ctx, notifications, statuses } = lifecycleContext(cwd, h.entries);
+  registerHooks(h.pi, state);
+
+  await h.pi.fire("session_start", {}, ctx);
+
+  assert.equal(state.mode, "normal");
+  assert.equal(state.widgetCtx, ctx);
+  assert.equal(state.shuttingDown, false);
+  assert.equal(state.config?.orchestrator.name, "Execution Lead");
+  assert.ok(
+    Array.from(state.runtimes.values()).some((runtime) => runtime.config.name === "Builder"),
+    `loaded runtimes: ${Array.from(state.runtimes.values()).map((runtime) => runtime.config.name).join(", ")}; notifications: ${JSON.stringify(notifications)}`,
+  );
+  assert.deepEqual(h.activeTools(), ["read", "bash"]);
+  assert.equal(typeof state.onRuntimeUpdate, "function");
+  assert.equal(typeof state.onRuntimeFinish, "function");
+
+  assert.equal(applyMode(state, ctx, "hive", { notify: false }), true);
+  const worker = Array.from(state.runtimes.values()).find((runtime) => runtime.config.name === "Builder")!;
+  let aborts = 0;
+  let disposals = 0;
+  let releasePrompt: (() => void) | undefined;
+  const createSession: CreateAgentSession = (async () => ({ session: {
+    subscribe(): () => void { return () => undefined; },
+    getAvailableThinkingLevels(): string[] { return ["off"]; },
+    getContextUsage(): { percent: number } { return { percent: 0 }; },
+    getSessionStats(): any { return { tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, cost: { total: 0 } }; },
+    state: { errorMessage: undefined },
+    async prompt(): Promise<void> { await new Promise<void>((resolve) => { releasePrompt = resolve; }); },
+    async abort(): Promise<void> { aborts++; releasePrompt?.(); },
+    dispose(): void { disposals++; },
+  } } as any)) as any;
+
+  const running = dispatchAgent(state, "Builder", "hold until shutdown", ctx, false, createSession);
+  while (state.activeRuns === 0 || !worker.session) await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(state.activeRuns, 1);
+
+  await h.pi.fire("session_shutdown", {}, ctx);
+  const result = await running;
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.output, /aborted|shutting down/i);
+  assert.equal(state.shuttingDown, true);
+  assert.equal(state.activeRuns, 0);
+  assert.equal(worker.session, undefined);
+  assert.equal(worker.timer, undefined);
+  assert.ok(aborts >= 1);
+  assert.ok(disposals >= 1);
+  assert.equal(state.onRuntimeUpdate, undefined);
+  assert.equal(state.onRuntimeFinish, undefined);
+  assert.equal(state.dashboardActionTimer, undefined);
+  assert.equal(state.obsServer, undefined);
+  assert.ok(statuses.some(([name, value]) => name === "hive" && value === undefined));
+});


### PR DESCRIPTION
## Summary
- add injectable command dependencies for deterministic integration coverage
- test mode switching, approved execution, active-worker guards, dashboard restart/stop, and authenticated pruning
- test opted-in session startup plus shutdown-driven worker abort and unconditional cleanup
- report workers aborted during session shutdown as failed rather than successfully completed

## Verification
- `just ci`
- 248 Node tests passed
- 61 Bun tests passed