### PR TITLE
test: enforce critical core coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -271,6 +271,7 @@ test-db:
 coverage-core:
   rm -rf coverage/core
   npx c8 --all --check-coverage --lines=85 --branches=80 --include='src/**/*.ts' --exclude='src/observability/db.ts' --exclude='src/observability/server/**' --reporter=text-summary --reporter=json-summary --reporter=json --reporter=lcov --reports-dir=coverage/core --temp-directory=coverage/.tmp/core node --experimental-strip-types --import ./tests/register-ts-loader.mjs --test tests/*.test.ts
+  node scripts/check-critical-coverage.mjs
   rm -rf coverage/.tmp
 
 # Generate Bun coverage for SQLite and dashboard-server modules.

--- a/scripts/check-critical-coverage.mjs
+++ b/scripts/check-critical-coverage.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CRITICAL_CORE_MODULES = [
+  "src/engine/dashboard.ts",
+  "src/engine/process.ts",
+  "src/engine/review.ts",
+  "src/integration/commands.ts",
+  "src/integration/hooks.ts",
+  "src/observability/agent-log.ts",
+];
+
+export const CRITICAL_LINE_THRESHOLD = 90;
+
+export function checkCriticalCoverage(summary, modules = CRITICAL_CORE_MODULES, threshold = CRITICAL_LINE_THRESHOLD) {
+  const entries = Object.entries(summary).filter(([file]) => file !== "total");
+  const failures = [];
+  const results = [];
+
+  for (const modulePath of modules) {
+    const match = entries.find(([file]) => file.replaceAll("\\", "/").endsWith(`/${modulePath}`));
+    if (!match) {
+      failures.push(`${modulePath}: missing from coverage report`);
+      continue;
+    }
+    const pct = Number(match[1]?.lines?.pct);
+    results.push({ modulePath, pct });
+    if (!Number.isFinite(pct) || pct < threshold) failures.push(`${modulePath}: ${Number.isFinite(pct) ? pct : "invalid"}% lines (requires ${threshold}%)`);
+  }
+
+  return { results, failures };
+}
+
+function main() {
+  const summaryPath = resolve(process.argv[2] || "coverage/core/coverage-summary.json");
+  let summary;
+  try {
+    summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+  } catch (error) {
+    console.error(`Critical coverage check could not read ${summaryPath}: ${error?.message || error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { results, failures } = checkCriticalCoverage(summary);
+  for (const result of results) console.log(`${result.modulePath}: ${result.pct}% lines`);
+  if (failures.length) {
+    console.error(`Critical coverage gate failed:\n- ${failures.join("\n- ")}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Critical core coverage gate passed (${CRITICAL_LINE_THRESHOLD}% lines per module).`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/tests/coverage-gate.test.ts
+++ b/tests/coverage-gate.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const SCRIPT = resolve("scripts/check-critical-coverage.mjs");
+const MODULES = [
+  "src/engine/dashboard.ts",
+  "src/engine/process.ts",
+  "src/engine/review.ts",
+  "src/integration/commands.ts",
+  "src/integration/hooks.ts",
+  "src/observability/agent-log.ts",
+];
+
+function runCoverageGate(percentages: Record<string, number>) {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-critical-coverage-"));
+  const summary = Object.fromEntries(Object.entries(percentages).map(([file, pct]) => [
+    `/checkout/${file}`,
+    { lines: { pct } },
+  ]));
+  const path = join(dir, "coverage-summary.json");
+  writeFileSync(path, JSON.stringify({ total: { lines: { pct: 100 } }, ...summary }));
+  return spawnSync(process.execPath, [SCRIPT, path], { encoding: "utf8" });
+}
+
+test("critical coverage gate accepts every required module at 90 percent", () => {
+  const result = runCoverageGate(Object.fromEntries(MODULES.map((file) => [file, 90])));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Critical core coverage gate passed/);
+});
+
+test("critical coverage gate rejects low and missing modules", () => {
+  const low = Object.fromEntries(MODULES.map((file) => [file, file.endsWith("review.ts") ? 89.99 : 100]));
+  const failed = runCoverageGate(low);
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /review\.ts: 89\.99% lines/);
+
+  const missing = runCoverageGate(Object.fromEntries(MODULES.slice(1).map((file) => [file, 100])));
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /dashboard\.ts: missing/);
+});

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -11,6 +11,7 @@ import {
   dashboardRegistryPath,
   dashboardUrl,
   daemonTokenPath,
+  bunAvailable,
   ensureDashboard,
   isHiveDashboard,
   probeDashboard,
@@ -176,6 +177,65 @@ test("concurrent startup calls serialize and spawn exactly one daemon", async ()
   } finally {
     delete process.env.HIVE_TELEMETRY_REGISTRY;
   }
+});
+
+test("default startup path validates session and server before spawning", async () => {
+  assert.equal(bunAvailable(), true);
+  const base: EnsureDeps = {
+    probe: async () => null,
+    stop: async () => [],
+    waitForReady: async () => null,
+    withLock: async (_path: string, fn: () => Promise<any>) => fn(),
+  };
+  const noSession = await ensureDashboard({} as any, ctx, ROOT, {}, base);
+  assert.match(noSession.error || "", /session not initialized/);
+  const missingRoot = mkdtempSync(join(tmpdir(), "pi-hive-dashboard-missing-server-"));
+  const missingServer = await ensureDashboard(state(), ctx, missingRoot, {}, base);
+  assert.match(missingServer.error || "", /missing observability server/);
+});
+
+test("default spawn forwards bounded telemetry settings and is explicitly cleaned up", async () => {
+  const isolated = mkdtempSync(join(tmpdir(), "pi-hive-dashboard-real-spawn-"));
+  const original = {
+    registry: process.env.HIVE_TELEMETRY_REGISTRY,
+    port: process.env.HIVE_TELEMETRY_PORT,
+  };
+  process.env.HIVE_TELEMETRY_REGISTRY = join(isolated, "registry.jsonl");
+  process.env.HIVE_TELEMETRY_PORT = String(48_000 + Math.floor(Math.random() * 1_000));
+  const s = state();
+  s.config = { settings: { telemetry: { retentionDays: 7, maxLogBytes: 123_456, captureThinking: true } } } as any;
+  try {
+    const result = await ensureDashboard(s, { ...ctx, cwd: isolated }, ROOT, {}, {
+      probe: async () => null,
+      stop: async () => [],
+      waitForReady: async (_host, _port, identity) => healthy(identity, { pid: s.obsServer?.proc?.pid || 1 }),
+      withLock: async (_path, fn) => fn(),
+    });
+    assert.equal(result.spawned, true);
+    assert.equal(typeof s.obsServer?.proc?.pid, "number");
+  } finally {
+    try { s.obsServer?.proc?.kill("SIGTERM"); } catch { /* best effort */ }
+    if (original.registry === undefined) delete process.env.HIVE_TELEMETRY_REGISTRY; else process.env.HIVE_TELEMETRY_REGISTRY = original.registry;
+    if (original.port === undefined) delete process.env.HIVE_TELEMETRY_PORT; else process.env.HIVE_TELEMETRY_PORT = original.port;
+  }
+});
+
+test("default readiness polling accepts the exact spawned identity", async () => {
+  let identity: DaemonIdentity | undefined;
+  const s = state();
+  const result = await ensureDashboard(s, ctx, ROOT, {}, {
+    probe: async () => identity ? healthy(identity) : null,
+    bunAvailable: () => true,
+    spawn: (current, _ctx, _root, request) => {
+      identity = request.identity;
+      current.obsServer = { url: dashboardUrl(), port: request.port, host: request.host, adopted: false };
+      return { ok: true, pid: 43210 };
+    },
+    stop: async () => [],
+    withLock: async (_path, fn) => fn(),
+  });
+  assert.equal(result.running, true);
+  assert.equal(result.spawned, true);
 });
 
 test("is Bun-gated and browser opening remains explicit", async () => {


### PR DESCRIPTION
## Summary
- enforce at least 90% line coverage for critical Bun-independent security and state modules
- raise dashboard process-control coverage from 85.41% to 95.76%
- exercise default Bun detection, server validation, spawn environment, readiness polling, and explicit child cleanup
- fail coverage when a required critical module is missing or falls below the threshold

## Critical module coverage
- dashboard process control: 95.76%
- process lifecycle: 100%
- review security: 91.09%
- commands: 100%
- hooks: 98.70%
- agent-log processing: 100%

Aggregate core coverage remains above the existing gates at 88.00% lines and 80.25% branches.

T23 still needs equivalent critical coverage enforcement for Bun server runtime and dashboard store/components before completion.

## Verification
- `just coverage`
- `just ci`
