### PR TITLE
chore(deps): update audited runtime dependencies

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,10 +7,10 @@ and do not replace pi-hive's MIT license.
 ## Plannotator
 
 The review-only UI in `ui/review/` is derived from
-`@plannotator/pi-extension` version 0.21.4:
+`@plannotator/pi-extension` version 0.23.1:
 
 - Project: Plannotator
-- Source: https://github.com/backnotprop/plannotator/tree/v0.21.4
+- Source: https://github.com/backnotprop/plannotator/tree/v0.23.1
 - Copyright: Copyright (c) 2025 backnotprop
 - Upstream license: MIT OR Apache-2.0
 - License used for this redistribution: MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@fission-ai/openspec": "1.5.0"
+        "@fission-ai/openspec": "1.6.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.3",
+        "@earendil-works/pi-coding-agent": "0.80.7",
         "@eslint/js": "^9.39.5",
-        "@plannotator/pi-extension": "0.21.4",
+        "@plannotator/pi-extension": "0.23.1",
         "@types/bun": "^1.3.14",
         "@types/node": "^22.20.1",
         "c8": "^10.1.3",
@@ -328,16 +328,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
+      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-tui": "^0.80.7",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -827,12 +827,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.7",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -842,8 +842,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -867,8 +867,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
-      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/@fission-ai/openspec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.5.0.tgz",
-      "integrity": "sha512-SLZkyF51gFYkISufZKaka0X04z4y/WCjPOcCB+EC7tALd0TC+7V76BOIzWOSIOhdhBWwh5EMIBhrgLnugIh1DA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.6.0.tgz",
+      "integrity": "sha512-7yFTQ3hrrk11mQ2ACClNv2gtAN0o116vCgwoiQKmreoB6ambSnrZh7wf2FNFoSDBXHBi9iiCQ7G16fG71ZNppA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3609,9 +3609,9 @@
       }
     },
     "node_modules/@plannotator/pi-extension": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@plannotator/pi-extension/-/pi-extension-0.21.4.tgz",
-      "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@plannotator/pi-extension/-/pi-extension-0.23.1.tgz",
+      "integrity": "sha512-YjzIsQ+nv+MFe+KItLlGRf/OIaG6m5/oIBLcQkKTM8hmDvjtXraRqTo91GRWzJ3s3fQeXcfzQFBc4APaUYkTsg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -3619,11 +3619,22 @@
         "@pierre/diffs": "1.2.8",
         "@plannotator/webtui": "0.1.0",
         "chokidar": "^5.0.0",
+        "diff": "^8.0.4",
         "parse5": "^7.3.0",
         "turndown": "^7.2.4"
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.74.0"
+      }
+    },
+    "node_modules/@plannotator/pi-extension/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/@plannotator/webtui": {
@@ -6733,9 +6744,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.2.tgz",
-      "integrity": "sha512-/JwVcKLrZkcmqtiX7hhvhxyJxEOSs22bzuTBMdzcdEfl9qNbQ0ZL7sg/z3QLEf7vLxo0TTLyH49Ca7TjagmRvw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
+      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
     }
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.3",
+    "@earendil-works/pi-coding-agent": "0.80.7",
     "@eslint/js": "^9.39.5",
-    "@plannotator/pi-extension": "0.21.4",
+    "@plannotator/pi-extension": "0.23.1",
     "@types/bun": "^1.3.14",
     "@types/node": "^22.20.1",
     "c8": "^10.1.3",
@@ -95,7 +95,7 @@
     "typescript-eslint": "^8.64.0"
   },
   "dependencies": {
-    "@fission-ai/openspec": "1.5.0"
+    "@fission-ai/openspec": "1.6.0"
   },
   "keywords": [
     "pi-package",

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -79,7 +79,7 @@ try {
 }
 
 const requiredNoticeText = [
-  "@plannotator/pi-extension` version 0.21.4",
+  "@plannotator/pi-extension` version 0.23.1",
   "Copyright (c) 2025 backnotprop",
   "MIT License",
   "Copyright 2021 The Hanken Grotesk Project Authors",
@@ -99,7 +99,7 @@ try {
   const version = vendor.package?.version;
   const lock = readJson("package-lock.json");
   const license = normalizedLicense(lock.packages?.[`node_modules/${packageName}`]?.license);
-  if (packageName !== "@plannotator/pi-extension" || version !== "0.21.4") {
+  if (packageName !== "@plannotator/pi-extension" || version !== "0.23.1") {
     failures.push("Plannotator vendor changed; refresh THIRD_PARTY_NOTICES.md and the license checks");
   }
   if (license !== "MIT OR Apache-2.0") failures.push(`unexpected Plannotator license: ${license ?? "missing"}`);

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const reviewVendor = JSON.parse(readFileSync(new URL("../ui/review/vendor.json", import.meta.url), "utf8"));
 
 test("Pi package manifest keeps a safe extension entrypoint", () => {
   assert.equal(pkg.main, "index.ts");
@@ -23,7 +24,7 @@ test("Pi runtime dependencies stay peer dependencies with wildcard ranges", () =
 });
 
 test("Plannotator is pinned only as a reproducibility dependency", () => {
-  assert.equal(pkg.devDependencies["@plannotator/pi-extension"], "0.21.4");
+  assert.equal(pkg.devDependencies["@plannotator/pi-extension"], reviewVendor.package.version);
   assert.equal(pkg.dependencies?.["@plannotator/pi-extension"], undefined);
 });
 

--- a/ui/review/dist/manifest.json
+++ b/ui/review/dist/manifest.json
@@ -2,10 +2,10 @@
   "version": 2,
   "vendor": {
     "name": "@plannotator/pi-extension",
-    "version": "0.21.4",
-    "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+    "version": "0.23.1",
+    "integrity": "sha512-YjzIsQ+nv+MFe+KItLlGRf/OIaG6m5/oIBLcQkKTM8hmDvjtXraRqTo91GRWzJ3s3fQeXcfzQFBc4APaUYkTsg==",
     "artifact": "plannotator.html",
-    "artifactSha256": "65c2345124f4e101e88d4cba095fb8bdd179b900fd80976ced9770718cc3c297"
+    "artifactSha256": "d843509878458c8f369d643c082b9cec04e30905bb6ee6c706c756443c4716e5"
   },
   "files": {
     "review.html": {

--- a/ui/review/vendor.json
+++ b/ui/review/vendor.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "package": {
     "name": "@plannotator/pi-extension",
-    "version": "0.21.4",
-    "integrity": "sha512-Lt0rbT4p6HHFS4/JmaKSBpP7lVGjWfsIeS9ztPIfywB8s00sky3bRZx4MPj4THfQ6IXskMIj1SPzjwre2Qi48A==",
+    "version": "0.23.1",
+    "integrity": "sha512-YjzIsQ+nv+MFe+KItLlGRf/OIaG6m5/oIBLcQkKTM8hmDvjtXraRqTo91GRWzJ3s3fQeXcfzQFBc4APaUYkTsg==",
     "artifact": "plannotator.html",
-    "artifactSha256": "65c2345124f4e101e88d4cba095fb8bdd179b900fd80976ced9770718cc3c297"
+    "artifactSha256": "d843509878458c8f369d643c082b9cec04e30905bb6ee6c706c756443c4716e5"
   },
   "derivedSources": {
     "review.html": "a821eb48a2e0c563f0f57bde80b594e01c5067e3ee44cb5be003ee985a10f319",


### PR DESCRIPTION
## Summary
- update Pi coding agent/TUI and TypeBox patch releases
- update OpenSpec to 1.6.0 while retaining CLI contract coverage
- update Plannotator to 0.23.1 and refresh vendor provenance, generated metadata, and licensing notices
- leave React, Vite, and Tailwind major migrations for separate pull requests

## Verification
- `npm audit --audit-level=high`
- `just verify-budgets`
- `just dashboard-test-e2e`
- `just ci`
