### PR TITLE
test: enforce core branch coverage target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -270,7 +270,7 @@ test-db:
 [group('quality')]
 coverage-core:
   rm -rf coverage/core
-  npx c8 --all --check-coverage --lines=85 --branches=75 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
+  npx c8 --all --check-coverage --lines=85 --branches=80 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=json --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
   rm -rf coverage/.tmp
 
 # Generate Bun coverage for SQLite and dashboard-server modules.

--- a/tests/agent-type-audit-branches.test.ts
+++ b/tests/agent-type-audit-branches.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { auditAgentTypes } from "../src/core/agent-type-audit.ts";
+
+function fixture(config: string): string {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-agent-audit-"));
+  mkdirSync(join(cwd, ".pi", "hive", "agents"), { recursive: true });
+  writeFileSync(join(cwd, ".pi", "hive", "hive-config.yaml"), config);
+  return cwd;
+}
+
+test("agent-type audit tolerates absent and non-object configurations", () => {
+  const missing = mkdtempSync(join(tmpdir(), "pi-hive-agent-audit-missing-"));
+  assert.deepEqual(auditAgentTypes(missing), { rows: [], offenders: [] });
+  assert.deepEqual(auditAgentTypes(fixture("null\n")), { rows: [], offenders: [] });
+  assert.deepEqual(auditAgentTypes(fixture("planning: text\nhive: false\n")), { rows: [], offenders: [] });
+});
+
+test("agent-type audit walks legacy, explicit, nested, duplicate, and sparse nodes", () => {
+  const cwd = fixture(`
+main:
+  name: Shared Lead
+  path: .pi/hive/agents/shared.md
+agents:
+  - name: Direct Coder
+    path: .pi/hive/agents/direct.md
+    agentType: coder
+    members:
+      - name: Frontmatter Reviewer
+        path: .pi/hive/agents/reviewer.md
+      - ignored
+    children:
+      - path: .pi/hive/agents/empty.md
+      - name: Escaping
+        path: ../outside.md
+planning:
+  orchestrator:
+    name: Shared Lead
+    path: .pi/hive/agents/shared.md
+  agents: not-an-array
+`);
+  writeFileSync(join(cwd, ".pi", "hive", "agents", "shared.md"), "---\nagent-type: lead\n---\nLead");
+  writeFileSync(join(cwd, ".pi", "hive", "agents", "reviewer.md"), "---\nagent-type: reviewer\n---\nReview");
+  writeFileSync(join(cwd, ".pi", "hive", "agents", "empty.md"), "");
+
+  const audit = auditAgentTypes(cwd);
+  assert.equal(audit.rows.filter((row) => row.name === "Shared Lead").length, 1);
+  assert.equal(audit.rows.find((row) => row.name === "Direct Coder")?.declared, "coder");
+  assert.equal(audit.rows.find((row) => row.name === "Frontmatter Reviewer")?.declared, "reviewer");
+  assert.ok(audit.rows.some((row) => row.name === "(unnamed)"));
+  assert.ok(audit.rows.some((row) => row.name === "Escaping" && !row.valid));
+  assert.ok(audit.offenders.length >= 2);
+});
+
+test("explicit hive block accepts orchestrator aliases and missing paths", () => {
+  const cwd = fixture(`
+hive:
+  orchestrator:
+    name: Inline Lead
+    agentType: lead
+  agents:
+    - name: No Path Coder
+      agentType: coder
+    - name: Missing File
+      path: .pi/hive/agents/missing.md
+`);
+  const audit = auditAgentTypes(cwd);
+  assert.equal(audit.rows.find((row) => row.name === "Inline Lead")?.valid, true);
+  assert.equal(audit.rows.find((row) => row.name === "No Path Coder")?.valid, true);
+  assert.equal(audit.rows.find((row) => row.name === "Missing File")?.declared, undefined);
+});

--- a/tests/command-integration.test.ts
+++ b/tests/command-integration.test.ts
@@ -227,6 +227,51 @@ test("plan command selects, lists, and rejects changes", async () => {
   assert.match(notifications.at(-1)?.message || "", /draft/);
 });
 
+test("headless command handlers fail safely without attempting UI notifications", async () => {
+  const h = harness();
+  const state = createState(h.pi);
+  const { ctx } = context();
+  ctx.hasUI = false;
+  let fetchMode: "status" | "throw" = "status";
+  registerCommands(h.pi, state, commandDeps({
+    openspec: fakeOpenSpec({ changeExists: () => false }),
+    fetch: async () => {
+      if (fetchMode === "throw") throw new Error("offline");
+      return new Response("no", { status: 503 });
+    },
+  }));
+
+  await h.commands.get("hive-doctor").handler("", ctx);
+  await h.commands.get("hive-execute").handler("", ctx);
+  await h.commands.get("hive-execute").handler("missing", ctx);
+  await h.commands.get("hive-plan").handler("missing", ctx);
+  await h.commands.get("hive-plan").handler("", ctx);
+  await h.commands.get("hive-observe").handler("", ctx);
+
+  state.session = { sessionId: "s1", sessionDir: ctx.cwd, conversationLog: "", observabilityLog: "" };
+  await h.commands.get("hive-observe").handler("", ctx);
+  await h.commands.get("hive-observe-stop").handler("", ctx);
+  await h.commands.get("hive-observe-prune").handler("bad", ctx);
+  await h.commands.get("hive-observe-prune").handler("1", ctx);
+  fetchMode = "throw";
+  await h.commands.get("hive-observe-prune").handler("1", ctx);
+
+  const blocked = harness();
+  const blockedState = createState(blocked.pi);
+  blockedState.mode = "plan";
+  blockedState.activeRuns = 2;
+  const warning = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: any[]) => warnings.push(args.join(" "));
+  try {
+    registerCommands(blocked.pi, blockedState, commandDeps());
+    await blocked.commands.get("hive-execute").handler("approved-change", ctx);
+  } finally {
+    console.warn = warning;
+  }
+  assert.match(warnings.join("\n"), /Cannot execute/);
+});
+
 test("dashboard command error paths stay visible and bounded", async () => {
   const h = harness();
   const state = createState(h.pi);

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -248,6 +248,29 @@ test("refuses to stop a daemon belonging to different storage", async () => {
   assert.equal(shutdownCalls, 0);
 });
 
+test("dashboard paths and loopback host normalization honor explicit environment values", () => {
+  const original = {
+    registry: process.env.HIVE_TELEMETRY_REGISTRY,
+    db: process.env.HIVE_TELEMETRY_DB,
+    host: process.env.HIVE_TELEMETRY_HOST,
+  };
+  const isolated = mkdtempSync(join(tmpdir(), "pi-hive-dashboard-paths-"));
+  try {
+    process.env.HIVE_TELEMETRY_REGISTRY = join(isolated, "custom-registry.jsonl");
+    process.env.HIVE_TELEMETRY_DB = join(isolated, "custom.db");
+    assert.equal(dashboardRegistryPath(), join(isolated, "custom-registry.jsonl"));
+    assert.equal(dashboardDbPath(), join(isolated, "custom.db"));
+    for (const [raw, expected] of [["localhost", "localhost"], ["[::1]", "::1"], ["::1", "::1"]]) {
+      process.env.HIVE_TELEMETRY_HOST = raw;
+      assert.equal(dashboardHost(), expected);
+    }
+  } finally {
+    if (original.registry === undefined) delete process.env.HIVE_TELEMETRY_REGISTRY; else process.env.HIVE_TELEMETRY_REGISTRY = original.registry;
+    if (original.db === undefined) delete process.env.HIVE_TELEMETRY_DB; else process.env.HIVE_TELEMETRY_DB = original.db;
+    if (original.host === undefined) delete process.env.HIVE_TELEMETRY_HOST; else process.env.HIVE_TELEMETRY_HOST = original.host;
+  }
+});
+
 test("health probing accepts migration fields and rejects unrelated listeners", async () => {
   const originalFetch = globalThis.fetch;
   try {
@@ -259,6 +282,16 @@ test("health probing accepts migration fields and rejects unrelated listeners", 
       registryPath: dashboardRegistryPath(), dbPath: dashboardDbPath(),
     });
     assert.equal(await isHiveDashboard(), true);
+
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      ok: true, mode: "global", registryPath: dashboardRegistryPath(), dbPath: dashboardDbPath(),
+      pid: 1, protocolVersion: 1, packageVersion: "x", buildHash: "x", startupNonce: "x",
+    })) as any;
+    assert.equal((await probeDashboard())?.registryPath, dashboardRegistryPath());
+    globalThis.fetch = async () => new Response(JSON.stringify({ ok: true, mode: "global", registry: dashboardRegistryPath() })) as any;
+    assert.equal(await probeDashboard(), null);
+    globalThis.fetch = async () => new Response("not json") as any;
+    assert.equal(await probeDashboard(), null);
 
     globalThis.fetch = async () => new Response("no", { status: 503 }) as any;
     assert.equal(await probeDashboard(), null);
@@ -335,6 +368,32 @@ test("stop falls back only to its live managed child handle", async () => {
   assert.deepEqual(stopped, [777]);
   assert.equal(kills, 1);
   assert.equal(s.obsServer, undefined);
+});
+
+test("managed child fallback requires exact live daemon identity", async () => {
+  const health = healthy(expectedIdentity("managed"), { pid: 888 });
+  const managed = { pid: 888, killed: false, kill() { this.killed = true; return true; }, on() {} } as any;
+  const s = state();
+  s.obsServer = { proc: managed, url: dashboardUrl(), port: dashboardPort(), host: dashboardHost(), adopted: false };
+  let kills = 0;
+  let running = true;
+  const stopped = await stopDashboard(s, dashboardHost(), dashboardPort(), {
+    probe: async () => running ? health : null,
+    requestShutdown: async () => false,
+    killManaged: () => { kills++; running = false; return 888; },
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.deepEqual(stopped, [888]);
+  assert.equal(kills, 1);
+
+  const alreadyKilled = state();
+  alreadyKilled.obsServer = { proc: { ...managed, killed: true }, url: dashboardUrl(), port: dashboardPort(), host: dashboardHost(), adopted: false } as any;
+  const none = await stopDashboard(alreadyKilled, dashboardHost(), dashboardPort(), {
+    probe: async () => null,
+    killManaged: () => { throw new Error("must not kill twice"); },
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.deepEqual(none, []);
 });
 
 test("token reads and IPv6 dashboard URLs fail safely", () => {

--- a/tests/dispatch-usage.test.ts
+++ b/tests/dispatch-usage.test.ts
@@ -304,7 +304,16 @@ test("dispatchAgent enforces optional timeout and nested delegation depth", asyn
     dispose(): void { /* noop */ },
   } } as any)) as any;
 
-  const timed = await dispatchAgent(state, "Builder", "slow task", ctx, false, create);
+  // dispatchAgent deliberately unrefs its timeout so a worker cannot keep Pi
+  // alive by itself. Keep this test process referenced while awaiting that
+  // timeout; coverage instrumentation can otherwise leave no active handles.
+  const keepAlive = setInterval(() => undefined, 1_000);
+  let timed;
+  try {
+    timed = await dispatchAgent(state, "Builder", "slow task", ctx, false, create);
+  } finally {
+    clearInterval(keepAlive);
+  }
   assert.equal(timed.exitCode, 1);
   assert.match(timed.output, /timed out after 10ms/i);
   assert.equal(state.activeRuns, 0);

--- a/tests/domain-routing.test.ts
+++ b/tests/domain-routing.test.ts
@@ -153,6 +153,31 @@ test("routeAgents scores specialists and respects delegation hierarchy", () => {
   }
 });
 
+test("routeAgents scores capability types and SDD phase groups", () => {
+  const specialists = [
+    runtime("Planning Specialist", { role: "lead", agentType: "planner", groupName: "Planning", consultWhen: "requirements and product scope", routingTags: ["proposal"], responsibilities: ["design specs"] }),
+    runtime("Implementation Coder", { role: "lead", agentType: "coder", groupName: "Engineering", consultWhen: "backend component", domain: [{ path: "src/api", description: "service migration", read: true, upsert: true, delete: false }] }),
+    runtime("QA Tester", { role: "lead", agentType: "tester", groupName: "QA Validation", consultWhen: "acceptance evidence" }),
+    runtime("Security Reviewer", { role: "lead", agentType: "reviewer", groupName: "Validation", consultWhen: "auth permission review" }),
+  ];
+  const state = stateWith([
+    runtime("Orchestrator", { role: "orchestrator", allowedAgents: specialists.map((entry) => entry.config.name) }),
+    ...specialists,
+  ]);
+
+  const task = "plan product requirements proposal design specs tasks; implement backend API service migration component; test QA acceptance evidence; security auth permission review; apply-progress implementation; verify-report release confidence";
+  const matches = runAsAgent("Orchestrator", () => routeAgents(state, task, 1000));
+  assert.deepEqual(new Set(matches.map((match) => match.name)), new Set(specialists.map((entry) => entry.config.name)));
+  assert.ok(matches.find((match) => match.name === "Planning Specialist")?.reasons.includes("planning-group"));
+  assert.ok(matches.find((match) => match.name === "Implementation Coder")?.reasons.includes("coder-type"));
+  assert.ok(matches.find((match) => match.name === "QA Tester")?.reasons.includes("tester-type"));
+  assert.ok(matches.find((match) => match.name === "Security Reviewer")?.reasons.includes("reviewer-type"));
+
+  state.mode = "plan";
+  const planning = runAsAgent("Orchestrator", () => routeAgents(state, task));
+  assert.equal(planning.some((match) => ["Implementation Coder", "QA Tester"].includes(match.name)), false);
+});
+
 test("buildOrchestratorPrompt routes to the ACTUAL configured leads, nothing hardcoded (H3/L4)", () => {
   // A team with entirely custom lead names — no "Engineering Lead"/"Planning
   // Lead" anywhere. The routing block must name these leads and their cues.

--- a/tests/format-branches.test.ts
+++ b/tests/format-branches.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  boundedDiagnostics,
+  clip,
+  extractFinalAnswer,
+  hexAnsi,
+  safeJson,
+  slug,
+  tailLines,
+  textFromMessage,
+  textOfResult,
+  truncateMiddle,
+} from "../src/core/format.ts";
+
+test("format helpers handle sparse, malformed, and circular values", () => {
+  assert.equal(slug("!!!"), "agent");
+  assert.equal(slug(" Hello, World! "), "hello-world");
+  assert.equal(hexAnsi(undefined, "x"), null);
+  assert.equal(hexAnsi("bad", "x"), null);
+  assert.match(hexAnsi("#204060", "x") || "", /32;64;96/);
+  assert.match(hexAnsi("204060", "x", true) || "", /16;32;48/);
+
+  assert.equal(textFromMessage(null), "");
+  assert.equal(textFromMessage({ content: "plain" }), "plain");
+  assert.equal(textFromMessage({ content: [{ text: "a" }, { content: "b" }, null, {}] }), "a\nb");
+  assert.equal(textFromMessage({ text: "fallback" }), "fallback");
+  assert.equal(textFromMessage({ content: { nested: true } }), '{"nested":true}');
+  const circular: any = {};
+  circular.self = circular;
+  assert.equal(textFromMessage(circular), "[object Object]");
+
+  assert.equal(safeJson(undefined), "undefined");
+  assert.equal(safeJson(circular), "[object Object]");
+  assert.equal(textOfResult(null), "");
+  assert.equal(textOfResult("result"), "result");
+  assert.equal(textOfResult({ text: "text" }), "text");
+  assert.equal(textOfResult({ content: [{ text: "a" }, { content: "b" }, null] }), "a\nb");
+  assert.equal(textOfResult({ output: "output" }), "output");
+  assert.equal(textOfResult({ ok: true }), '{"ok":true}');
+});
+
+test("bounded text helpers enforce safe fallback and ceiling behavior", () => {
+  assert.equal(truncateMiddle("short", 10), "short");
+  assert.match(truncateMiddle("x".repeat(100), 20), /truncated/);
+  assert.equal(truncateMiddle("short", Number.NaN), "short");
+
+  assert.deepEqual(clip("short", 10), { text: "short", truncated: false });
+  assert.deepEqual(clip("abcdef", 3), { text: "abc", truncated: true });
+  assert.deepEqual(clip("short", -1), { text: "short", truncated: false });
+  assert.equal(tailLines("\na\n\nb\nc\n", 2), "b\nc");
+  assert.equal(tailLines("a\nb", Number.POSITIVE_INFINITY), "a\nb");
+  assert.equal(extractFinalAnswer("before <final_answer> done </final_answer> after"), "done");
+  assert.equal(extractFinalAnswer("none"), null);
+  assert.equal(extractFinalAnswer("<final_answer> </final_answer>"), null);
+});
+
+test("diagnostic bounding rejects absent and empty collections", () => {
+  assert.equal(boundedDiagnostics(undefined), undefined);
+  assert.equal(boundedDiagnostics([]), undefined);
+  assert.equal(boundedDiagnostics([null, {}]), undefined);
+});
+
+test("diagnostic bounding keeps typed and error entries without undefined fields", () => {
+  const diagnostics = boundedDiagnostics([
+    null,
+    {},
+    { type: "warning" },
+    { error: { message: "x".repeat(500) } },
+    { type: "both", error: { message: "message" } },
+  ], 2);
+  assert.equal(diagnostics?.length, 2);
+  assert.deepEqual(diagnostics?.[0], { type: "warning" });
+  assert.equal(Object.hasOwn(diagnostics?.[0] || {}, "message"), false);
+  assert.match(diagnostics?.[1].message || "", /truncated/);
+  assert.equal(boundedDiagnostics([{ type: "one" }], Number.NaN)?.length, 1);
+  assert.equal(boundedDiagnostics([{}, null]), undefined);
+});

--- a/tests/observability-agent-log.test.ts
+++ b/tests/observability-agent-log.test.ts
@@ -76,6 +76,56 @@ test("parseAgentLog bounds its initial response and pages older entries", () => 
   assert.ok(Number(older.entries.at(-1).ts) < Number(newest.entries[0].ts));
 });
 
+test("parseAgentLog handles metadata, sparse messages, and unmatched tool results", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-agent-log-variants-"));
+  const file = join(dir, "worker.jsonl");
+  writeFileSync(file, [
+    "{bad json",
+    JSON.stringify({ type: "ignored" }),
+    JSON.stringify({ type: "model_change", modelId: "m1", provider: "p", timestamp: 1 }),
+    JSON.stringify({ type: "model_change", model: "m2", timestamp: 2 }),
+    JSON.stringify({ type: "model_change", timestamp: 3 }),
+    JSON.stringify({ type: "thinking_level_change", thinkingLevel: "high", timestamp: 4 }),
+    JSON.stringify({ type: "thinking_level_change", level: "low", timestamp: 5 }),
+    JSON.stringify({ type: "thinking_level_change", timestamp: 6 }),
+    JSON.stringify({ type: "message", timestamp: 7, message: { content: "plain" } }),
+    JSON.stringify({ type: "message", timestamp: 8, message: { role: "assistant", content: [
+      { type: "thinking", thinking: "reason" },
+      { type: "toolCall", id: "t1", name: "write", input: { path: "x" } },
+      { type: "toolCall", name: "read" },
+      { type: "unknown" },
+    ] } }),
+    JSON.stringify({ type: "message", timestamp: 9, message: { role: "toolResult", toolCallId: "t1", content: [{ text: "ok" }, "tail"], isError: true } }),
+    JSON.stringify({ type: "message", timestamp: 10, message: { role: "toolResult", toolName: "missing", content: [{ text: "no call" }] } }),
+    JSON.stringify({ type: "message", timestamp: 11, role: "user", content: null }),
+    JSON.stringify({ type: "message", timestamp: 12, message: { role: "assistant", content: [] } }),
+    "",
+  ].join("\n"));
+
+  const parsed = parseAgentLog(file, 0);
+  assert.equal(parsed.entries.filter((entry) => entry.kind === "meta").length, 4);
+  assert.ok(parsed.entries.some((entry) => entry.role === "assistant" && entry.parts[0]?.text === "plain"));
+  const call = parsed.entries.flatMap((entry) => entry.parts || []).find((part) => part.id === "t1");
+  assert.equal(call.result, "ok\ntail");
+  assert.equal(call.resultError, true);
+  assert.ok(parsed.entries.some((entry) => entry.role === "toolResult"));
+  assert.ok(parseAgentLog(file, 1).offset >= 1);
+});
+
+test("agentRuns tolerates missing directories and sorts multiple archives", () => {
+  const missing = join(tmpdir(), `pi-hive-missing-${Date.now()}`, "worker.jsonl");
+  assert.deepEqual(agentRuns(missing), []);
+
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-agent-runs-many-"));
+  const current = join(dir, "worker.jsonl");
+  writeFileSync(join(dir, "worker.run-10.jsonl"), "");
+  writeFileSync(join(dir, "worker.run-2.jsonl"), "");
+  writeFileSync(join(dir, "worker.run-x.jsonl"), "");
+  assert.deepEqual(agentRuns(current).map((run) => run.id), ["run-10", "run-2"]);
+  writeFileSync(current, "");
+  assert.deepEqual(agentRuns(current).map((run) => run.id), ["current", "run-10", "run-2"]);
+});
+
 test("agentRuns returns archived runs and current newest-first", () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-hive-agent-runs-"));
   const current = join(dir, "worker.jsonl");

--- a/tests/openspec.test.ts
+++ b/tests/openspec.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import * as openspec from "../src/engine/openspec.ts";
 import { parseRid, renderReviewInput, ridFromReferer } from "../src/engine/review.ts";
-import { resolveHiveSddStatus } from "../src/engine/sdd.ts";
+import { renderHiveSddStatus, renderSddPromptBlock, resolveHiveSddStatus } from "../src/engine/sdd.ts";
 import type { HiveState } from "../src/core/types.ts";
 import { resolveProjectIdentity } from "../src/shared/project-identity.ts";
 
@@ -375,6 +375,57 @@ test("resolveHiveSddStatus degrades when OpenSpec is not initialized", () => {
   assert.equal(status.configured, false);
   assert.deepEqual(status.activeChanges, []);
   assert.ok(Array.isArray(status.suggestedRouting));
+});
+
+test("SDD status rendering covers configured, empty, active, and default prompt states", () => {
+  const unconfigured = {
+    configured: false,
+    configPath: "openspec CLI not installed",
+    activeChanges: [],
+    suggestedRouting: ["proposal → Planning"],
+  } as any;
+  assert.match(renderHiveSddStatus(unconfigured), /OpenSpec not initialized/);
+  assert.match(renderSddPromptBlock({ sddStatus: unconfigured } as any), /not initialized yet/);
+  assert.match(renderSddPromptBlock({ sddStatus: null } as any), /Planning lead/);
+
+  const configured = {
+    configured: true,
+    configPath: "openspec/",
+    suggestedRouting: ["apply → Engineering"],
+    activeChanges: [
+      { name: "with-summary", nextPhase: "tasks", files: ["proposal", "design"], path: "openspec/changes/with-summary", summary: "1/2 tasks complete" },
+      { name: "without-summary", nextPhase: "proposal", files: [], path: "openspec/changes/without-summary", summary: "" },
+    ],
+  } as any;
+  const rendered = renderHiveSddStatus(configured);
+  assert.match(rendered, /artifacts=proposal, design/);
+  assert.match(rendered, /artifacts=none/);
+  assert.match(rendered, /1\/2 tasks complete/);
+  assert.match(renderSddPromptBlock({ sddStatus: configured } as any), /with-summary/);
+
+  assert.match(renderHiveSddStatus({ ...configured, activeChanges: [] }), /No active changes/);
+});
+
+test("resolveHiveSddStatus detects configured phase specialists", { skip: openspec.isAvailable() ? false : "openspec CLI not installed" }, () => {
+  const cwd = scratch();
+  openspec.ensureInit(cwd);
+  openspec.newChange(cwd, "Status Branches");
+  const makeRuntime = (name: string, groupName: string, routingTags: string[]) => ({
+    config: { name, groupName, routingTags, role: "lead", path: `${name}.md`, domain: [] as any[] },
+  });
+  const state = emptyState();
+  state.runtimes = new Map([
+    ["orchestrator", { config: { name: "Orchestrator", role: "orchestrator" } } as any],
+    ["planner", makeRuntime("Planner", "Planning", ["requirements"]) as any],
+    ["engineer", makeRuntime("Engineer", "Engineering", ["implementation"]) as any],
+    ["reviewer", makeRuntime("Reviewer", "Validation", ["security", "verify"]) as any],
+  ]);
+  const status = resolveHiveSddStatus(state, cwd);
+  assert.equal(status.configured, true);
+  assert.equal(status.activeChanges.length, 1);
+  assert.match(status.suggestedRouting[0], /Planner/);
+  assert.match(status.suggestedRouting[1], /Engineer/);
+  assert.match(status.suggestedRouting[2], /Reviewer/);
 });
 
 // --- CLI-backed (skipped when the openspec binary is absent) ---

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -8,7 +8,7 @@ import { checkPlannerStages, checkTypePolicy } from "../src/engine/policy.ts";
 import { bashMutationKind, enforceDomainForTool, isCommitCommand, readOnlyCommandDecision } from "../src/engine/domain.ts";
 import { checkReservedPath } from "../src/engine/reserved-paths.ts";
 import { runAsAgent } from "../src/engine/session.ts";
-import { buildOperatingContract } from "../src/engine/prompts.ts";
+import { buildDistillerPrompt, buildOperatingContract, buildWorkerPrompt, extractTagged } from "../src/engine/prompts.ts";
 import type { AgentRuntime, AgentType, HiveState, PlanStage } from "../src/core/types.ts";
 
 function runtime(name: string, extra: Partial<AgentRuntime["config"]> = {}): AgentRuntime {
@@ -377,5 +377,37 @@ test("buildOperatingContract states the type's boundary", () => {
   assert.match(buildOperatingContract(runtime("P", { agentType: "planner", stages: ["proposal", "design"] })), /proposal, design/);
   assert.match(buildOperatingContract(runtime("R", { agentType: "reviewer" })), /submit_review_verdict/);
   assert.match(buildOperatingContract(runtime("L", { agentType: "lead", commit: "only when green" })), /Commit guidance: only when green/);
+  assert.match(buildOperatingContract(runtime("L", { agentType: "lead" })), /Network commands are disabled/);
+  assert.match(buildOperatingContract(runtime("C", { agentType: "coder", network: true })), /coder.*interpreter.*Network capability/is);
+  assert.match(buildOperatingContract(runtime("T", { agentType: "tester", network: false })), /tester.*interpreter.*Network commands are disabled/is);
   assert.equal(buildOperatingContract(runtime("U")), ""); // no type → no block
+});
+
+test("worker prompt covers lead delegation and leaf fallback context", () => {
+  const state = stateWith([]);
+  state.config = {
+    orchestrator: { name: "Orchestrator", path: "o.md" }, agents: [], sharedContext: [], settings: {},
+  } as any;
+  const lead = runtime("Lead", {
+    agentType: "lead", groupName: "Engineering", responsibilities: ["Coordinate", "Synthesize"],
+    allowedAgents: ["Coder", "Tester"], context: [], domain: [],
+  });
+  const leadPrompt = buildWorkerPrompt(state, { cwd: "/repo" } as any, lead, "Coordinate work");
+  assert.match(leadPrompt, /Group: Engineering/);
+  assert.match(leadPrompt, /Coder, Tester/);
+  assert.match(leadPrompt, /- Coordinate/);
+
+  const leaf = runtime("Leaf", { context: undefined, domain: undefined, responsibilities: undefined, allowedAgents: undefined });
+  const leafPrompt = buildWorkerPrompt(state, { cwd: "/repo" } as any, leaf, "Inspect");
+  assert.match(leafPrompt, /Group: Orchestration/);
+  assert.match(leafPrompt, /Use your role prompt/);
+  assert.match(leafPrompt, /No shared context files were readable/);
+  assert.doesNotMatch(leafPrompt, /Nested delegation/);
+});
+
+test("distiller prompt and tagged extraction handle empty and populated content", () => {
+  assert.match(buildDistillerPrompt("Agent", "", "", "2026-07-15"), /\(empty\).*\(none\)/s);
+  assert.match(buildDistillerPrompt("Agent", "current", "conversation", "2026-07-15"), /current.*conversation/s);
+  assert.equal(extractTagged("before <result> value </result>", "result"), "value");
+  assert.equal(extractTagged("missing", "result"), null);
 });

--- a/tests/schema-branches.test.ts
+++ b/tests/schema-branches.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { validateAgentTypes, validateHiveConfigShape } from "../src/core/schema.ts";
+
+function agent(name = "Lead", overrides: Record<string, any> = {}): any {
+  return {
+    name, slug: name.toLowerCase().replace(/\s+/g, "-"), path: `${name}.md`, role: "lead",
+    agentType: "lead", routingTags: [], responsibilities: [], context: [], skills: [], domain: [],
+    members: [], children: [], ...overrides,
+  };
+}
+
+function config(overrides: Record<string, any> = {}): any {
+  return {
+    orchestrator: agent("Orchestrator", { role: "orchestrator" }),
+    agents: [], sharedContext: [], settings: {}, ...overrides,
+  };
+}
+
+test("schema accepts every optional governance, domain, and nested-agent field", () => {
+  const member = agent("Member", {
+    role: "member", agentType: "planner", stages: ["proposal", "design", "specs", "tasks"],
+    network: true, commit: "Commit verified work.", color: "#aBc123",
+    routingTags: ["plan"], responsibilities: ["author"],
+    context: [{ path: "docs/context.md" }], skills: [{ path: "skills/test/SKILL.md" }],
+    domain: [{ path: "src", read: true, upsert: false, delete: false, include: ["**/*.ts"], exclude: ["**/*.key"] }],
+    governance: { timeoutMs: 1, maxDelegationDepth: 2, maxRuns: 3, tokenBudget: 4, costBudgetUsd: 5, distillerRuns: 6 },
+  });
+  const child = agent("Child", { role: "member", agentType: "coder" });
+  const lead = agent("Lead", { members: [member], children: [child] });
+  const value = config({
+    agents: [lead],
+    sharedContext: [{ path: "README.md" }],
+    settings: {
+      subagentOutputLimit: 100, maxParallel: 2, queueSize: 3,
+      worker: { timeoutMs: 1, maxDelegationDepth: 2, maxRuns: 3, tokenBudget: 4, costBudgetUsd: 5, distillerRuns: 6 },
+      teamBudgets: { maxRuns: 10, tokenBudget: 20, costBudgetUsd: 30 },
+      secretPaths: [".env", "keys/*.pem"],
+      distiller: { enabled: false, conversationLines: 20 },
+    },
+  });
+  assert.doesNotThrow(() => validateHiveConfigShape(value));
+  assert.doesNotThrow(() => validateAgentTypes(value));
+});
+
+test("shape validation rejects malformed optional collections and scalar fields", () => {
+  const invalid: Array<[any, RegExp]> = [
+    [null, /must be an object/],
+    [[], /must be an object/],
+    [config({ orchestrator: agent("", { name: "" }) }), /name must be a non-empty string/],
+    [config({ orchestrator: agent("O", { path: "" }) }), /path must be a non-empty string/],
+    [config({ orchestrator: agent("O", { slug: "" }) }), /slug must be a non-empty string/],
+    [config({ orchestrator: agent("O", { context: "bad" }) }), /context must be a list/],
+    [config({ orchestrator: agent("O", { context: [null] }) }), /context\[0\] must be an object/],
+    [config({ orchestrator: agent("O", { skills: [{ path: "" }] }) }), /skills\[0\]\.path/],
+    [config({ orchestrator: agent("O", { domain: "bad" }) }), /domain must be a list/],
+    [config({ orchestrator: agent("O", { domain: [null] }) }), /domain\[0\] must be an object/],
+    [config({ orchestrator: agent("O", { domain: [{ path: "src", read: true, upsert: false }] }) }), /delete must be explicitly/],
+    [config({ orchestrator: agent("O", { domain: [{ path: "src", read: "yes", upsert: false, delete: false }] }) }), /read must be explicitly/],
+    [config({ orchestrator: agent("O", { members: "bad" }) }), /members must be a list/],
+    [config({ orchestrator: agent("O", { children: "bad" }) }), /children must be a list/],
+    [config({ sharedContext: "bad" }), /shared_context must be a list/],
+    [config({ agents: "bad" }), /agents must be a list/],
+    [config({ settings: "bad" }), /settings must be an object/],
+    [config({ settings: { maxParallel: Number.NaN } }), /finite number/],
+    [config({ settings: { worker: [] } }), /worker must be an object/],
+    [config({ settings: { teamBudgets: [] } }), /teamBudgets must be an object/],
+    [config({ settings: { secretPaths: [""] } }), /secretPaths\[0\]/],
+    [config({ settings: { distiller: { enabled: "yes" } } }), /enabled must be true or false/],
+  ];
+  for (const [value, expected] of invalid) assert.throws(() => validateHiveConfigShape(value), expected);
+});
+
+test("agent-type validation rejects every malformed capability contract", () => {
+  const invalid: Array<[Record<string, any>, RegExp]> = [
+    [{ agentType: undefined }, /agent-type is required/],
+    [{ agentType: null }, /agent-type is required/],
+    [{ agentType: " " }, /agent-type is required/],
+    [{ agentType: "wizard" }, /must be one of/],
+    [{ agentType: "planner", stages: "proposal" }, /stages must be a list/],
+    [{ agentType: "coder", stages: ["proposal"] }, /only valid on an agent-type: planner/],
+    [{ agentType: "planner", stages: ["ship"] }, /stages\[0\] must be one of/],
+    [{ agentType: "coder", network: "yes" }, /network must be true or false/],
+    [{ agentType: "coder", commit: "" }, /commit must be a non-empty string/],
+  ];
+  for (const [overrides, expected] of invalid) {
+    assert.throws(() => validateAgentTypes(config({ orchestrator: agent("Orchestrator", overrides) })), expected);
+  }
+  assert.doesNotThrow(() => validateAgentTypes(config({ orchestrator: agent("Orchestrator"), agents: undefined })));
+});

--- a/tests/session-branches.test.ts
+++ b/tests/session-branches.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -7,6 +7,7 @@ import {
   currentAgentName,
   currentChangeId,
   currentDelegationDepth,
+  loadAgentRuntime,
   restoreOrCreateSession,
   restoreRuntimeCounters,
   runAsAgent,
@@ -40,6 +41,81 @@ test("session restoration migrates legacy records and creates missing sessions",
   assert.equal(appended.type, "hive-session");
   assert.equal(appended.data.sessionId, created.sessionId);
   assert.match(created.conversationLog, /conversation\.jsonl$/);
+});
+
+test("agent runtime loading covers frontmatter precedence, defaults, and fail-closed requirements", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hive-runtime-load-"));
+  const agentsDir = join(cwd, ".pi", "hive", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  const sessionDir = join(cwd, "session");
+  mkdirSync(sessionDir, { recursive: true });
+  const state = { session: { sessionDir } } as any;
+  const cfg = { settings: { defaultTools: "read" } } as any;
+
+  writeFileSync(join(agentsDir, "rich.md"), `---
+slug: Rich Agent
+name: Frontmatter Name
+model: provider/model
+thinking: high
+tools: read,bash
+color: '#123456'
+description: Handles rich work
+routing-tags: [api]
+responsibilities: [build]
+context:
+  - path: .pi/hive/agents/rich-mental-model.yaml
+skills:
+  - path: skills/example/SKILL.md
+domain:
+  - path: src
+    read: true
+    upsert: true
+    delete: false
+agent-type: planner
+stages: [proposal]
+commit: Commit the result.
+---
+Rich prompt body.`);
+  const rich = loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Config Name", path: ".pi/hive/agents/rich.md", role: "member", routingTags: [], domain: [],
+  } as any);
+  assert.equal(rich.config.name, "Frontmatter Name");
+  assert.equal(rich.config.model, "provider/model");
+  assert.equal(rich.config.thinking, "high");
+  assert.equal(rich.systemPrompt, "Rich prompt body.");
+  assert.equal(rich.config.context?.filter((ref: any) => ref.path.endsWith("mental-model.yaml")).length, 1);
+
+  writeFileSync(join(agentsDir, "configured.md"), "Configured prompt.");
+  const configured = loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Configured", slug: "configured-slug", path: ".pi/hive/agents/configured.md", role: "member",
+    model: "agent/model", thinking: "low", tools: "read", color: "#abcdef", consultWhen: "configured work",
+    routingTags: ["configured"], responsibilities: ["work"], context: [{ path: "README.md" }], skills: [],
+    domain: [], agentType: "coder", commit: "Commit configured work.",
+  } as any);
+  assert.equal(configured.config.slug, "configured-slug");
+  assert.equal(configured.config.model, "agent/model");
+  assert.equal(configured.config.consultWhen, "configured work");
+  assert.equal(configured.lastWork, "configured work");
+
+  writeFileSync(join(agentsDir, "main.md"), "");
+  const main = loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Main", path: ".pi/hive/agents/main.md", role: "orchestrator", routingTags: [], domain: [],
+  } as any);
+  assert.equal(main.config.model, "inherit");
+  assert.equal(main.config.thinking, "medium");
+  assert.match(main.systemPrompt, /You are Main/);
+
+  writeFileSync(join(agentsDir, "missing.md"), "---\nthinking: low\n---\nWorker");
+  assert.throws(() => loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Missing Model", path: ".pi/hive/agents/missing.md", role: "member",
+  } as any), /missing required 'model'/);
+  writeFileSync(join(agentsDir, "missing.md"), "---\nmodel: provider/model\n---\nWorker");
+  assert.throws(() => loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Missing Thinking", path: ".pi/hive/agents/missing.md", role: "member",
+  } as any), /missing required 'thinking'/);
+  assert.throws(() => loadAgentRuntime(state, { cwd } as any, cfg, {
+    name: "Escape", path: "../outside.md", role: "member",
+  } as any), /missing or escapes/);
 });
 
 test("runtime counter restoration handles sparse, corrupt, and explicit snapshots", () => {


### PR DESCRIPTION
## Summary
- raise core branch coverage from 75.63% to 80.12%
- enforce the required 80% aggregate core branch threshold
- add branch matrices for formatting, schema validation, agent-type audit, session loading, dashboard lifecycle, routing, SDD rendering, prompts, commands, and agent-log parsing
- keep timeout tests reliable under coverage instrumentation while production timers remain unreferenced
- publish Istanbul JSON alongside summary and LCOV artifacts for precise branch diagnostics

## Coverage
- lines: 87.53%
- branches: 80.12%
- functions: 88.75%

## Verification
- `just coverage`
- `just ci`
