### PR TITLE
test: raise Bun server runtime coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -279,6 +279,7 @@ coverage-core:
 coverage-db:
   rm -rf coverage/bun
   bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/bun ./tests/*.spec.ts
+  node scripts/check-bun-coverage.mjs
 
 # Produce all machine-readable coverage reports consumed by CI.
 [group('quality')]

--- a/scripts/check-bun-coverage.mjs
+++ b/scripts/check-bun-coverage.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const BUN_LINE_THRESHOLDS = {
+  "src/observability/server/config.ts": 90,
+  "src/observability/server/db.ts": 90,
+  "src/observability/server/jsonl-reader.ts": 90,
+  "src/observability/server/plan-routes.ts": 90,
+  "src/observability/server/runtime.ts": 65,
+  "src/observability/server/topology-hash.ts": 90,
+};
+
+export function parseLcovLines(lcov) {
+  const results = new Map();
+  for (const block of lcov.split("end_of_record")) {
+    const file = /^SF:(.+)$/m.exec(block)?.[1]?.replaceAll("\\", "/");
+    if (!file) continue;
+    const found = Number(/^LF:(\d+)$/m.exec(block)?.[1]);
+    const hit = Number(/^LH:(\d+)$/m.exec(block)?.[1]);
+    results.set(file, { found, hit, pct: found > 0 ? (hit / found) * 100 : 100 });
+  }
+  return results;
+}
+
+export function checkBunCoverage(lcov, thresholds = BUN_LINE_THRESHOLDS) {
+  const coverage = parseLcovLines(lcov);
+  const results = [];
+  const failures = [];
+  for (const [modulePath, threshold] of Object.entries(thresholds)) {
+    const match = Array.from(coverage.entries()).find(([file]) => file === modulePath || file.endsWith(`/${modulePath}`));
+    if (!match) {
+      failures.push(`${modulePath}: missing from coverage report`);
+      continue;
+    }
+    const pct = match[1].pct;
+    results.push({ modulePath, pct, threshold });
+    if (!Number.isFinite(pct) || pct < threshold) failures.push(`${modulePath}: ${Number.isFinite(pct) ? pct.toFixed(2) : "invalid"}% lines (requires ${threshold}%)`);
+  }
+  return { results, failures };
+}
+
+function main() {
+  const lcovPath = resolve(process.argv[2] || "coverage/bun/lcov.info");
+  let lcov;
+  try {
+    lcov = readFileSync(lcovPath, "utf8");
+  } catch (error) {
+    console.error(`Bun coverage check could not read ${lcovPath}: ${error?.message || error}`);
+    process.exitCode = 1;
+    return;
+  }
+  const { results, failures } = checkBunCoverage(lcov);
+  for (const result of results) console.log(`${result.modulePath}: ${result.pct.toFixed(2)}% lines (requires ${result.threshold}%)`);
+  if (failures.length) {
+    console.error(`Bun coverage gate failed:\n- ${failures.join("\n- ")}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("Bun server coverage gates passed.");
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/tests/bun-coverage-gate.test.ts
+++ b/tests/bun-coverage-gate.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const SCRIPT = resolve("scripts/check-bun-coverage.mjs");
+const THRESHOLDS: Record<string, number> = {
+  "src/observability/server/config.ts": 90,
+  "src/observability/server/db.ts": 90,
+  "src/observability/server/jsonl-reader.ts": 90,
+  "src/observability/server/plan-routes.ts": 90,
+  "src/observability/server/runtime.ts": 65,
+  "src/observability/server/topology-hash.ts": 90,
+};
+
+function run(percentages: Record<string, number>) {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-bun-coverage-"));
+  const lcov = Object.entries(percentages).map(([file, pct]) => {
+    const hit = Math.floor(pct);
+    return `SF:${file}\nLF:100\nLH:${hit}\nend_of_record\n`;
+  }).join("");
+  const path = join(dir, "lcov.info");
+  writeFileSync(path, lcov);
+  return spawnSync(process.execPath, [SCRIPT, path], { encoding: "utf8" });
+}
+
+test("Bun server coverage gate accepts every enforced threshold", () => {
+  const result = run(Object.fromEntries(Object.entries(THRESHOLDS).map(([file, threshold]) => [file, threshold])));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Bun server coverage gates passed/);
+});
+
+test("Bun server coverage gate rejects low and missing runtime coverage", () => {
+  const low = { ...THRESHOLDS, "src/observability/server/runtime.ts": 64 };
+  const failed = run(low);
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /runtime\.ts: 64\.00% lines/);
+
+  const { "src/observability/server/runtime.ts": _missing, ...withoutRuntime } = THRESHOLDS;
+  const missing = run(withoutRuntime);
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /runtime\.ts: missing/);
+});

--- a/tests/runtime-logs.spec.ts
+++ b/tests/runtime-logs.spec.ts
@@ -1,0 +1,102 @@
+import { beforeAll, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.HIVE_TELEMETRY_DB ||= join(mkdtempSync(join(tmpdir(), "pi-hive-runtime-logs-db-")), "telemetry.db");
+
+let runtime: typeof import("../src/observability/server/runtime");
+
+beforeAll(async () => {
+  runtime = await import("../src/observability/server/runtime");
+});
+
+function message(role: string, content: unknown, timestamp: string, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({ type: "message", timestamp, message: { role, content, ...extra } });
+}
+
+test("runtime serves bounded main/worker logs and deletes tracked source artifacts", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-runtime-logs-"));
+  const telemetryLog = join(dir, "hive-events.jsonl");
+  const stateFile = join(dir, "hive-state.json");
+  const conversationLog = join(dir, "conversation.jsonl");
+  const workerLog = join(dir, "builder.jsonl");
+  const workerArchive = join(dir, "builder.run-1.jsonl");
+  writeFileSync(telemetryLog, "");
+  writeFileSync(`${telemetryLog}.1.gz`, "archive");
+  writeFileSync(`${telemetryLog}.lock`, "lock");
+  writeFileSync(conversationLog, [
+    message("user", [{ type: "text", text: "question" }], "2026-07-15T00:00:00.000Z"),
+    message("assistant", [{ type: "thinking", thinking: "private" }, { type: "text", text: "answer" }], "2026-07-15T00:00:01.000Z"),
+  ].join("\n") + "\n");
+  writeFileSync(workerLog, [
+    message("assistant", [{ type: "thinking", thinking: "worker thought" }, { type: "text", text: "worker answer" }], "2026-07-15T00:00:02.000Z"),
+    message("assistant", [{ type: "toolCall", id: "t1", name: "read", arguments: { path: "x" } }], "2026-07-15T00:00:03.000Z"),
+    message("toolResult", "ok", "2026-07-15T00:00:04.000Z", { toolCallId: "t1", toolName: "read" }),
+  ].join("\n") + "\n");
+  writeFileSync(workerArchive, message("assistant", "archived", "2026-07-14T00:00:00.000Z") + "\n");
+  writeFileSync(stateFile, JSON.stringify({
+    updated_at: "2026-07-15T00:00:05.000Z",
+    session_id: "runtime-logs",
+    project_id: "project-runtime-logs",
+    project_root: dir,
+    project_label: "Runtime logs",
+    cwd: dir,
+    session_dir: dir,
+    telemetry_log: telemetryLog,
+    conversation_log: conversationLog,
+    active_runs: 1,
+    topologies: {
+      active: "hive",
+      hive: { orchestrator: { name: "Main" }, agents: [{ name: "Builder" }] },
+      planning: { orchestrator: { name: "Planner" }, agents: [] },
+    },
+    agents: [
+      { name: "Main", role: "orchestrator", status: "running", sessionFile: conversationLog },
+      { name: "Builder", role: "member", status: "done", sessionFile: workerLog },
+      { name: "No File", role: "member", status: "idle" },
+    ],
+  }));
+
+  runtime.addSource(telemetryLog, {
+    session_id: "runtime-logs", project_id: "project-runtime-logs", project_root: dir,
+    cwd: dir, session_dir: dir, conversation_log: conversationLog, state_file: stateFile,
+  });
+
+  expect(runtime.sourcePaths()).toContain(telemetryLog);
+  expect(runtime.allSnapshots().some((snapshot) => snapshot.session_id === "runtime-logs")).toBe(true);
+  expect(runtime.allSnapshots({ offset: -2, limit: 0 }).length).toBeGreaterThanOrEqual(1);
+  expect(runtime.sourceLogForSession("runtime-logs")).toBe(telemetryLog);
+  expect(runtime.sourceLogForSession("missing")).toBeUndefined();
+
+  expect(runtime.agentLogPath("missing", "Builder")).toEqual({});
+  expect(runtime.agentLogPath("runtime-logs", "Main").main).toBe(true);
+  expect(runtime.agentLogPath("runtime-logs", "Orchestrator").main).toBe(true);
+  expect(runtime.agentLogPath("runtime-logs", "Builder").file).toBe(workerLog);
+  expect(runtime.agentLogPath("runtime-logs", "No File").status).toBe("idle");
+  expect(runtime.agentLogPath("runtime-logs", "Unknown")).toEqual({ status: undefined });
+
+  const unknown = runtime.readAgentLog("missing", "Builder", 0, "");
+  expect(unknown.exists).toBe(false);
+  const main = runtime.readAgentLog("runtime-logs", "Main", 0, "");
+  expect(main.exists).toBe(true);
+  expect(main.run).toBe("current");
+  expect(main.entries.length).toBeGreaterThan(0);
+  const worker = runtime.readAgentLog("runtime-logs", "Builder", 0, "current");
+  expect(worker.exists).toBe(true);
+  expect(worker.runs.length).toBe(2);
+  expect(worker.entries.length).toBeGreaterThan(0);
+  expect(runtime.readAgentLog("runtime-logs", "Builder", 1, "run-1").run).toBe("run-1");
+  expect(runtime.readAgentLog("runtime-logs", "Builder", 0, "missing", 10).exists).toBe(true);
+
+  expect(Array.isArray(runtime.recentThinking("missing"))).toBe(true);
+  const storage = runtime.telemetryStorage("project-runtime-logs", 30);
+  expect(storage.sourceLogs.files).toBeGreaterThanOrEqual(1);
+  expect(runtime.deleteProjectSourceLogs("")).toEqual({ files: 0, bytes: 0 });
+  const deleted = runtime.deleteProjectSourceLogs("project-runtime-logs");
+  expect(deleted.files).toBe(2);
+  expect(deleted.bytes).toBeGreaterThan(0);
+  expect(existsSync(telemetryLog)).toBe(false);
+  expect(existsSync(stateFile)).toBe(true);
+  expect(existsSync(`${telemetryLog}.lock`)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- raise Bun server runtime line coverage from 44.82% to 68.13%
- cover snapshot-backed main/worker logs, archived runs, source-log lookup, storage accounting, and guarded source deletion
- raise DB coverage above the critical 90% target
- add tested fail-closed LCOV gates for server modules already at their target and a 65% runtime ratchet

## Bun server coverage
- config: 95.16%
- database: 90.35%
- JSONL reader: 94.68%
- plan routes: 100%
- runtime: 68.13% (65% enforced ratchet)
- topology hashing: 100%

T23 remains open: runtime must reach 90%, remaining server perimeter modules need their 90% gates, and dashboard store/components still require coverage.

## Verification
- `just coverage`
- `just ci`
