### PR TITLE
ci: verify generated and vendored artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Verify
         run: just ci
 
+      - name: Require committed generated artifacts
+        run: git diff --exit-code -- ui/web/dist ui/review/dist
+
       - name: Generate coverage reports
         run: just coverage
 

--- a/Justfile
+++ b/Justfile
@@ -210,9 +210,14 @@ dashboard-install:
 dashboard-build:
   cd {{dashboard_dir}} && npm install && npm run build
 
+# Verify the review-only source against the pinned Plannotator package.
+[group('dashboard')]
+review-vendor-verify:
+  node scripts/check-review-vendor.mjs
+
 # Build the committed, review-only UI and deterministic gzip artifacts.
 [group('dashboard')]
-review-build:
+review-build: review-vendor-verify
   node scripts/build-review-bundle.mjs
 
 # Run every strict TypeScript project checker.
@@ -265,6 +270,11 @@ dashboard-test-e2e:
 [group('dashboard')]
 dashboard-verify:
   node scripts/check-dashboard-fresh.mjs
+
+# Rebuild every committed UI artifact and reject any uncommitted output.
+[group('quality')]
+generated-verify: dashboard-build review-build
+  git diff --exit-code -- ui/web/dist ui/review/dist
 
 # Start the dashboard Vite dev server.
 [group('dashboard')]
@@ -332,12 +342,12 @@ verify-budgets:
 
 # Run tests plus verification gates, without packaging dry-run.
 [group('quality')]
-verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify verify-package verify-budgets
+verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify review-vendor-verify verify-package verify-budgets
   @printf "{{GREEN}}All verification gates passed.{{NC}}\n"
 
 # Run all local release/CI gates, including packaging dry-run.
 [group('quality')]
-ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify verify-package verify-budgets pack-dry-run
+ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated-verify verify-package verify-budgets pack-dry-run
   @printf "{{GREEN}}CI gates passed.{{NC}}\n"
 
 # =============================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.80.3",
         "@eslint/js": "^9.39.5",
+        "@plannotator/pi-extension": "0.21.4",
         "@types/bun": "^1.3.14",
         "@types/node": "^22.20.1",
         "c8": "^10.1.3",
@@ -3468,6 +3469,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/@joplin/turndown-plugin-gfm": {
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.67.tgz",
+      "integrity": "sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3518,6 +3526,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3553,6 +3568,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.8.tgz",
+      "integrity": "sha512-HVaWzZ1cW5GDKodivaPCN1hU05DGvoLiG/uvVBNZODD+qY2NTr36KYgATGhb79Vr8OCKNG3qATTWJEwbkMGfzA==",
+      "dev": true,
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.0.3",
+        "@shikijs/transformers": "^3.0.0",
+        "diff": "8.0.3",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz",
+      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3562,6 +3606,48 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@plannotator/pi-extension": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@plannotator/pi-extension/-/pi-extension-0.21.4.tgz",
+      "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@joplin/turndown-plugin-gfm": "^1.0.64",
+        "@pierre/diffs": "1.2.8",
+        "@plannotator/webtui": "0.1.0",
+        "chokidar": "^5.0.0",
+        "parse5": "^7.3.0",
+        "turndown": "^7.2.4"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.74.0"
+      }
+    },
+    "node_modules/@plannotator/webtui": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@plannotator/webtui/-/webtui-0.1.0.tgz",
+      "integrity": "sha512-pwJfFg5VXOwucs55K6mef5fgK5eC8mJrFYc8RJdvB/T00alwnzgDjT/BAsarPiMj4U3NjUZImzxnbypJsn/ESA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xterm/addon-fit": "0.12.0-beta.216",
+        "@xterm/addon-unicode11": "0.10.0-beta.216",
+        "@xterm/addon-web-links": "0.13.0-beta.216",
+        "@xterm/addon-webgl": "0.20.0-beta.215",
+        "@xterm/xterm": "6.1.0-beta.216",
+        "lucide-react": "^0.577.0",
+        "node-pty": "^1.1.0",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || ^19.0.0",
+        "react-dom": "^18.3.0 || ^19.0.0"
       }
     },
     "node_modules/@posthog/core": {
@@ -3577,6 +3663,91 @@
       "version": "1.392.0",
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.0.tgz",
       "integrity": "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
+      "integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/bun": {
@@ -3596,6 +3767,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3610,6 +3791,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -3619,6 +3810,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
@@ -3863,6 +4061,63 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.12.0-beta.216",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.12.0-beta.216.tgz",
+      "integrity": "sha512-IgKE3ngNodSnmj1O+EEYpKQZkSbAUbghPlCWd8G32RL0piIMqb3FX3BuYLnWZeLNoD9iMtublLMG1T9XjGeVvA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^6.1.0-beta.216"
+      }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.10.0-beta.216",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.10.0-beta.216.tgz",
+      "integrity": "sha512-i7TrEHOTzUEOClH1+6IHoHy7bR/XHVRBjHc5e0u6A1HucFkAlCU+bqUY8EfwNOh1/iUjuB06EtNh6BM1o/ZAlA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^6.1.0-beta.216"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.13.0-beta.216",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.13.0-beta.216.tgz",
+      "integrity": "sha512-ZP3BDy1na/37TZHO8FB+XHJFoO8muyPoOzkaL2X28n5A9ZFQPbf834EMRsvDczKnfQvtZcve+ZCmMJj1ZHGjow==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^6.1.0-beta.216"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.20.0-beta.215",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.20.0-beta.215.tgz",
+      "integrity": "sha512-oCbH3YxiGOzRcKxwTfSRCA1TqpoT/AitO2X5MuqD14DVnb4Z3rTKQYfHBA7R6HA7U4K9OzmtIsi5+VyEIEaWsg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^6.1.0-beta.216"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.1.0-beta.216",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.216.tgz",
+      "integrity": "sha512-87rfymzVje5eYUlGG94hz1WkOYvFRcFDGdiOAbg4d8xt8OGSGR2nMNU4I1n5MDE1RBPBqRd+WVJ5w7q3pwMoZA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4094,6 +4349,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -4106,11 +4372,49 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
       "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -4244,6 +4548,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -4306,6 +4621,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4325,6 +4674,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -4899,6 +5261,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4922,6 +5322,17 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -5252,12 +5663,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -5288,6 +5716,28 @@
         "node": ">= 20"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5296,6 +5746,100 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5371,6 +5915,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -5394,6 +5956,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/optionator": {
@@ -5489,6 +6070,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5574,6 +6168,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5602,6 +6207,72 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -5679,6 +6350,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -5713,6 +6392,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5723,6 +6419,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stdin-discarder": {
@@ -5798,6 +6505,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -5940,6 +6662,17 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5970,6 +6703,20 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/type-check": {
@@ -6037,6 +6784,79 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -6091,6 +6911,36 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -6235,6 +7085,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {
@@ -6388,6 +7260,17 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
     "ui/web/dist/",
     "ui/review/src/",
     "ui/review/dist/",
+    "ui/review/vendor.json",
     "scripts/build-review-bundle.mjs",
     "scripts/check-package-budgets.mjs",
+    "scripts/check-review-vendor.mjs",
     "README.md",
     "SECURITY.md",
     "SETUP.md"
@@ -77,6 +79,7 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.80.3",
     "@eslint/js": "^9.39.5",
+    "@plannotator/pi-extension": "0.21.4",
     "@types/bun": "^1.3.14",
     "@types/node": "^22.20.1",
     "c8": "^10.1.3",

--- a/scripts/build-review-bundle.mjs
+++ b/scripts/build-review-bundle.mjs
@@ -4,15 +4,21 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
+import { readVerifiedReviewVendor } from "./check-review-vendor.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const sourceDir = join(root, "ui", "review", "src");
 const distDir = join(root, "ui", "review", "dist");
 const files = ["review.html", "review.css", "review.js"];
 
+const vendor = readVerifiedReviewVendor(root);
 rmSync(distDir, { recursive: true, force: true });
 mkdirSync(distDir, { recursive: true });
-const manifest = { version: 1, files: {} };
+const manifest = {
+  version: 2,
+  vendor: vendor.package,
+  files: {},
+};
 for (const name of files) {
   const source = join(sourceDir, name);
   if (!existsSync(source)) throw new Error(`Missing review bundle source: ${source}`);
@@ -25,6 +31,7 @@ for (const name of files) {
     contentType: name.endsWith(".html") ? "text/html; charset=utf-8" : name.endsWith(".css") ? "text/css; charset=utf-8" : "text/javascript; charset=utf-8",
     bytes: raw.byteLength,
     compressedBytes: compressed.byteLength,
+    sourceSha256: createHash("sha256").update(raw).digest("hex"),
     sha256: createHash("sha256").update(compressed).digest("hex"),
   };
   console.log(`${basename(source)}: ${raw.byteLength} -> ${compressed.byteLength} bytes`);

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -1,41 +1,89 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
-const limits = {
-  packedBytes: 600 * 1024,
-  unpackedBytes: 1536 * 1024,
-  reviewRawBytes: 32 * 1024,
-  reviewCompressedBytes: 10 * 1024,
-};
-const failures = [];
-const manifest = JSON.parse(readFileSync(join(root, "ui", "review", "dist", "manifest.json"), "utf8"));
-const reviewFiles = Object.values(manifest.files || {});
-const reviewRaw = reviewFiles.reduce((sum, file) => sum + Number(file.bytes || 0), 0);
-const reviewCompressed = reviewFiles.reduce((sum, file) => sum + Number(file.compressedBytes || 0), 0);
-if (reviewRaw > limits.reviewRawBytes) failures.push(`review bundle raw size ${reviewRaw} exceeds ${limits.reviewRawBytes} bytes`);
-if (reviewCompressed > limits.reviewCompressedBytes) failures.push(`review bundle compressed size ${reviewCompressed} exceeds ${limits.reviewCompressedBytes} bytes`);
+export const PACKAGE_BASELINES = Object.freeze({
+  packedBytes: 368_000,
+  unpackedBytes: 1_160_000,
+  reviewRawBytes: 12_625,
+  reviewCompressedBytes: 4_304,
+});
+export const MAX_REGRESSION_RATIO = 0.1;
 
-const packed = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd: root, encoding: "utf8" });
-if (packed.status !== 0) {
-  failures.push(`npm pack dry-run failed: ${(packed.stderr || packed.stdout).trim()}`);
-} else {
-  try {
-    const result = JSON.parse(packed.stdout)[0];
-    if (result.size > limits.packedBytes) failures.push(`packed package size ${result.size} exceeds ${limits.packedBytes} bytes`);
-    if (result.unpackedSize > limits.unpackedBytes) failures.push(`unpacked package size ${result.unpackedSize} exceeds ${limits.unpackedBytes} bytes`);
-    console.log(`package: ${result.size} packed / ${result.unpackedSize} unpacked bytes`);
-  } catch (error) {
-    failures.push(`could not parse npm pack dry-run output: ${error instanceof Error ? error.message : String(error)}`);
+const exactPackagePaths = new Set([
+  "LICENSE",
+  "README.md",
+  "SECURITY.md",
+  "SETUP.md",
+  "index.ts",
+  "package.json",
+  "scripts/build-review-bundle.mjs",
+  "scripts/check-package-budgets.mjs",
+  "scripts/check-review-vendor.mjs",
+  "ui/review/dist/manifest.json",
+  "ui/review/dist/review.css.gz",
+  "ui/review/dist/review.html.gz",
+  "ui/review/dist/review.js.gz",
+  "ui/review/src/review.css",
+  "ui/review/src/review.html",
+  "ui/review/src/review.js",
+  "ui/review/vendor.json",
+  "ui/web/dist/.build-hash",
+  "ui/web/dist/index.html",
+]);
+
+const allowedPackagePatterns = [
+  /^src\/(?:agents|core|engine|integration|observability|shared|ui\/tui)\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.ts$/,
+  /^ui\/web\/dist\/assets\/[A-Za-z0-9_-]+\.(?:css|js)$/,
+  /^ui\/web\/dist\/fonts\/[a-z0-9-]+\.woff2$/,
+];
+
+export function regressionLimit(baseline) {
+  return Math.ceil(baseline * (1 + MAX_REGRESSION_RATIO));
+}
+
+export function isAllowedPackagePath(path) {
+  return exactPackagePaths.has(path) || allowedPackagePatterns.some((pattern) => pattern.test(path));
+}
+
+export function checkPackageBudgets(projectRoot = root) {
+  const limits = Object.fromEntries(Object.entries(PACKAGE_BASELINES).map(([name, value]) => [name, regressionLimit(value)]));
+  const failures = [];
+  const manifest = JSON.parse(readFileSync(join(projectRoot, "ui", "review", "dist", "manifest.json"), "utf8"));
+  const reviewFiles = Object.values(manifest.files || {});
+  const reviewRaw = reviewFiles.reduce((sum, file) => sum + Number(file.bytes || 0), 0);
+  const reviewCompressed = reviewFiles.reduce((sum, file) => sum + Number(file.compressedBytes || 0), 0);
+  if (reviewRaw > limits.reviewRawBytes) failures.push(`review bundle raw size ${reviewRaw} exceeds regression limit ${limits.reviewRawBytes} bytes`);
+  if (reviewCompressed > limits.reviewCompressedBytes) failures.push(`review bundle compressed size ${reviewCompressed} exceeds regression limit ${limits.reviewCompressedBytes} bytes`);
+
+  const packed = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd: projectRoot, encoding: "utf8" });
+  if (packed.status !== 0) {
+    failures.push(`npm pack dry-run failed: ${(packed.stderr || packed.stdout).trim()}`);
+  } else {
+    try {
+      const result = JSON.parse(packed.stdout)[0];
+      if (result.size > limits.packedBytes) failures.push(`packed package size ${result.size} exceeds regression limit ${limits.packedBytes} bytes`);
+      if (result.unpackedSize > limits.unpackedBytes) failures.push(`unpacked package size ${result.unpackedSize} exceeds regression limit ${limits.unpackedBytes} bytes`);
+      const unexpected = (result.files || []).map((file) => file.path).filter((path) => !isAllowedPackagePath(path));
+      for (const path of unexpected) failures.push(`package contains non-allowlisted file: ${path}`);
+      console.log(`package: ${result.size} packed / ${result.unpackedSize} unpacked bytes (${result.files?.length ?? 0} allowlisted files)`);
+    } catch (error) {
+      failures.push(`could not parse npm pack dry-run output: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
+  console.log(`review bundle: ${reviewRaw} raw / ${reviewCompressed} compressed bytes`);
+  return failures;
 }
-console.log(`review bundle: ${reviewRaw} raw / ${reviewCompressed} compressed bytes`);
-if (failures.length) {
-  console.error("✗ package budget check failed:");
-  for (const failure of failures) console.error(`  - ${failure}`);
-  process.exit(1);
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const failures = checkPackageBudgets(root);
+  if (failures.length) {
+    console.error("✗ package budget check failed:");
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+  console.log(`✓ package allowlist and ${MAX_REGRESSION_RATIO * 100}% size-regression budgets passed`);
 }
-console.log("✓ package and review bundle budgets are within limits");

--- a/scripts/check-review-vendor.mjs
+++ b/scripts/check-review-vendor.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REVIEW_SOURCE_FILES = ["review.html", "review.css", "review.js"];
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function verifyReviewVendor(root) {
+  const failures = [];
+  let vendor;
+  let pkg;
+  let lock;
+
+  try {
+    vendor = readJson(join(root, "ui", "review", "vendor.json"));
+    pkg = readJson(join(root, "package.json"));
+    lock = readJson(join(root, "package-lock.json"));
+  } catch (error) {
+    return [`could not read review vendor metadata: ${error instanceof Error ? error.message : String(error)}`];
+  }
+
+  if (vendor.schemaVersion !== 1) failures.push("ui/review/vendor.json must use schemaVersion 1");
+  const packageName = vendor.package?.name;
+  const expectedVersion = vendor.package?.version;
+  const lockPath = `node_modules/${packageName}`;
+  const lockEntry = lock.packages?.[lockPath];
+  const declaredVersion = pkg.devDependencies?.[packageName];
+  const lockedRootVersion = lock.packages?.[""]?.devDependencies?.[packageName];
+
+  if (typeof packageName !== "string" || !packageName) failures.push("review vendor package name is missing");
+  if (typeof expectedVersion !== "string" || !expectedVersion) failures.push("review vendor package version is missing");
+  if (declaredVersion !== expectedVersion) failures.push(`package.json must pin ${packageName} to exactly ${expectedVersion}; found ${declaredVersion ?? "missing"}`);
+  if (lockedRootVersion !== expectedVersion) failures.push(`package-lock root must pin ${packageName} to exactly ${expectedVersion}; found ${lockedRootVersion ?? "missing"}`);
+  if (lockEntry?.version !== expectedVersion) failures.push(`package-lock resolved ${packageName} version ${lockEntry?.version ?? "missing"}; expected ${expectedVersion}`);
+  if (lockEntry?.integrity !== vendor.package?.integrity) failures.push(`${packageName} lockfile integrity does not match ui/review/vendor.json`);
+
+  const installedRoot = join(root, "node_modules", ...(typeof packageName === "string" ? packageName.split("/") : []));
+  const installedManifest = join(installedRoot, "package.json");
+  if (!existsSync(installedManifest)) {
+    failures.push(`${packageName || "review vendor package"} is not installed; run npm ci`);
+  } else {
+    try {
+      const installed = readJson(installedManifest);
+      if (installed.version !== expectedVersion) failures.push(`installed ${packageName} version ${installed.version} does not match ${expectedVersion}`);
+      const artifact = join(installedRoot, vendor.package?.artifact || "");
+      if (!existsSync(artifact)) {
+        failures.push(`installed vendor artifact is missing: ${vendor.package?.artifact ?? "unspecified"}`);
+      } else if (sha256File(artifact) !== vendor.package?.artifactSha256) {
+        failures.push(`installed ${packageName}/${vendor.package.artifact} hash does not match ui/review/vendor.json`);
+      }
+    } catch (error) {
+      failures.push(`could not verify installed review vendor: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  for (const name of REVIEW_SOURCE_FILES) {
+    const source = join(root, "ui", "review", "src", name);
+    if (!existsSync(source)) {
+      failures.push(`review source is missing: ${name}`);
+    } else if (sha256File(source) !== vendor.derivedSources?.[name]) {
+      failures.push(`review source ${name} changed without refreshing ui/review/vendor.json`);
+    }
+  }
+
+  return failures;
+}
+
+export function readVerifiedReviewVendor(root) {
+  const failures = verifyReviewVendor(root);
+  if (failures.length) throw new Error(failures.join("\n"));
+  return readJson(join(root, "ui", "review", "vendor.json"));
+}
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const projectRoot = process.argv[2] ? resolve(process.argv[2]) : root;
+  const failures = verifyReviewVendor(projectRoot);
+  if (failures.length) {
+    console.error("✗ review vendor verification failed:");
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+  const vendor = readJson(join(projectRoot, "ui", "review", "vendor.json"));
+  console.log(`✓ review vendor matches ${vendor.package.name}@${vendor.package.version}, lockfile integrity, and source hashes`);
+}

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -5,6 +5,7 @@ import { gzipSync } from "node:zlib";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dashboardSourceHash, STAMP_PATH } from "./dashboard-hash.mjs";
+import { verifyReviewVendor } from "./check-review-vendor.mjs";
 
 const root = join(fileURLToPath(new URL("..", import.meta.url)));
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
@@ -26,12 +27,14 @@ const requiredPaths = [
   "ui/review/src/review.html",
   "ui/review/src/review.css",
   "ui/review/src/review.js",
+  "ui/review/vendor.json",
   "ui/review/dist/review.html.gz",
   "ui/review/dist/review.css.gz",
   "ui/review/dist/review.js.gz",
   "ui/review/dist/manifest.json",
   "scripts/build-review-bundle.mjs",
   "scripts/check-package-budgets.mjs",
+  "scripts/check-review-vendor.mjs",
   "README.md",
   "SETUP.md",
 ];
@@ -42,8 +45,10 @@ const requiredPackageFileEntries = [
   "ui/web/dist/",
   "ui/review/src/",
   "ui/review/dist/",
+  "ui/review/vendor.json",
   "scripts/build-review-bundle.mjs",
   "scripts/check-package-budgets.mjs",
+  "scripts/check-review-vendor.mjs",
   "README.md",
   "SETUP.md",
 ];
@@ -69,18 +74,24 @@ for (const entry of requiredPackageFileEntries) {
 for (const entry of ["ui/web/src/", "ui/web/vendor/", "ui/web/package.json", "ui/web/index.html", "ui/web/tsconfig.json", "ui/web/vite.config.ts"]) {
   if (pkg.files?.includes(entry)) failures.push(`runtime package must not include dashboard build input: ${entry}`);
 }
-if (pkg.devDependencies?.["@plannotator/pi-extension"] || pkg.dependencies?.["@plannotator/pi-extension"]) {
+if (pkg.dependencies?.["@plannotator/pi-extension"]) {
   failures.push("the runtime package must not depend on the full Plannotator extension");
 }
+failures.push(...verifyReviewVendor(root));
 
 try {
   const manifest = JSON.parse(readFileSync(join(root, "ui/review/dist/manifest.json"), "utf8"));
+  const vendor = JSON.parse(readFileSync(join(root, "ui/review/vendor.json"), "utf8"));
+  if (manifest.version !== 2 || JSON.stringify(manifest.vendor) !== JSON.stringify(vendor.package)) {
+    failures.push("review dist vendor metadata is stale; run just review-build");
+  }
   for (const name of ["review.html", "review.css", "review.js"]) {
     const source = readFileSync(join(root, "ui/review/src", name));
     const compressed = gzipSync(source, { level: 9, mtime: 0 });
     const entry = manifest.files?.[name];
     const hash = createHash("sha256").update(compressed).digest("hex");
-    if (!entry || entry.sha256 !== hash || entry.compressedBytes !== compressed.byteLength) failures.push(`review dist is stale for ${name}; run just review-build`);
+    const sourceHash = createHash("sha256").update(source).digest("hex");
+    if (!entry || entry.sha256 !== hash || entry.sourceSha256 !== sourceHash || entry.compressedBytes !== compressed.byteLength) failures.push(`review dist is stale for ${name}; run just review-build`);
   }
 } catch (error) {
   failures.push(`review bundle manifest is invalid: ${error instanceof Error ? error.message : String(error)}`);

--- a/tests/artifact-verification.test.ts
+++ b/tests/artifact-verification.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const VENDOR_SCRIPT = resolve("scripts/check-review-vendor.mjs");
+const BUDGET_SCRIPT = new URL("../scripts/check-package-budgets.mjs", import.meta.url).href;
+
+function sha256(content: string) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function makeVendorFixture() {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-vendor-"));
+  const packageName = "@plannotator/pi-extension";
+  const version = "0.21.4";
+  const integrity = "sha512-test-integrity";
+  const artifact = "upstream review";
+  const sources = {
+    "review.html": "<main>review</main>",
+    "review.css": "main { display: block; }",
+    "review.js": "export {};",
+  };
+  mkdirSync(join(root, "ui", "review", "src"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@plannotator", "pi-extension"), { recursive: true });
+  writeJson(join(root, "package.json"), { devDependencies: { [packageName]: version } });
+  writeJson(join(root, "package-lock.json"), {
+    packages: {
+      "": { devDependencies: { [packageName]: version } },
+      "node_modules/@plannotator/pi-extension": { version, integrity },
+    },
+  });
+  writeJson(join(root, "node_modules", "@plannotator", "pi-extension", "package.json"), { name: packageName, version });
+  writeFileSync(join(root, "node_modules", "@plannotator", "pi-extension", "plannotator.html"), artifact);
+  for (const [name, content] of Object.entries(sources)) writeFileSync(join(root, "ui", "review", "src", name), content);
+  writeJson(join(root, "ui", "review", "vendor.json"), {
+    schemaVersion: 1,
+    package: {
+      name: packageName,
+      version,
+      integrity,
+      artifact: "plannotator.html",
+      artifactSha256: sha256(artifact),
+    },
+    derivedSources: Object.fromEntries(Object.entries(sources).map(([name, content]) => [name, sha256(content)])),
+  });
+  return root;
+}
+
+function runVendorCheck(root: string) {
+  return spawnSync(process.execPath, [VENDOR_SCRIPT, root], { encoding: "utf8" });
+}
+
+test("review vendor verification binds package, lockfile, upstream artifact, and derived sources", (t) => {
+  const root = makeVendorFixture();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const valid = runVendorCheck(root);
+  assert.equal(valid.status, 0, valid.stderr);
+
+  writeJson(join(root, "package.json"), { devDependencies: { "@plannotator/pi-extension": "0.21.5" } });
+  const changedDependency = runVendorCheck(root);
+  assert.equal(changedDependency.status, 1);
+  assert.match(changedDependency.stderr, /must pin .* exactly 0\.21\.4/);
+
+  writeJson(join(root, "package.json"), { devDependencies: { "@plannotator/pi-extension": "0.21.4" } });
+  writeFileSync(join(root, "ui", "review", "src", "review.js"), "changed");
+  const changedSource = runVendorCheck(root);
+  assert.equal(changedSource.status, 1);
+  assert.match(changedSource.stderr, /changed without refreshing ui\/review\/vendor\.json/);
+});
+
+test("package allowlist rejects build inputs, maps, and unrelated files", () => {
+  const expression = `
+    import { isAllowedPackagePath, regressionLimit } from ${JSON.stringify(BUDGET_SCRIPT)};
+    const paths = process.argv.slice(1);
+    console.log(JSON.stringify({ allowed: paths.map(isAllowedPackagePath), limit: regressionLimit(1000) }));
+  `;
+  const paths = [
+    "src/engine/session.ts",
+    "ui/web/dist/assets/index-AbC_123.js",
+    "ui/review/vendor.json",
+    "ui/web/src/App.tsx",
+    "ui/web/dist/assets/index.js.map",
+    "notes/private.txt",
+  ];
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", expression, ...paths], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.allowed, [true, true, true, false, false, false]);
+  assert.equal(output.limit, 1100);
+});

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -10,8 +10,8 @@ test("Pi package manifest keeps a safe extension entrypoint", () => {
   assert.deepEqual(pkg.pi.extensions, ["./index.ts"]);
 });
 
-test("package includes runtime assets and prebuilt dashboard", () => {
-  for (const entry of ["index.ts", "src/", "ui/web/dist/"]) {
+test("package includes runtime assets, prebuilt UIs, and review provenance", () => {
+  for (const entry of ["index.ts", "src/", "ui/web/dist/", "ui/review/dist/", "ui/review/vendor.json", "scripts/check-review-vendor.mjs"]) {
     assert.ok(pkg.files.includes(entry), `files[] should include ${entry}`);
   }
 });
@@ -20,6 +20,11 @@ test("Pi runtime dependencies stay peer dependencies with wildcard ranges", () =
   for (const dep of ["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui", "typebox"]) {
     assert.equal(pkg.peerDependencies[dep], "*");
   }
+});
+
+test("Plannotator is pinned only as a reproducibility dependency", () => {
+  assert.equal(pkg.devDependencies["@plannotator/pi-extension"], "0.21.4");
+  assert.equal(pkg.dependencies?.["@plannotator/pi-extension"], undefined);
 });
 
 test("package scripts delegate to Justfile commands", () => {

--- a/ui/review/dist/manifest.json
+++ b/ui/review/dist/manifest.json
@@ -1,11 +1,19 @@
 {
-  "version": 1,
+  "version": 2,
+  "vendor": {
+    "name": "@plannotator/pi-extension",
+    "version": "0.21.4",
+    "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+    "artifact": "plannotator.html",
+    "artifactSha256": "65c2345124f4e101e88d4cba095fb8bdd179b900fd80976ced9770718cc3c297"
+  },
   "files": {
     "review.html": {
       "path": "review.html.gz",
       "contentType": "text/html; charset=utf-8",
       "bytes": 1781,
       "compressedBytes": 735,
+      "sourceSha256": "a821eb48a2e0c563f0f57bde80b594e01c5067e3ee44cb5be003ee985a10f319",
       "sha256": "c59ade15144aedc62b15885c2a72af4443f4bb116994b88fca6eabda54789f34"
     },
     "review.css": {
@@ -13,6 +21,7 @@
       "contentType": "text/css; charset=utf-8",
       "bytes": 3533,
       "compressedBytes": 1316,
+      "sourceSha256": "a36d17e509875df3f33db0eae9a2c26615cb8b246734c9c34ee5a30c8f07f1ef",
       "sha256": "2c2ab0a5b1a0dea10ade28fa072d64cdeb11deedb083bbf78d1bb81517f2c7f7"
     },
     "review.js": {
@@ -20,6 +29,7 @@
       "contentType": "text/javascript; charset=utf-8",
       "bytes": 7311,
       "compressedBytes": 2253,
+      "sourceSha256": "563557f400de954dfb2c3891524868b3cd8701cb78f1d2759a8744afc74c31b4",
       "sha256": "92c9747e6cc0f3ab0f8c3a80727754927c69e4856106968d372d3b8ddeb3259d"
     }
   }

--- a/ui/review/vendor.json
+++ b/ui/review/vendor.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "package": {
+    "name": "@plannotator/pi-extension",
+    "version": "0.21.4",
+    "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+    "artifact": "plannotator.html",
+    "artifactSha256": "65c2345124f4e101e88d4cba095fb8bdd179b900fd80976ced9770718cc3c297"
+  },
+  "derivedSources": {
+    "review.html": "a821eb48a2e0c563f0f57bde80b594e01c5067e3ee44cb5be003ee985a10f319",
+    "review.css": "a36d17e509875df3f33db0eae9a2c26615cb8b246734c9c34ee5a30c8f07f1ef",
+    "review.js": "563557f400de954dfb2c3891524868b3cd8701cb78f1d2759a8744afc74c31b4"
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild committed dashboard and review artifacts during CI and reject any generated diff
- pin Plannotator as a development-only reproducibility dependency and bind the review surface to its lockfile integrity, upstream artifact hash, and derived source hashes
- carry vendor provenance into the review bundle manifest and fail dependency/source changes until provenance is refreshed
- enforce an npm package file allowlist and 10% size-regression ceilings

## Validation
- `npm ci`
- `just ci`
- `just coverage`
- `just generated-verify`
- root and dashboard `npm audit --audit-level=high`
- artifact/package regression tests