### PR TITLE
test: enforce critical Bun server coverage

### DIFF
--- a/scripts/check-bun-coverage.mjs
+++ b/scripts/check-bun-coverage.mjs
@@ -9,8 +9,11 @@ export const BUN_LINE_THRESHOLDS = {
   "src/observability/server/db.ts": 90,
   "src/observability/server/http-handler.ts": 90,
   "src/observability/server/jsonl-reader.ts": 90,
+  "src/observability/server/plan-bridge.ts": 90,
   "src/observability/server/plan-routes.ts": 90,
-  "src/observability/server/runtime.ts": 80,
+  "src/observability/server/review-wiring.ts": 90,
+  "src/observability/server/runtime.ts": 90,
+  "src/observability/server/sse.ts": 90,
   "src/observability/server/topology-hash.ts": 90,
 };
 

--- a/tests/aaa-runtime-thinking.spec.ts
+++ b/tests/aaa-runtime-thinking.spec.ts
@@ -1,0 +1,74 @@
+import { beforeAll, expect, test } from "bun:test";
+import { appendFileSync, mkdtempSync, mkdirSync, writeFileSync, unwatchFile } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+process.env.HIVE_TELEMETRY_CAPTURE_THINKING = "1";
+process.env.HIVE_TELEMETRY_DB ||= join(mkdtempSync(join(tmpdir(), "pi-hive-thinking-db-")), "telemetry.db");
+
+let runtime: typeof import("../src/observability/server/runtime");
+let config: typeof import("../src/observability/server/config");
+
+beforeAll(async () => {
+  config = await import("../src/observability/server/config");
+  runtime = await import("../src/observability/server/runtime");
+});
+
+function thinkingMessage(ts: string, text: string, usage: Record<string, number>) {
+  return JSON.stringify({
+    type: "message", timestamp: ts,
+    message: { role: "assistant", content: [{ type: "thinking", thinking: text }, { type: "text", text: "answer" }], usage },
+  });
+}
+
+test("runtime incrementally materializes bounded thinking tails", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-thinking-runtime-"));
+  const log = join(dir, "hive-events.jsonl");
+  const stateFile = join(dir, "hive-state.json");
+  const worker = join(dir, "thinker.jsonl");
+  writeFileSync(log, "");
+  writeFileSync(worker, [
+    thinkingMessage("2026-07-15T03:00:00.000Z", "first thought", { reasoning: 5, output: 9 }),
+    JSON.stringify({ type: "message", timestamp: "2026-07-15T03:00:01.000Z", message: { role: "assistant", content: [{ type: "text", text: "no thought" }] } }),
+  ].join("\n") + "\n");
+  writeFileSync(stateFile, JSON.stringify({
+    updated_at: "2026-07-15T03:00:02.000Z", session_id: "runtime-thinking", cwd: dir,
+    agents: [
+      { name: "Thinker", status: "done", sessionFile: worker },
+      { name: "Missing", status: "idle", sessionFile: join(dir, "missing.jsonl") },
+      { name: "No File", status: "idle" },
+    ],
+  }));
+  runtime.addSource(log, { session_id: "runtime-thinking", cwd: dir, state_file: stateFile });
+
+  const first = runtime.recentThinking("runtime-thinking", 1, 10);
+  expect(first).toHaveLength(1);
+  expect(first[0].text).toBe("first thought");
+  expect(first[0].tokens).toBe(5);
+
+  appendFileSync(worker, thinkingMessage("2026-07-15T03:00:03.000Z", "second thought", { output: 7 }) + "\n");
+  const second = runtime.recentThinking("runtime-thinking", 2, 1);
+  expect(second).toHaveLength(1);
+  expect(second[0].text).toBe("second thought");
+  expect(second[0].tokens).toBe(7);
+  expect(runtime.recentThinking("missing")).toEqual([]);
+});
+
+test("runtime startup reads the registry once and remains idempotent", () => {
+  mkdirSync(dirname(config.REGISTRY_PATH), { recursive: true });
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-registry-runtime-"));
+  const log = join(dir, "events.jsonl");
+  writeFileSync(log, "");
+  writeFileSync(config.REGISTRY_PATH, [
+    "{bad json",
+    JSON.stringify({ telemetry_log: log, session_id: "old", cwd: dir }),
+    JSON.stringify({ telemetry_log: log, session_id: "registry-runtime", cwd: dir }),
+    JSON.stringify({ session_id: "no-log" }),
+    "",
+  ].join("\n"));
+
+  runtime.startTelemetryRuntime();
+  runtime.startTelemetryRuntime();
+  expect(runtime.sourcePaths()).toContain(log);
+  unwatchFile(config.REGISTRY_PATH);
+});

--- a/tests/bun-coverage-gate.test.ts
+++ b/tests/bun-coverage-gate.test.ts
@@ -11,8 +11,11 @@ const THRESHOLDS: Record<string, number> = {
   "src/observability/server/db.ts": 90,
   "src/observability/server/http-handler.ts": 90,
   "src/observability/server/jsonl-reader.ts": 90,
+  "src/observability/server/plan-bridge.ts": 90,
   "src/observability/server/plan-routes.ts": 90,
-  "src/observability/server/runtime.ts": 80,
+  "src/observability/server/review-wiring.ts": 90,
+  "src/observability/server/runtime.ts": 90,
+  "src/observability/server/sse.ts": 90,
   "src/observability/server/topology-hash.ts": 90,
 };
 
@@ -34,10 +37,10 @@ test("Bun server coverage gate accepts every enforced threshold", () => {
 });
 
 test("Bun server coverage gate rejects low and missing runtime coverage", () => {
-  const low = { ...THRESHOLDS, "src/observability/server/runtime.ts": 79 };
+  const low = { ...THRESHOLDS, "src/observability/server/runtime.ts": 89 };
   const failed = run(low);
   assert.equal(failed.status, 1);
-  assert.match(failed.stderr, /runtime\.ts: 79\.00% lines/);
+  assert.match(failed.stderr, /runtime\.ts: 89\.00% lines/);
 
   const { "src/observability/server/runtime.ts": _missing, ...withoutRuntime } = THRESHOLDS;
   const missing = run(withoutRuntime);

--- a/tests/plan-bridge.spec.ts
+++ b/tests/plan-bridge.spec.ts
@@ -1,0 +1,60 @@
+import { beforeAll, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.HIVE_TELEMETRY_DB ||= join(mkdtempSync(join(tmpdir(), "pi-hive-plan-bridge-db-")), "telemetry.db");
+
+let runtime: typeof import("../src/observability/server/runtime");
+let bridge: typeof import("../src/observability/server/plan-bridge");
+
+beforeAll(async () => {
+  runtime = await import("../src/observability/server/runtime");
+  bridge = await import("../src/observability/server/plan-bridge");
+});
+
+function addSnapshot(root: string, cwd: string, sessionId: string, updatedAt: string, withSessionDir = true) {
+  const dir = join(root, sessionId);
+  mkdirSync(dir, { recursive: true });
+  const log = join(dir, "events.jsonl");
+  const stateFile = join(dir, "hive-state.json");
+  writeFileSync(log, "");
+  writeFileSync(stateFile, JSON.stringify({
+    updated_at: updatedAt,
+    session_id: sessionId,
+    project_id: `project-${cwd.split("/").at(-1)}`,
+    project_root: cwd,
+    cwd,
+    session_dir: withSessionDir ? dir : undefined,
+    agents: [],
+  }));
+  runtime.addSource(log, { session_id: sessionId, cwd, session_dir: withSessionDir ? dir : undefined, state_file: stateFile });
+  return dir;
+}
+
+test("plan bridge targets an owner session then falls back to the newest project session", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-plan-bridge-"));
+  const cwd = join(root, "project");
+  mkdirSync(cwd, { recursive: true });
+  const older = addSnapshot(root, cwd, "bridge-older", "2026-07-15T01:00:00.000Z");
+  const newer = addSnapshot(root, cwd, "bridge-newer", "2026-07-15T02:00:00.000Z");
+
+  expect(bridge.knownCwds()).toContain(cwd);
+  expect(bridge.resolveProjectCwd(cwd)).toBe(cwd);
+  expect(bridge.resolveProjectCwd(join(root, "unknown"))).toBeNull();
+
+  expect(bridge.enqueueDashboardAction(cwd, { type: "owner" }, "bridge-older")).toBe(true);
+  expect(readFileSync(join(older, "dashboard-actions.jsonl"), "utf8")).toContain('"type":"owner"');
+
+  expect(bridge.enqueueDashboardAction(cwd, { type: "newest" }, "missing-owner")).toBe(true);
+  expect(readFileSync(join(newer, "dashboard-actions.jsonl"), "utf8")).toContain('"type":"newest"');
+});
+
+test("plan bridge fails closed when the matching session has no writable directory", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-plan-bridge-no-dir-"));
+  const cwd = join(root, "project-no-dir");
+  mkdirSync(cwd, { recursive: true });
+  addSnapshot(root, cwd, "bridge-no-dir", "2026-07-15T03:00:00.000Z", false);
+  expect(bridge.enqueueDashboardAction(cwd, { type: "ignored" })).toBe(false);
+  expect(existsSync(join(root, "dashboard-actions.jsonl"))).toBe(false);
+});

--- a/tests/plan-server.spec.ts
+++ b/tests/plan-server.spec.ts
@@ -135,7 +135,7 @@ test("resolveProjectCwd rejects an unknown cwd and echoes a known one", () => {
 const REVIEW_ORIGIN = "http://127.0.0.1:43191";
 const REVIEW_HEADERS = { host: "127.0.0.1:43191", origin: REVIEW_ORIGIN };
 
-async function approveProposal(changeId: string, activeProject: string) {
+async function mintReview(changeId: string, activeProject: string) {
   const rid = `${changeId}#proposal.md`;
   const mint = new Request(`${REVIEW_ORIGIN}/review-sessions`, {
     method: "POST",
@@ -144,7 +144,11 @@ async function approveProposal(changeId: string, activeProject: string) {
   });
   const minted = await review.handlePlanReview(mint, new URL(mint.url));
   expect(minted?.status).toBe(201);
-  const { reviewUrl } = await minted!.json() as { reviewUrl: string };
+  return (await minted!.json() as { reviewUrl: string }).reviewUrl;
+}
+
+async function approveProposal(changeId: string, activeProject: string) {
+  const reviewUrl = await mintReview(changeId, activeProject);
   const req = new Request(`${REVIEW_ORIGIN}/api/approve`, {
     method: "POST",
     headers: { ...REVIEW_HEADERS, "content-type": "application/json", referer: `${REVIEW_ORIGIN}${reviewUrl}` },
@@ -152,6 +156,29 @@ async function approveProposal(changeId: string, activeProject: string) {
   });
   return review.handlePlanReview(req, new URL(req.url));
 }
+
+test("review denial persists authority and routes structured feedback", async () => {
+  const activeProject = bridge.resolveProjectCwd(null)!;
+  const changeId = "human-denial";
+  const dir = join(activeProject, "openspec", "changes", changeId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "proposal.md"), "# Human denial\n\nNeeds revision.\n");
+
+  try {
+    expect(review.planReviewAvailable()).toBe(true);
+    const reviewUrl = await mintReview(changeId, activeProject);
+    const req = new Request(`${REVIEW_ORIGIN}/api/deny`, {
+      method: "POST",
+      headers: { ...REVIEW_HEADERS, "content-type": "application/json", referer: `${REVIEW_ORIGIN}${reviewUrl}` },
+      body: JSON.stringify({ feedback: "Clarify the acceptance criteria.", annotations: [] }),
+    });
+    const response = await review.handlePlanReview(req, new URL(req.url));
+    expect(response?.status).toBe(200);
+    expect(openspec.artifactVerdict(activeProject, changeId, "proposal")).toBe("red");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("review approval ignores legacy SQLite-only agent verdicts", async () => {
   const activeProject = bridge.resolveProjectCwd(null)!;

--- a/tests/runtime-events.spec.ts
+++ b/tests/runtime-events.spec.ts
@@ -51,7 +51,9 @@ test("runtime materializes delegation, tool, and model event variants", () => {
       { provider: "provider", modelId: "catalog", name: "Catalog", api: "responses", reasoning: true, thinkingLevels: ["low", "high"], contextWindow: 100_000, maxTokens: 8_000, costRates: { input: 1, output: 2 } },
       { provider: "provider", modelId: "minimal", reasoning: false, thinkingLevels: "unknown", contextWindow: 0, maxTokens: 0 },
     ] }),
-    event(10, "delegation_progress", { from: "Builder", text: "ignored" }),
+    event(10, "review_verdict", { changeId: " add-runtime-coverage ", reviewer: "Reviewer", verdict: "green", summary: "ready", evidence: ["tests"], concerns: [], blockers: [] }),
+    event(11, "review_verdict", { changeId: "", verdict: "red" }),
+    event(12, "delegation_progress", { from: "Builder", text: "ignored" }),
   ];
   writeFileSync(log, `${rows.join("\n")}\n`);
   runtime.addSource(log, { session_id: "runtime-events", cwd: "/runtime-events" });
@@ -70,6 +72,24 @@ test("runtime materializes delegation, tool, and model event variants", () => {
   expect(models.some((model) => model.provider === "provider" && model.modelId === "catalog")).toBe(true);
   expect(models.some((model) => model.provider === "provider" && model.modelId === "model" && model.thinkingLevels?.includes("high"))).toBe(true);
   expect(runtime.queryEvents({ session: "runtime-events" }).some((row) => row.type === "delegation_progress")).toBe(false);
+});
+
+test("runtime prune removes stale sessions and source watchers through one path", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-hive-runtime-prune-"));
+  const log = join(dir, "hive-events.jsonl");
+  writeFileSync(log, `${JSON.stringify({
+    event_id: "runtime-prune-old", session_id: "runtime-prune", seq: 1,
+    ts: "2010-01-01T00:00:00.000Z", type: "user_message", actor: "User", pid: 1,
+    cwd: dir, payload: { text: "old" },
+  })}\n`);
+  runtime.addSource(log, { session_id: "runtime-prune", cwd: dir });
+  expect(runtime.sourcePaths()).toContain(log);
+  const pruned = runtime.pruneTelemetry("2015-01-01T00:00:00.000Z");
+  expect(pruned.events).toBeGreaterThanOrEqual(1);
+  expect(pruned.sessions).toBeGreaterThanOrEqual(1);
+  expect(runtime.sourcePaths()).not.toContain(log);
+  expect(runtime.deleteSessions([])).toBe(0);
+  expect(runtime.deleteProject("missing-project")).toBe(0);
 });
 
 test("snapshot topology fallback loads both configured teams and caches the result", () => {

--- a/tests/sse.spec.ts
+++ b/tests/sse.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  broadcastEvent,
+  broadcastEventWithId,
+  broadcastFrame,
+  broadcastPing,
+  eventFrame,
+  subscribers,
+} from "../src/observability/server/sse.ts";
+
+function subscriber(options: { desiredSize?: number | null; closeThrows?: boolean; enqueueThrows?: boolean } = {}) {
+  const chunks: Uint8Array[] = [];
+  let closed = false;
+  const controller = {
+    get desiredSize() { return options.desiredSize === undefined ? 1024 : options.desiredSize; },
+    enqueue(chunk: Uint8Array) {
+      if (options.enqueueThrows) throw new Error("closed");
+      chunks.push(chunk);
+    },
+    close() {
+      closed = true;
+      if (options.closeThrows) throw new Error("already closed");
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  return { controller, chunks, isClosed: () => closed };
+}
+
+afterEach(() => subscribers.clear());
+
+test("SSE frame helpers encode events with and without cursors", () => {
+  expect(eventFrame("hive", { ok: true })).toBe('event: hive\ndata: {"ok":true}\n\n');
+  expect(eventFrame("hive", { ok: true }, 7)).toStartWith("id: 7\n");
+
+  const sub = subscriber({ desiredSize: null });
+  subscribers.add(sub.controller);
+  broadcastEvent("plain", { value: 1 });
+  broadcastEventWithId("cursor", { value: 2 }, 9);
+  expect(sub.chunks).toHaveLength(2);
+  expect(new TextDecoder().decode(sub.chunks[1])).toContain("id: 9");
+});
+
+test("SSE broadcaster drops slow and closed subscribers without throwing", () => {
+  const slow = subscriber({ desiredSize: 1, closeThrows: true });
+  const closed = subscriber({ enqueueThrows: true });
+  subscribers.add(slow.controller);
+  subscribers.add(closed.controller);
+  broadcastFrame('event: hive\ndata: {"large":true}\n\n');
+  expect(slow.isClosed()).toBe(true);
+  expect(subscribers.has(slow.controller)).toBe(false);
+  expect(subscribers.has(closed.controller)).toBe(false);
+});
+
+test("SSE ping is a no-op without subscribers and bounded with subscribers", () => {
+  broadcastPing();
+  const sub = subscriber();
+  subscribers.add(sub.controller);
+  broadcastPing();
+  expect(new TextDecoder().decode(sub.chunks[0])).toBe(": ping\n\n");
+});


### PR DESCRIPTION
## Summary
- raise Bun server runtime coverage from 81.58% to 95.96%
- raise review wiring, plan bridge, and SSE coverage to 100%
- enforce at least 90% lines for every critical Bun server module
- cover thinking-tail incrementality, registry startup, retention pruning, review denial authority, dashboard action routing, and SSE backpressure

## Critical Bun server coverage
- config: 95.16%
- database: 91.89%
- HTTP handler: 90.00%
- JSONL reader: 94.68%
- plan bridge: 100%
- plan routes: 100%
- review wiring: 100%
- runtime: 95.96%
- SSE: 100%
- topology hashing: 100%

T23 now only needs dashboard store/component critical coverage and enforcement.

## Verification
- `just coverage`
- `just ci`
