### PR TITLE
chore: add third-party license verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
           node-version: "lts/*"
           cache: "npm"
 
+      - name: Scan third-party licenses and notices
+        run: node scripts/check-licenses.mjs
+
       - name: Audit root dependencies
         run: npm audit --audit-level=high
 

--- a/Justfile
+++ b/Justfile
@@ -340,14 +340,19 @@ verify-package:
 verify-budgets:
   node scripts/check-package-budgets.mjs
 
+# Scan locked dependency licenses and verify redistributed asset notices.
+[group('quality')]
+verify-licenses:
+  node scripts/check-licenses.mjs
+
 # Run tests plus verification gates, without packaging dry-run.
 [group('quality')]
-verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify review-vendor-verify verify-package verify-budgets
+verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify review-vendor-verify verify-package verify-budgets verify-licenses
   @printf "{{GREEN}}All verification gates passed.{{NC}}\n"
 
 # Run all local release/CI gates, including packaging dry-run.
 [group('quality')]
-ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated-verify verify-package verify-budgets pack-dry-run
+ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated-verify verify-package verify-budgets verify-licenses pack-dry-run
   @printf "{{GREEN}}CI gates passed.{{NC}}\n"
 
 # =============================================================================
@@ -356,12 +361,12 @@ ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated
 
 # Rebuild committed UIs and run package verification, matching package prepack.
 [group('package')]
-prepack: dashboard-build review-build verify-package verify-budgets
+prepack: dashboard-build review-build verify-package verify-budgets verify-licenses
   @printf "{{GREEN}}Prepack checks passed.{{NC}}\n"
 
 # Run publish-time checks.
 [group('package')]
-prepublish: test dashboard-verify verify-package verify-budgets
+prepublish: test dashboard-verify verify-package verify-budgets verify-licenses
   @printf "{{GREEN}}Prepublish checks passed.{{NC}}\n"
 
 # Inspect package contents. Runs the package prepack hook.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,159 @@
+# Third-Party Notices
+
+pi-hive includes or redistributes the third-party materials listed below. This
+file is informational; the licenses below apply only to the named materials
+and do not replace pi-hive's MIT license.
+
+## Plannotator
+
+The review-only UI in `ui/review/` is derived from
+`@plannotator/pi-extension` version 0.21.4:
+
+- Project: Plannotator
+- Source: https://github.com/backnotprop/plannotator/tree/v0.21.4
+- Copyright: Copyright (c) 2025 backnotprop
+- Upstream license: MIT OR Apache-2.0
+- License used for this redistribution: MIT
+
+pi-hive extracts and modifies only the review functionality from Plannotator's
+`plannotator.html`; it does not redistribute the full extension. The derived
+source and compressed output are verified against the pinned npm artifact by
+`scripts/check-review-vendor.mjs`.
+
+### MIT License
+
+Copyright (c) 2025 backnotprop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Hanken Grotesk
+
+The dashboard redistributes this Latin-subset web font:
+
+- `ui/web/public/fonts/hanken-grotesk-latin.woff2`
+- Source project: https://github.com/marcologous/hanken-grotesk
+- Copyright: Copyright 2021 The Hanken Grotesk Project Authors
+- Project lead: Alfredo Marco Pradil
+- License: SIL Open Font License 1.1
+
+## DM Mono
+
+The dashboard redistributes these Latin-subset web fonts:
+
+- `ui/web/public/fonts/dm-mono-latin-400.woff2`
+- `ui/web/public/fonts/dm-mono-latin-500.woff2`
+- Source project: https://github.com/googlefonts/dm-mono
+- Copyright: Copyright 2020 The DM Mono Project Authors
+- Typeface design and development: Colophon Foundry, commissioned by DeepMind
+- License: SIL Open Font License 1.1
+
+### SIL Open Font License 1.1
+
+The following terms apply to both Hanken Grotesk and DM Mono.
+
+Copyright 2021 The Hanken Grotesk Project Authors
+
+Copyright 2020 The DM Mono Project Authors
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership with
+others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The fonts,
+including any derivative works, can be bundled, embedded, redistributed
+and/or sold with any software provided that any reserved names are not used
+by derivative works. The fonts and derivatives, however, cannot be released
+under any other type of license. The requirement for fonts to remain under
+this license does not apply to any document created using the fonts or their
+derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright Holder(s)
+under this license and clearly marked as such. This may include source files,
+build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright
+statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or
+substituting -- in part or in whole -- any of the components of the Original
+Version, by changing formats or by porting the Font Software to a new
+environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or
+other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Font Software, to use, study, copy, merge, embed, modify, redistribute,
+and sell modified and unmodified copies of the Font Software, subject to the
+following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original
+or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy contains
+the above copyright notice and this license. These can be included either as
+stand-alone text files, human-readable headers or in the appropriate
+machine-readable metadata fields within text or binary files as long as those
+fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s)
+unless explicit written permission is granted by the corresponding Copyright
+Holder. This restriction only applies to the primary font name as presented
+to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software
+shall not be used to promote, endorse or advertise any Modified Version,
+except to acknowledge the contribution(s) of the Copyright Holder(s) and the
+Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be
+distributed entirely under this license, and must not be distributed under any
+other license. The requirement for fonts to remain under this license does not
+apply to any document created using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
+TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL,
+INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE
+THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "LICENSE",
+    "THIRD_PARTY_NOTICES.md",
     "index.ts",
     "src/",
     "ui/web/dist/",
@@ -40,6 +41,7 @@
     "scripts/build-review-bundle.mjs",
     "scripts/check-package-budgets.mjs",
     "scripts/check-review-vendor.mjs",
+    "scripts/check-licenses.mjs",
     "README.md",
     "SECURITY.md",
     "SETUP.md"
@@ -56,6 +58,7 @@
     "test": "just test",
     "verify:dashboard": "just dashboard-verify",
     "verify:package": "just verify-package",
+    "verify:licenses": "just verify-licenses",
     "ci": "just ci",
     "prepack": "just prepack",
     "prepublishOnly": "just prepublish"

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL("..", import.meta.url)));
+const failures = [];
+
+const allowedLicenses = new Set([
+  "0BSD",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BlueOak-1.0.0",
+  "CC-BY-4.0",
+  "ISC",
+  "MIT",
+  "MIT OR Apache-2.0",
+  "MIT-0",
+  "MPL-2.0",
+  "OFL-1.1",
+  "Python-2.0",
+]);
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+}
+
+function normalizedLicense(value) {
+  return value === "apache-2.0" ? "Apache-2.0" : value;
+}
+
+function scanLockfile(relativePath) {
+  let lock;
+  try {
+    lock = readJson(relativePath);
+  } catch (error) {
+    failures.push(`could not read ${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+    return 0;
+  }
+
+  let scanned = 0;
+  for (const [packagePath, metadata] of Object.entries(lock.packages ?? {})) {
+    if (!packagePath) continue;
+    scanned += 1;
+    const name = metadata.name ?? packagePath.slice(packagePath.lastIndexOf("node_modules/") + 13);
+    const license = normalizedLicense(metadata.license);
+    if (typeof license !== "string" || !license) {
+      failures.push(`${relativePath}: ${name}@${metadata.version ?? "unknown"} has no declared license`);
+    } else if (!allowedLicenses.has(license)) {
+      failures.push(`${relativePath}: ${name}@${metadata.version ?? "unknown"} uses unreviewed license ${license}`);
+    }
+  }
+  return scanned;
+}
+
+const expectedAssets = new Map([
+  ["ui/web/public/fonts/hanken-grotesk-latin.woff2", "a1376a563717f1efa2f5286ab23da2b61ae8dec827a77b97adfa01cad4ec4ee2"],
+  ["ui/web/public/fonts/dm-mono-latin-400.woff2", "7f8712cbbd64135f9e74a527475a97cd8c5a49d8e0a1de7a65f8e2c30c5214d9"],
+  ["ui/web/public/fonts/dm-mono-latin-500.woff2", "e284f2a17fc9cca89cc30f496945bd9a2903010944a9469fb357924da21b6f6c"],
+]);
+
+for (const [relativePath, expectedHash] of expectedAssets) {
+  const absolutePath = join(root, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`licensed asset is missing: ${relativePath}`);
+    continue;
+  }
+  const actualHash = createHash("sha256").update(readFileSync(absolutePath)).digest("hex");
+  if (actualHash !== expectedHash) failures.push(`${relativePath} changed; review its provenance and refresh THIRD_PARTY_NOTICES.md`);
+}
+
+let notices = "";
+try {
+  notices = readFileSync(join(root, "THIRD_PARTY_NOTICES.md"), "utf8");
+} catch (error) {
+  failures.push(`could not read THIRD_PARTY_NOTICES.md: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const requiredNoticeText = [
+  "@plannotator/pi-extension` version 0.21.4",
+  "Copyright (c) 2025 backnotprop",
+  "MIT License",
+  "Copyright 2021 The Hanken Grotesk Project Authors",
+  "https://github.com/marcologous/hanken-grotesk",
+  "Copyright 2020 The DM Mono Project Authors",
+  "https://github.com/googlefonts/dm-mono",
+  "SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007",
+  ...expectedAssets.keys(),
+];
+for (const text of requiredNoticeText) {
+  if (!notices.includes(text)) failures.push(`THIRD_PARTY_NOTICES.md is missing required attribution: ${text}`);
+}
+
+try {
+  const vendor = readJson("ui/review/vendor.json");
+  const packageName = vendor.package?.name;
+  const version = vendor.package?.version;
+  const lock = readJson("package-lock.json");
+  const license = normalizedLicense(lock.packages?.[`node_modules/${packageName}`]?.license);
+  if (packageName !== "@plannotator/pi-extension" || version !== "0.21.4") {
+    failures.push("Plannotator vendor changed; refresh THIRD_PARTY_NOTICES.md and the license checks");
+  }
+  if (license !== "MIT OR Apache-2.0") failures.push(`unexpected Plannotator license: ${license ?? "missing"}`);
+} catch (error) {
+  failures.push(`could not verify Plannotator licensing: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const packageCount = scanLockfile("package-lock.json") + scanLockfile("ui/web/package-lock.json");
+
+if (failures.length) {
+  console.error("✗ third-party license verification failed:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+console.log(`✓ verified notices, 3 vendored font files, and licenses for ${packageCount} locked packages`);

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -15,6 +15,7 @@ export const MAX_REGRESSION_RATIO = 0.1;
 
 const exactPackagePaths = new Set([
   "LICENSE",
+  "THIRD_PARTY_NOTICES.md",
   "README.md",
   "SECURITY.md",
   "SETUP.md",
@@ -23,6 +24,7 @@ const exactPackagePaths = new Set([
   "scripts/build-review-bundle.mjs",
   "scripts/check-package-budgets.mjs",
   "scripts/check-review-vendor.mjs",
+  "scripts/check-licenses.mjs",
   "ui/review/dist/manifest.json",
   "ui/review/dist/review.css.gz",
   "ui/review/dist/review.html.gz",

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -35,8 +35,10 @@ const requiredPaths = [
   "scripts/build-review-bundle.mjs",
   "scripts/check-package-budgets.mjs",
   "scripts/check-review-vendor.mjs",
+  "scripts/check-licenses.mjs",
   "README.md",
   "SETUP.md",
+  "THIRD_PARTY_NOTICES.md",
 ];
 
 const requiredPackageFileEntries = [
@@ -49,8 +51,10 @@ const requiredPackageFileEntries = [
   "scripts/build-review-bundle.mjs",
   "scripts/check-package-budgets.mjs",
   "scripts/check-review-vendor.mjs",
+  "scripts/check-licenses.mjs",
   "README.md",
   "SETUP.md",
+  "THIRD_PARTY_NOTICES.md",
 ];
 
 const requiredPeerDeps = [


### PR DESCRIPTION
## Summary
- add shipped third-party notices for the derived Plannotator review UI
- document Hanken Grotesk and DM Mono provenance and SIL OFL terms
- scan both lockfiles against reviewed license identifiers and pin redistributed font hashes
- enforce license and notice verification in CI, prepack, and prepublish checks

## Validation
- `just ci`
