### PR TITLE
test: enforce core line coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -270,7 +270,7 @@ test-db:
 [group('quality')]
 coverage-core:
   rm -rf coverage/core
-  npx c8 --all --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
+  npx c8 --all --check-coverage --lines=85 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
   rm -rf coverage/.tmp
 
 # Generate Bun coverage for SQLite and dashboard-server modules.

--- a/tests/command-integration.test.ts
+++ b/tests/command-integration.test.ts
@@ -175,3 +175,86 @@ test("dashboard commands cover uninitialized, restart, stop, and authenticated p
   assert.deepEqual(JSON.parse(String(requests[0].init?.body)), { olderThanDays: 30 });
   assert.match(notifications.at(-1)?.message || "", /Pruned 7 events and 2 sessions/);
 });
+
+test("plan and execute commands report every fail-closed artifact state", async () => {
+  const cases: Array<{ overrides: Partial<typeof openspec>; expected: RegExp }> = [
+    { overrides: {}, expected: /Usage: \/hive-execute/ },
+    { overrides: { changeExists: () => false }, expected: /No OpenSpec change/ },
+    { overrides: { hasTasks: () => false }, expected: /has no tasks\.md/ },
+    { overrides: { isReadyToExecute: () => false }, expected: /is not ready/ },
+    { overrides: { isApprovedForExecution: () => false }, expected: /is not approved/ },
+  ];
+
+  for (const [index, entry] of cases.entries()) {
+    const h = harness();
+    const state = createState(h.pi);
+    const { ctx, notifications } = context();
+    registerCommands(h.pi, state, commandDeps({ openspec: fakeOpenSpec(entry.overrides) }));
+    await h.commands.get("hive-execute").handler(index === 0 ? "" : "candidate", ctx);
+    assert.match(notifications.at(-1)?.message || "", entry.expected);
+    assert.equal(h.messages.length, 0);
+  }
+});
+
+test("plan command selects, lists, and rejects changes", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  const { ctx, notifications } = context();
+  registerCommands(h.pi, state, commandDeps({
+    openspec: fakeOpenSpec({
+      listChanges: () => [
+        { name: "ready", status: "in-progress", completedTasks: 0, totalTasks: 1 },
+        { name: "draft", status: "in-progress", completedTasks: 0, totalTasks: 0 },
+      ],
+      changeExists: (_cwd, id) => id === "ready",
+      hasTasks: (_cwd, id) => id === "ready",
+    }),
+  }));
+
+  const execute = h.commands.get("hive-execute");
+  state.widgetCtx = { cwd: ctx.cwd } as any;
+  assert.deepEqual(execute.getArgumentCompletions("re"), [{ value: "ready", label: "ready" }]);
+
+  await h.commands.get("hive-plan").handler("missing", ctx);
+  assert.match(notifications.at(-1)?.message || "", /No OpenSpec change/);
+
+  await h.commands.get("hive-plan").handler("ready", ctx);
+  assert.equal(state.activeChangeId, "ready");
+  assert.match(notifications.at(-1)?.message || "", /Active plan change/);
+
+  await h.commands.get("hive-plan").handler("", ctx);
+  assert.match(notifications.at(-1)?.message || "", /ready \(active\).*tasks ready/s);
+  assert.match(notifications.at(-1)?.message || "", /draft/);
+});
+
+test("dashboard command error paths stay visible and bounded", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  const { ctx, notifications } = context();
+  state.session = { sessionId: "s1", sessionDir: ctx.cwd, conversationLog: "", observabilityLog: "" };
+  let observeResult: any = { running: false, url: "", adopted: false, spawned: false, bunMissing: true };
+  let pruneMode: "status" | "throw" = "status";
+  registerCommands(h.pi, state, commandDeps({
+    ensureDashboard: async () => observeResult,
+    stopDashboard: async () => [],
+    fetch: async () => {
+      if (pruneMode === "throw") throw new Error("connection refused");
+      return new Response("no", { status: 503 });
+    },
+  }));
+
+  await h.commands.get("hive-observe").handler("", ctx);
+  assert.match(notifications.at(-1)?.message || "", /Bun is not installed/);
+  observeResult = { running: false, url: "", adopted: false, spawned: false, error: "bind failed" };
+  await h.commands.get("hive-observe").handler("", ctx);
+  assert.match(notifications.at(-1)?.message || "", /bind failed/);
+
+  await h.commands.get("hive-observe-stop").handler("", ctx);
+  assert.match(notifications.at(-1)?.message || "", /No pi-hive telemetry dashboard/);
+
+  await h.commands.get("hive-observe-prune").handler("1", ctx);
+  assert.match(notifications.at(-1)?.message || "", /Prune failed \(503\)/);
+  pruneMode = "throw";
+  await h.commands.get("hive-observe-prune").handler("1", ctx);
+  assert.match(notifications.at(-1)?.message || "", /connection refused/);
+});

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -12,6 +12,10 @@ import {
   dashboardUrl,
   daemonTokenPath,
   ensureDashboard,
+  isHiveDashboard,
+  probeDashboard,
+  readDaemonToken,
+  requestDaemonShutdown,
   stopDashboard,
   type EnsureDeps,
 } from "../src/engine/dashboard.ts";
@@ -242,6 +246,111 @@ test("refuses to stop a daemon belonging to different storage", async () => {
   });
   assert.deepEqual(stopped, []);
   assert.equal(shutdownCalls, 0);
+});
+
+test("health probing accepts migration fields and rejects unrelated listeners", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      ok: true, mode: "global", registry: dashboardRegistryPath(), db: dashboardDbPath(),
+    }), { status: 200 }) as any;
+    assert.deepEqual(await probeDashboard(), {
+      ok: true, mode: "global", registry: dashboardRegistryPath(), db: dashboardDbPath(),
+      registryPath: dashboardRegistryPath(), dbPath: dashboardDbPath(),
+    });
+    assert.equal(await isHiveDashboard(), true);
+
+    globalThis.fetch = async () => new Response("no", { status: 503 }) as any;
+    assert.equal(await probeDashboard(), null);
+    globalThis.fetch = async () => new Response(JSON.stringify({ ok: true, mode: "other" })) as any;
+    assert.equal(await probeDashboard(), null);
+    globalThis.fetch = async () => { throw new Error("offline"); };
+    assert.equal(await probeDashboard(), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("authenticated shutdown validates token, response, and network failures", async () => {
+  const originalFetch = globalThis.fetch;
+  const health = healthy(expectedIdentity("shutdown"));
+  try {
+    let calls = 0;
+    globalThis.fetch = async (_input, init) => {
+      calls++;
+      assert.equal(new Headers(init?.headers).get("authorization"), "Bearer secret");
+      assert.deepEqual(JSON.parse(String(init?.body)), { startupNonce: "shutdown" });
+      return new Response(null, { status: 202 });
+    };
+    assert.equal(await requestDaemonShutdown(dashboardHost(), dashboardPort(), health, ""), false);
+    assert.equal(calls, 0);
+    assert.equal(await requestDaemonShutdown(dashboardHost(), dashboardPort(), health, "secret"), true);
+    globalThis.fetch = async () => new Response(null, { status: 403 });
+    assert.equal(await requestDaemonShutdown(dashboardHost(), dashboardPort(), health, "secret"), false);
+    globalThis.fetch = async () => { throw new Error("offline"); };
+    assert.equal(await requestDaemonShutdown(dashboardHost(), dashboardPort(), health, "secret"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("startup failures never report a daemon as running", async () => {
+  const invalidPort = process.env.HIVE_TELEMETRY_PORT;
+  process.env.HIVE_TELEMETRY_PORT = "bad";
+  assert.match((await ensureDashboard(state(), ctx, ROOT)).error || "", /Invalid HIVE_TELEMETRY_PORT/);
+  if (invalidPort === undefined) delete process.env.HIVE_TELEMETRY_PORT;
+  else process.env.HIVE_TELEMETRY_PORT = invalidPort;
+
+  const current = healthy(expectedIdentity());
+  const force = deps({ probe: async () => current, stop: async () => [] });
+  assert.match((await ensureDashboard(state(), ctx, ROOT, { forceRestart: true }, force.deps)).error || "", /still running/);
+
+  let probes = 0;
+  const incompatible = deps({
+    probe: async () => (++probes <= 2 ? healthy({ ...expectedIdentity(), packageVersion: "old" }) : null),
+    stop: async () => [],
+  });
+  assert.match((await ensureDashboard(state(), ctx, ROOT, {}, incompatible.deps)).error || "", /Incompatible dashboard is still running/);
+
+  const spawnFailure = deps({ spawn: () => ({ ok: false, error: "spawn denied" }) });
+  assert.equal((await ensureDashboard(state(), ctx, ROOT, {}, spawnFailure.deps)).error, "spawn denied");
+
+  const wrongReady = deps({ waitForReady: async (_host, _port, identity) => healthy({ ...identity, startupNonce: "wrong" }) });
+  assert.match((await ensureDashboard(state(), ctx, ROOT, {}, wrongReady.deps)).error || "", /identity-checked/);
+
+  const lockFailure = deps({ withLock: async () => { throw new Error("lock denied"); } });
+  assert.equal((await ensureDashboard(state(), ctx, ROOT, {}, lockFailure.deps)).error, "lock denied");
+});
+
+test("stop falls back only to its live managed child handle", async () => {
+  const managed = { pid: 777, killed: false, kill() { this.killed = true; return true; }, on() {} } as any;
+  const s = state();
+  s.obsServer = { proc: managed, url: dashboardUrl(), port: dashboardPort(), host: dashboardHost(), adopted: false };
+  let kills = 0;
+  const stopped = await stopDashboard(s, dashboardHost(), dashboardPort(), {
+    probe: async () => null,
+    killManaged: () => { kills++; return 777; },
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.deepEqual(stopped, [777]);
+  assert.equal(kills, 1);
+  assert.equal(s.obsServer, undefined);
+});
+
+test("token reads and IPv6 dashboard URLs fail safely", () => {
+  const isolated = mkdtempSync(join(tmpdir(), "pi-hive-dashboard-token-"));
+  process.env.HIVE_TELEMETRY_REGISTRY = join(isolated, "registry.jsonl");
+  try {
+    assert.equal(readDaemonToken(), undefined);
+    mkdirSync(isolated, { recursive: true });
+    writeFileSync(daemonTokenPath(), "\n");
+    assert.equal(readDaemonToken(), undefined);
+    writeFileSync(daemonTokenPath(), " token \n");
+    assert.equal(readDaemonToken(), "token");
+    assert.equal(dashboardUrl("::1", 1234), "http://[::1]:1234");
+  } finally {
+    delete process.env.HIVE_TELEMETRY_REGISTRY;
+  }
 });
 
 test("host and port validation fail closed; non-loopback requires dangerous opt-in", () => {

--- a/tests/orchestrator-hooks.test.ts
+++ b/tests/orchestrator-hooks.test.ts
@@ -22,7 +22,9 @@ function fakePi() {
       handlers.set(event, list);
     },
     async fire(event: string, payload: any, ctx: any) {
-      for (const h of handlers.get(event) || []) await h(payload, ctx);
+      let result: any;
+      for (const h of handlers.get(event) || []) result = await h(payload, ctx);
+      return result;
     },
   };
 }
@@ -137,4 +139,101 @@ test("model_select re-emits a catalog covering the event's newly-selected model 
   assert.ok(catalog, "expected a model_catalog event after model_select");
   const models = (catalog.payload.models || []).map((m: any) => `${m.provider}/${m.modelId}`);
   assert.ok(models.includes("openai-codex/gpt-5.5"), `catalog should describe the switched-to model; got ${JSON.stringify(models)}`);
+});
+
+test("orchestrator hooks emit bounded telemetry for the full SDK event surface", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-orch-events-"));
+  const obsLog = join(dir, "events.jsonl");
+  const state: HiveState = {
+    mode: "hive",
+    session: { sessionId: "events", sessionDir: dir, observabilityLog: obsLog, conversationLog: join(dir, "conversation.jsonl") },
+    widgetCtx: { cwd: dir },
+    obsSeq: 0,
+    runtimes: new Map(),
+    backgroundTasks: new Set(),
+    backgroundDistillerSessions: new Set(),
+    distillQueues: new Map(),
+    orchestratorRuntime: {
+      config: { name: "Orchestrator" }, status: "idle", toolCount: 0,
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+      reasoningTokens: 0, costUsd: 0, elapsedMs: 0,
+    },
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md", model: "inherit" },
+      agents: [{
+        name: "Lead", slug: "lead", path: "lead.md", routingTags: ["code"], consultWhen: "implementation",
+        children: [{
+          name: "Worker", slug: "worker", path: "worker.md", routingTags: ["tests"], consultWhen: "verification",
+          children: [{ name: "Nested", slug: "nested", path: "nested.md", children: [] }],
+        }],
+      }],
+    },
+  } as any;
+  const pi = fakePi();
+  registerHooks(pi as any, state);
+  const ctx = {
+    cwd: dir,
+    mode: "rpc",
+    hasUI: false,
+    modelRegistry: { getAll: (): any[] => [] },
+    getContextUsage: () => ({ percent: 42, tokens: 420, contextWindow: 1_000 }),
+    ui: { setStatus() {}, setHeader() {}, setWidget() {}, setWorkingVisible() {} },
+  } as any;
+
+  await pi.fire("model_select", {
+    model: { provider: "test", id: "new" }, previousModel: { provider: "test", id: "old" }, source: "user",
+  }, ctx);
+  await pi.fire("thinking_level_select", { level: "high", previousLevel: "low" }, ctx);
+  await pi.fire("session_compact", { reason: "threshold", willRetry: true, fromExtension: true }, ctx);
+
+  for (let turnIndex = 0; turnIndex < 65; turnIndex++) await pi.fire("turn_start", { turnIndex }, ctx);
+  await pi.fire("turn_start", { turnIndex: "not-a-number" }, ctx);
+  await pi.fire("turn_end", { turnIndex: 64 }, ctx);
+  await pi.fire("turn_end", {}, ctx);
+
+  await pi.fire("after_provider_response", { status: 200 }, ctx);
+  await pi.fire("after_provider_response", { status: "invalid" }, ctx);
+  await pi.fire("after_provider_response", {
+    status: 429,
+    headers: { "retry-after": "3", "x-ratelimit-remaining": "0" },
+  }, ctx);
+  await pi.fire("user_bash", { command: "x".repeat(700), excludeFromContext: true }, ctx);
+  await pi.fire("input", { source: "interactive", streamingBehavior: "steer", images: [{}] }, ctx);
+  await pi.fire("session_before_fork", { entryId: "e1", position: 2 }, ctx);
+  await pi.fire("session_tree", { newLeafId: "new", oldLeafId: "old", fromExtension: true }, ctx);
+  await pi.fire("session_info_changed", { name: "n".repeat(300) }, ctx);
+  const prompt = await pi.fire("before_agent_start", { systemPrompt: "base prompt" }, ctx);
+  assert.match(prompt.systemPrompt, /Hive orchestrator mode/);
+  assert.match(prompt.systemPrompt, /Lead/);
+  assert.match(prompt.systemPrompt, /Worker/);
+  assert.match(prompt.systemPrompt, /Nested/);
+
+  state.mode = "plan";
+  const planPrompt = await pi.fire("before_agent_start", { systemPrompt: "base prompt" }, ctx);
+  assert.match(planPrompt.systemPrompt, /Plan mode/);
+  state.mode = "hive";
+
+  await pi.fire("message_end", { message: {
+    role: "assistant",
+    content: [{ type: "text", text: "finished" }],
+    model: "requested", responseModel: "served", provider: "provider", api: "api", responseId: "r1",
+    stopReason: "stop", errorMessage: "e".repeat(700), diagnostics: [{ message: "diagnostic" }],
+    usage: { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, reasoning: 3, cost: { total: 0.25 } },
+  } }, ctx);
+  await pi.fire("message_end", { message: { role: "user", content: [{ type: "text", text: "hello" }] } }, ctx);
+  await pi.fire("message_end", { message: { role: "toolResult", content: "ignored" } }, ctx);
+  await pi.fire("message_end", { message: { role: "assistant", content: [] } }, ctx);
+
+  const events = readEvents(obsLog);
+  for (const type of [
+    "model_select", "thinking_level_select", "orchestrator_compaction", "turn", "provider_response",
+    "user_bash", "input", "session_fork", "session_tree", "session_info_changed",
+    "orchestrator_message", "assistant_message", "user_message",
+  ]) assert.ok(events.some((event) => event.type === type), `missing ${type}`);
+  assert.equal(state.orchestratorRuntime?.contextPct, 42);
+  assert.equal(state.orchestratorRuntime?.inputTokens, 10);
+  assert.equal(state.orchestratorRuntime?.outputTokens, 5);
+  assert.equal(state.orchestratorRuntime?.costUsd, 0.25);
+
+  await pi.fire("session_shutdown", {}, ctx);
 });

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { killProcess, spawnManaged } from "../src/engine/process.ts";
+
+test("managed processes expose identity and forward termination signals", () => {
+  const managed = spawnManaged(process.execPath, ["-e", "setTimeout(() => {}, 10_000)"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  assert.equal(typeof managed.pid, "number");
+  assert.equal(managed.kill("SIGTERM"), true);
+});
+
+test("process cleanup handles child, managed, absent, and throwing handles", () => {
+  const signals: Array<string | undefined> = [];
+  const child = {
+    pid: 123,
+    killed: false,
+    kill(signal?: string) { signals.push(signal); this.killed = true; return true; },
+  } as any;
+  assert.equal(killProcess(child, "SIGINT"), 123);
+  assert.deepEqual(signals, ["SIGINT"]);
+  assert.equal(killProcess(child), 123);
+  assert.deepEqual(signals, ["SIGINT"]);
+
+  const nestedChild = {
+    pid: 456,
+    killed: false,
+    kill(signal?: string) { signals.push(signal); this.killed = true; return true; },
+  } as any;
+  assert.equal(killProcess({ proc: nestedChild, pid: 456, kill: () => true }), 456);
+  assert.equal(killProcess(undefined), undefined);
+
+  const throwing = { pid: 789, killed: false, kill() { throw new Error("gone"); } } as any;
+  assert.equal(killProcess(throwing), 789);
+});

--- a/tests/session-lifecycle.integration.test.ts
+++ b/tests/session-lifecycle.integration.test.ts
@@ -141,3 +141,52 @@ test("session start loads an opted-in team and shutdown aborts an active worker 
   assert.equal(state.obsServer, undefined);
   assert.ok(statuses.some(([name, value]) => name === "hive" && value === undefined));
 });
+
+test("session start fails back to normal mode for malformed opted-in configuration", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-session-invalid-"));
+  mkdirSync(join(cwd, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(cwd, ".pi", "hive", "hive-config.yaml"), "settings:\n  unknown-setting: true\n");
+  const h = extensionHarness();
+  const state = createState(h.pi);
+  const { ctx, notifications } = lifecycleContext(cwd, h.entries);
+  registerHooks(h.pi, state);
+
+  await h.pi.fire("session_start", {}, ctx);
+
+  assert.equal(state.mode, "normal");
+  assert.match(notifications.at(-1)?.[0] || "", /Hive failed to load/);
+});
+
+test("shutdown cleanup is best-effort across failing worker and distiller sessions", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-session-cleanup-"));
+  const h = extensionHarness();
+  const state = createState(h.pi);
+  const workerTimer = setInterval(() => undefined, 10_000);
+  const dashboardTimer = setInterval(() => undefined, 10_000);
+  state.runtimes.set("worker", {
+    timer: workerTimer,
+    session: {
+      abort() { throw new Error("abort failed"); },
+      dispose() { throw new Error("dispose failed"); },
+    },
+  } as any);
+  state.backgroundDistillerSessions = new Set([{
+    abort() { throw new Error("distiller abort failed"); },
+    dispose() { throw new Error("distiller dispose failed"); },
+  } as any]);
+  state.backgroundTasks = new Set([Promise.resolve()]);
+  state.distillQueues = new Map([["target", Promise.resolve()]]);
+  state.dashboardActionTimer = dashboardTimer;
+  const { ctx, statuses, widgets } = lifecycleContext(cwd, h.entries);
+  ctx.mode = "tui";
+  registerHooks(h.pi, state);
+
+  await h.pi.fire("session_shutdown", {}, ctx);
+
+  assert.equal(state.runtimes.get("worker")?.session, undefined);
+  assert.equal(state.backgroundDistillerSessions.size, 0);
+  assert.equal(state.backgroundTasks.size, 0);
+  assert.equal(state.distillQueues.size, 0);
+  assert.ok(widgets.some(([name, value]) => name === "hive-tree" && value === undefined));
+  assert.ok(statuses.some(([name, value]) => name === "hive" && value === undefined));
+});


### PR DESCRIPTION
## Summary
- raise Bun-independent core line coverage from 81.43% to 85.08%
- add fail-closed command, dashboard lifecycle, orchestrator hook, session cleanup, and managed-process regression tests
- enforce the 85% aggregate core line threshold in the coverage recipe

## Coverage
- lines: 85.08%
- branches: 72.41%
- functions: 85.15%
- hooks: 98.70% lines
- commands: 98.46% lines
- process control: 100% lines

The 80% branch gate, remaining critical-module line coverage, Bun server coverage, and dashboard coverage remain subsequent T23 slices.

## Verification
- `just coverage`
- `just ci`
