### PR TITLE
test: raise core branch coverage floor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -270,7 +270,7 @@ test-db:
 [group('quality')]
 coverage-core:
   rm -rf coverage/core
-  npx c8 --all --check-coverage --lines=85 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
+  npx c8 --all --check-coverage --lines=85 --branches=75 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
   rm -rf coverage/.tmp
 
 # Generate Bun coverage for SQLite and dashboard-server modules.

--- a/tests/orchestrator-hooks.test.ts
+++ b/tests/orchestrator-hooks.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -236,4 +236,67 @@ test("orchestrator hooks emit bounded telemetry for the full SDK event surface",
   assert.equal(state.orchestratorRuntime?.costUsd, 0.25);
 
   await pi.fire("session_shutdown", {}, ctx);
+});
+
+test("normal mode suppresses every orchestrator telemetry hook", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-orch-normal-"));
+  const obsLog = join(dir, "events.jsonl");
+  const state = {
+    mode: "normal",
+    session: { sessionId: "normal", sessionDir: dir, observabilityLog: obsLog, conversationLog: join(dir, "conversation.jsonl") },
+    runtimes: new Map(),
+  } as any;
+  const pi = fakePi();
+  registerHooks(pi as any, state);
+  const ctx = { cwd: dir, mode: "rpc", hasUI: false } as any;
+  for (const event of [
+    "tool_call", "tool_result", "model_select", "thinking_level_select", "session_compact",
+    "turn_start", "turn_end", "after_provider_response", "user_bash", "input",
+    "session_before_fork", "session_tree", "session_info_changed", "before_agent_start", "message_end",
+  ]) await pi.fire(event, event === "message_end" ? { message: { role: "user", content: "ignored" } } : {}, ctx);
+  assert.equal(existsSync(obsLog), false);
+});
+
+test("orchestrator telemetry tolerates sparse SDK payloads and missing runtime state", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-orch-sparse-"));
+  const obsLog = join(dir, "events.jsonl");
+  const state = {
+    mode: "hive",
+    session: { sessionId: "sparse", sessionDir: dir, observabilityLog: obsLog, conversationLog: join(dir, "conversation.jsonl") },
+    obsSeq: 0,
+    runtimes: new Map(),
+    config: { orchestrator: { name: "Orchestrator", path: "o.md" }, agents: [] },
+  } as any;
+  const pi = fakePi();
+  registerHooks(pi as any, state);
+  const ctx = {
+    cwd: dir, mode: "rpc", hasUI: false,
+    model: { provider: "fallback", id: "model" },
+    modelRegistry: { getAll: (): any[] => [] },
+  } as any;
+
+  await pi.fire("tool_call", { name: "custom" }, ctx);
+  await pi.fire("tool_result", { name: "custom", result: [{ type: "text", text: "done" }] }, ctx);
+  await pi.fire("model_select", {}, ctx);
+  await pi.fire("thinking_level_select", {}, ctx);
+  await pi.fire("session_compact", {}, ctx);
+  await pi.fire("turn_end", { turnIndex: "unknown" }, ctx);
+  await pi.fire("after_provider_response", {
+    status: 529,
+    headers: { "retry-after": "1", "anthropic-ratelimit-requests-remaining": "2" },
+  }, ctx);
+  await pi.fire("user_bash", {}, ctx);
+  await pi.fire("input", {}, ctx);
+  await pi.fire("session_before_fork", {}, ctx);
+  await pi.fire("session_tree", {}, ctx);
+  await pi.fire("session_info_changed", {}, ctx);
+  await pi.fire("message_end", { message: {
+    role: "assistant", content: "fallback response", responseModel: "served", errorMessage: "failed", diagnostics: "invalid",
+  } }, ctx);
+
+  const events = readEvents(obsLog);
+  assert.ok(events.some((event) => event.type === "orchestrator_tool_start" && event.payload.toolName === "custom"));
+  assert.ok(events.some((event) => event.type === "model_select" && event.payload.model === "fallback/model"));
+  assert.ok(events.some((event) => event.type === "provider_response" && event.payload.rateLimitRemaining === "2"));
+  assert.ok(events.some((event) => event.type === "assistant_message"));
 });

--- a/tests/session-branches.test.ts
+++ b/tests/session-branches.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  currentAgentName,
+  currentChangeId,
+  currentDelegationDepth,
+  restoreOrCreateSession,
+  restoreRuntimeCounters,
+  runAsAgent,
+  runAtDelegationDepth,
+  runWithChange,
+} from "../src/engine/session.ts";
+
+test("session restoration migrates legacy records and creates missing sessions", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-session-record-"));
+  const legacy = { sessionId: "legacy", sessionDir: join(cwd, "legacy"), conversationLog: join(cwd, "legacy.jsonl") };
+  const state = { pi: { appendEntry() { throw new Error("must not append"); } } } as any;
+  const restored = restoreOrCreateSession(state, {
+    cwd,
+    sessionManager: { getEntries: () => [
+      { type: "custom", customType: "other", data: {} },
+      { type: "custom", customType: "hive-session", data: legacy },
+    ] },
+  } as any, {} as any);
+  assert.equal(restored.sessionId, "legacy");
+  assert.equal(restored.observabilityLog, join(legacy.sessionDir, "hive-events.jsonl"));
+
+  const current = { ...legacy, observabilityLog: join(cwd, "events.jsonl") };
+  assert.equal(restoreOrCreateSession(state, {
+    cwd, sessionManager: { getEntries: () => [{ type: "custom", customType: "hive-session", data: current }] },
+  } as any, {} as any).observabilityLog, current.observabilityLog);
+
+  let appended: any;
+  const created = restoreOrCreateSession({ pi: { appendEntry(type: string, data: any) { appended = { type, data }; } } } as any, {
+    cwd, sessionManager: { getEntries: (): any[] => [] },
+  } as any, {} as any);
+  assert.equal(appended.type, "hive-session");
+  assert.equal(appended.data.sessionId, created.sessionId);
+  assert.match(created.conversationLog, /conversation\.jsonl$/);
+});
+
+test("runtime counter restoration handles sparse, corrupt, and explicit snapshots", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-counter-"));
+  const log = join(cwd, "events.jsonl");
+  const runtime = { config: { name: "Worker", slug: "worker" } } as any;
+  const absent = { config: { name: "Absent", slug: "absent" }, inputTokens: 7 } as any;
+  const state = { session: { observabilityLog: log }, runtimes: new Map([["worker", runtime], ["absent", absent]]) } as any;
+
+  restoreRuntimeCounters({ session: {}, runtimes: new Map() } as any);
+  writeFileSync(log, [
+    JSON.stringify({ type: "other", payload: {} }),
+    "{bad delegation_end",
+    JSON.stringify({ type: "distill_start", payload: {} }),
+    JSON.stringify({ type: "distill_start", payload: { agent: "Worker" } }),
+    JSON.stringify({ type: "delegation_end", payload: {} }),
+    JSON.stringify({ type: "delegation_end", payload: { from: "Worker", runtime: { name: "Worker", runCount: 5 } } }),
+    JSON.stringify({ type: "delegation_end", payload: { runtime: {
+      slug: "worker", inputTokens: 10, outputTokens: 4, cacheReadTokens: 3, cacheWriteTokens: 2,
+      reasoningTokens: 1, costUsd: 0.5, governanceTokens: 25, governanceCostUsd: 0.75,
+      runCount: 2, toolCount: 6,
+    } } }),
+    JSON.stringify({ type: "distill_start", payload: { agent: "Worker", distillerRunCount: 3 } }),
+  ].join("\n") + "\n");
+
+  restoreRuntimeCounters(state);
+  assert.deepEqual({
+    input: runtime.inputTokens, output: runtime.outputTokens, cacheRead: runtime.cacheReadTokens,
+    cacheWrite: runtime.cacheWriteTokens, reasoning: runtime.reasoningTokens, cost: runtime.costUsd,
+    governanceTokens: runtime.governanceTokens, governanceCost: runtime.governanceCostUsd,
+    runs: runtime.runCount, tools: runtime.toolCount, distillers: runtime.distillerRunCount,
+  }, {
+    input: 10, output: 4, cacheRead: 3, cacheWrite: 2, reasoning: 1, cost: 0.5,
+    governanceTokens: 25, governanceCost: 0.75, runs: 5, tools: 6, distillers: 3,
+  });
+  assert.equal(absent.inputTokens, 7);
+});
+
+test("async-local session context preserves defaults and nested values", async () => {
+  assert.equal(currentAgentName(), "Orchestrator");
+  assert.equal(currentDelegationDepth(), 0);
+  assert.equal(currentChangeId(), undefined);
+
+  await runAsAgent("Lead", async () => {
+    assert.equal(currentAgentName(), "Lead");
+    await runAtDelegationDepth(2, async () => {
+      assert.equal(currentDelegationDepth(), 2);
+      await runWithChange("change-1", async () => {
+        await Promise.resolve();
+        assert.equal(currentAgentName(), "Lead");
+        assert.equal(currentDelegationDepth(), 2);
+        assert.equal(currentChangeId(), "change-1");
+      });
+    });
+  });
+
+  assert.equal(runWithChange(undefined, currentChangeId), undefined);
+});

--- a/tests/tools-branches.test.ts
+++ b/tests/tools-branches.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { buildHiveTools, registerTools } from "../src/agents/tools.ts";
+
+function runtime(dir: string, name: string, overrides: Record<string, any> = {}): any {
+  return {
+    config: {
+      name, slug: name.toLowerCase(), path: `${name}.md`, role: "member", agentType: "coder",
+      groupName: "Engineering", routingTags: [], domain: [], allowedAgents: [], ...overrides.config,
+    },
+    systemPrompt: "", status: "idle", task: "", lastWork: "", toolCount: 0, elapsedMs: 0,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, reasoningTokens: 0,
+    costUsd: 0, contextPct: 0, runCount: 0, sessionFile: join(dir, `${name}.jsonl`),
+    ...overrides,
+  };
+}
+
+function toolState(dir: string): any {
+  const rows = [
+    runtime(dir, "Tiny", { contextPct: Number.NaN, contextWindow: Number.NaN, inputTokens: 20, outputTokens: 5 }),
+    runtime(dir, "Warm", { contextPct: 76, contextWindow: 8_000, inputTokens: 1_000, outputTokens: 1_000 }),
+    runtime(dir, "Full", { contextPct: 86, contextTokens: 5_000_000, contextWindow: 20_000_000, inputTokens: 20_000, outputTokens: 40_000, task: "working" }),
+  ];
+  return {
+    pi: {}, mode: "hive", activeRuns: 2, workerQueue: [{}, {}], activeChangeId: undefined,
+    config: {
+      orchestrator: { name: "Orchestrator", path: "o.md", role: "orchestrator", allowedAgents: rows.map((r) => r.config.slug) },
+      agents: rows.map((r) => r.config), sharedContext: [],
+      settings: { subagentOutputLimit: 100, defaultTools: "read", maxParallel: 3, distiller: { enabled: false, model: "", conversationLines: 10 } },
+    },
+    session: { sessionId: "s1", sessionDir: dir, conversationLog: join(dir, "conversation.jsonl"), observabilityLog: join(dir, "events.jsonl") },
+    runtimes: new Map(rows.map((row) => [row.config.slug, row])),
+    latestVerdicts: new Map([
+      ["red", { changeId: "red", reviewer: "R", verdict: "red", blockers: ["b"], concerns: [], summary: "blocked" }],
+      ["yellow", { changeId: "yellow", reviewer: "R", verdict: "yellow", blockers: [], concerns: ["c"], summary: "concern" }],
+      ["green", { changeId: "green", reviewer: "R", verdict: "green", blockers: [], concerns: [], summary: "clean" }],
+    ]),
+  };
+}
+
+const theme = {
+  fg: (_color: string, value: string) => value,
+  bold: (value: string) => value,
+};
+
+test("team status formats sparse context, budgets, queues, and verdict variants", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-tools-status-"));
+  const state = toolState(dir);
+  const tools = buildHiveTools(state, "Orchestrator") as any[];
+  const status = tools.find((tool) => tool.name === "team_status");
+  const result = await status.execute("id", {});
+  const text = result.content[0].text;
+  assert.match(text, /active_runs: 2/);
+  assert.match(text, /queued_runs: 2/);
+  assert.match(text, /resume-ok/);
+  assert.match(text, /consider-fresh/);
+  assert.match(text, /fresh-recommended/);
+  assert.match(text, /1 blocker/);
+  assert.match(text, /1 concern/);
+  assert.equal(result.details.agents.length, 3);
+
+  state.session = undefined;
+  state.workerQueue = undefined;
+  state.latestVerdicts = new Map();
+  const empty = await status.execute("id", {});
+  assert.match(empty.content[0].text, /session: not initialized/);
+  assert.match(empty.content[0].text, /queued_runs: 0/);
+});
+
+test("team conversation rejects unsafe scopes and bounds known transcripts", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-tools-conversation-"));
+  const state = toolState(dir);
+  const tool = (buildHiveTools(state, "Orchestrator") as any[]).find((entry) => entry.name === "team_conversation");
+
+  const session = state.session;
+  state.session = undefined;
+  assert.match((await tool.execute("id", { agent: "Tiny" })).content[0].text, /not initialized/);
+  state.session = session;
+  assert.equal((await tool.execute("id", { lines: Number.NaN })).details.ok, false);
+  assert.match((await tool.execute("id", { agent: "missing", lines: -1 })).content[0].text, /Unknown agent/);
+  assert.match((await tool.execute("id", { agent: "Tiny", lines: 5 })).content[0].text, /no session transcript/);
+
+  const tiny = state.runtimes.get("tiny");
+  writeFileSync(tiny.sessionFile, Array.from({ length: 20 }, (_, i) => JSON.stringify({ i })).join("\n"));
+  const result = await tool.execute("id", { agent: "tiny", lines: 50_000 });
+  assert.equal(result.details.ok, true);
+  assert.equal(result.details.lines, 1_000);
+  assert.ok(result.content[0].text.length <= 100);
+});
+
+test("tool renderers remain bounded for partial, expanded, success, and error states", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-tools-render-"));
+  const state = toolState(dir);
+  const delegate = (buildHiveTools(state, "Orchestrator") as any[]).find((tool) => tool.name === "delegate_agent");
+
+  assert.deepEqual(delegate.renderCall({}, theme).render(1), []);
+  assert.equal(delegate.renderCall({ agent: "Tiny", task: "inspect" }, theme).render(80).length, 1);
+  assert.deepEqual(delegate.renderResult({ details: { status: "running" } }, { isPartial: true }, theme).render(80), []);
+  assert.equal(delegate.renderResult({ details: { agent: "Tiny", status: "done", elapsed: 1_500, outputPreview: "ok" } }, { expanded: true }, theme).render(80).length, 2);
+  assert.equal(delegate.renderResult({ details: { agent: "missing", status: "error" } }, {}, theme).render(80).length, 1);
+});
+
+test("routing handles empty matches and registerTools exposes every base tool", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-tools-route-"));
+  const state = toolState(dir);
+  const route = (buildHiveTools(state, "Orchestrator") as any[]).find((tool) => tool.name === "route_agent");
+  const noMatch = await route.execute("id", { task: "zz", limit: Number.POSITIVE_INFINITY });
+  assert.match(noMatch.content[0].text, /No strong route found/);
+  const match = await route.execute("id", { task: "implement engineering code", limit: 2.9 });
+  assert.ok(match.details.recommendations.length > 0);
+  assert.ok(match.details.recommendations.length <= 2);
+
+  const registered: string[] = [];
+  registerTools({ registerTool(tool: any) { registered.push(tool.name); } } as any, state);
+  assert.ok(registered.includes("delegate_agent"));
+  assert.ok(registered.includes("plan_new"));
+});


### PR DESCRIPTION
## Summary
- raise core branch coverage from 72.41% to 75.63%
- enforce a 75% branch-coverage floor alongside the existing 85% line gate
- cover normal-mode telemetry suppression and sparse SDK payloads
- cover legacy session restoration, sparse runtime counter recovery, and async-local context
- cover tool status, transcript bounds, rendering states, routing, and registration

## Coverage
- lines: 86.07%
- branches: 75.63%
- functions: 87.11%
- orchestrator hooks: 86.32% branches
- agent tools: 82.05% branches

The final T23 branch target remains 80%; this PR establishes the next enforced ratchet toward it.

## Verification
- `just coverage`
- `just ci`
