### PR TITLE
ci(release): harden trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
-  id-token: write # required for npm provenance
+  contents: write # attach SBOMs and dependency manifests to the GitHub Release
+  id-token: write # npm trusted publishing and provenance
 
 jobs:
   publish:
+    environment: npm
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -34,7 +35,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: echo "value=${RELEASE_TAG:-$INPUT_TAG}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag must be a v-prefixed semantic version"
+            exit 1
+          fi
+          printf 'value=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,6 +54,9 @@ jobs:
           node-version: "24"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Install trusted-publishing-capable npm
+        run: npm install --global npm@11.18.0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -77,10 +87,35 @@ jobs:
           fi
           echo "Releasing v$PKG"
 
+      - name: Verify GitHub Release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+        run: |
+          NOTES="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+          if [ -z "${NOTES//[[:space:]]/}" ]; then
+            echo "::error::GitHub Release $RELEASE_TAG has no maintained release notes"
+            exit 1
+          fi
+
       - name: Run release gates
         run: just ci
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Verify tagged release state
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+        run: just release-verify
+
+      - name: Publish to npm with trusted publishing
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+        run: npm publish --provenance --access public
+
+      - name: Generate release SBOMs and dependency manifest
+        run: just release-artifacts
+
+      - name: Attach release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+        run: gh release upload "$RELEASE_TAG" release-artifacts/* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ coverage/
 *.db-shm
 *.db-wal
 
-# Package tarball output
+# Package and release artifact output
 *.tgz
+/release-artifacts/
 
 # Local project notes and temporary planning documents
 /notes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to pi-hive are documented here. Release headings match the
+version in `package.json`; the release workflow refuses to publish a version
+without a corresponding section.
+
+## [Unreleased]
+
+### Changed
+
+- Hardened release publishing with protected-environment approval, npm trusted
+  publishing, reproducibility checks, and attached software bills of materials.
+
+## [0.1.0] - 2026-07-05
+
+### Added
+
+- Hierarchical multi-agent orchestration for opted-in Pi projects.
+- OpenSpec-backed planning, review, approval, and execution gates.
+- Local-only telemetry collection and a prebuilt React dashboard.
+- Project-scoped policy enforcement, lifecycle management, and privacy controls.
+
+[Unreleased]: https://github.com/demetere/pi-hive/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/demetere/pi-hive/releases/tag/v0.1.0

--- a/Justfile
+++ b/Justfile
@@ -364,9 +364,19 @@ ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated
 prepack: dashboard-build review-build verify-package verify-budgets verify-licenses
   @printf "{{GREEN}}Prepack checks passed.{{NC}}\n"
 
-# Run publish-time checks.
+# Verify that the checkout is the clean, tagged, reproducible release commit.
 [group('package')]
-prepublish: test dashboard-verify verify-package verify-budgets verify-licenses
+release-verify:
+  node scripts/verify-release.mjs
+
+# Generate CycloneDX SBOMs, a dependency/build manifest, and checksums.
+[group('package')]
+release-artifacts:
+  node scripts/generate-release-artifacts.mjs
+
+# Run publish-time checks, including checks required for direct local publish.
+[group('package')]
+prepublish: typecheck test test-db dashboard-verify review-vendor-verify verify-package verify-budgets verify-licenses release-verify
   @printf "{{GREEN}}Prepublish checks passed.{{NC}}\n"
 
 # Inspect package contents. Runs the package prepack hook.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing pi-hive
+
+## One-time repository configuration
+
+The `Release` workflow publishes through the protected `npm` GitHub environment.
+Keep at least one required reviewer on that environment. In npm package settings,
+configure a **GitHub Actions trusted publisher** for:
+
+- organization/user: `demetere`
+- repository: `pi-hive`
+- workflow: `release.yml`
+- environment: `npm`
+- allowed action: `npm publish`
+
+With an authenticated npm CLI 11.15 or newer, the equivalent configuration is:
+
+```sh
+npm trust github pi-hive --repo demetere/pi-hive --file release.yml \
+  --env npm --allow-publish
+```
+
+The workflow intentionally has no `NPM_TOKEN` fallback. npm authenticates it with
+GitHub OIDC and records provenance for the published package.
+
+## Release process
+
+1. Update `package.json` and `package-lock.json` to the same version.
+2. Move relevant entries from **Unreleased** in `CHANGELOG.md` into a heading of
+   the form `## [x.y.z] - YYYY-MM-DD`.
+3. Run `just ci` and commit all generated output.
+4. Create and push the matching tag (`vx.y.z`) from the clean release commit.
+5. Publish a GitHub Release with maintained release notes. Publishing the release
+   starts the protected `Release` workflow; approve its `npm` environment job.
+
+For an existing GitHub Release and tag, the workflow can be retried with:
+
+```sh
+gh workflow run Release -f tag=vx.y.z
+```
+
+Before npm publishing, the workflow verifies the tag and package versions,
+release notes, dashboard build stamp, Plannotator vendor and review-bundle hashes,
+and a clean Git index/worktree. Direct `npm publish` runs the same release check,
+all TypeScript projects, Node tests, and Bun tests through `prepublishOnly`.
+
+Successful releases attach two CycloneDX SBOMs, a dependency/build manifest, and
+`SHA256SUMS` to the GitHub Release.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "LICENSE",
+    "CHANGELOG.md",
     "THIRD_PARTY_NOTICES.md",
     "index.ts",
     "src/",
@@ -59,6 +60,8 @@
     "verify:dashboard": "just dashboard-verify",
     "verify:package": "just verify-package",
     "verify:licenses": "just verify-licenses",
+    "verify:release": "just release-verify",
+    "release:artifacts": "just release-artifacts",
     "ci": "just ci",
     "prepack": "just prepack",
     "prepublishOnly": "just prepublish"

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -15,6 +15,7 @@ export const MAX_REGRESSION_RATIO = 0.1;
 
 const exactPackagePaths = new Set([
   "LICENSE",
+  "CHANGELOG.md",
   "THIRD_PARTY_NOTICES.md",
   "README.md",
   "SECURITY.md",

--- a/scripts/dashboard-hash.d.mts
+++ b/scripts/dashboard-hash.d.mts
@@ -1,0 +1,3 @@
+export function dashboardSourceHash(webDir?: string): string;
+export function dashboardStampPath(webDir?: string): string;
+export const STAMP_PATH: string;

--- a/scripts/dashboard-hash.mjs
+++ b/scripts/dashboard-hash.mjs
@@ -12,23 +12,27 @@ const WEB_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "ui", "web")
 // dependency bump invalidates the stamp; node_modules and dist are excluded.
 const INPUTS = ["src", "index.html", "vite.config.ts", "tsconfig.json", "package.json", "package-lock.json"];
 
-function walk(abs, acc) {
+function walk(abs, acc, webDir) {
   let st;
   try { st = statSync(abs); } catch { return; }
   if (st.isDirectory()) {
-    for (const name of readdirSync(abs).sort()) walk(join(abs, name), acc);
+    for (const name of readdirSync(abs).sort()) walk(join(abs, name), acc, webDir);
   } else {
-    acc.push([relative(WEB_DIR, abs), readFileSync(abs)]);
+    acc.push([relative(webDir, abs), readFileSync(abs)]);
   }
 }
 
-export function dashboardSourceHash() {
+export function dashboardSourceHash(webDir = WEB_DIR) {
   const files = [];
-  for (const input of INPUTS) walk(join(WEB_DIR, input), files);
+  for (const input of INPUTS) walk(join(webDir, input), files, webDir);
   files.sort((a, b) => a[0].localeCompare(b[0]));
   const h = createHash("sha256");
   for (const [rel, buf] of files) { h.update(rel); h.update("\0"); h.update(buf); h.update("\0"); }
   return h.digest("hex");
 }
 
-export const STAMP_PATH = join(WEB_DIR, "dist", ".build-hash");
+export function dashboardStampPath(webDir = WEB_DIR) {
+  return join(webDir, "dist", ".build-hash");
+}
+
+export const STAMP_PATH = dashboardStampPath();

--- a/scripts/generate-release-artifacts.mjs
+++ b/scripts/generate-release-artifacts.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const outputDir = join(root, "release-artifacts");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const vendor = JSON.parse(readFileSync(join(root, "ui", "review", "vendor.json"), "utf8"));
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function npmSbom(cwd) {
+  const raw = execFileSync("npm", ["sbom", "--sbom-format=cyclonedx"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(raw);
+}
+
+rmSync(outputDir, { recursive: true, force: true });
+mkdirSync(outputDir, { recursive: true });
+
+const packageSbomName = `pi-hive-${pkg.version}.sbom.cdx.json`;
+const dashboardSbomName = `pi-hive-dashboard-${pkg.version}.sbom.cdx.json`;
+writeFileSync(join(outputDir, packageSbomName), `${JSON.stringify(npmSbom(root), null, 2)}\n`);
+writeFileSync(join(outputDir, dashboardSbomName), `${JSON.stringify(npmSbom(join(root, "ui", "web")), null, 2)}\n`);
+
+const manifest = {
+  schemaVersion: 1,
+  package: { name: pkg.name, version: pkg.version },
+  commit: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
+  lockfiles: {
+    "package-lock.json": sha256(join(root, "package-lock.json")),
+    "ui/web/package-lock.json": sha256(join(root, "ui", "web", "package-lock.json")),
+  },
+  builds: {
+    dashboardSourceSha256: readFileSync(join(root, "ui", "web", "dist", ".build-hash"), "utf8").trim(),
+    reviewVendor: vendor.package,
+  },
+  sboms: [packageSbomName, dashboardSbomName],
+};
+const manifestName = `pi-hive-${pkg.version}.dependency-manifest.json`;
+writeFileSync(join(outputDir, manifestName), `${JSON.stringify(manifest, null, 2)}\n`);
+
+const checksums = [packageSbomName, dashboardSbomName, manifestName]
+  .map((name) => `${sha256(join(outputDir, name))}  ${name}`)
+  .join("\n");
+writeFileSync(join(outputDir, "SHA256SUMS"), `${checksums}\n`);
+console.log(`✓ generated ${packageSbomName}, ${dashboardSbomName}, ${manifestName}, and SHA256SUMS`);

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -38,6 +38,7 @@ const requiredPaths = [
   "scripts/check-licenses.mjs",
   "README.md",
   "SETUP.md",
+  "CHANGELOG.md",
   "THIRD_PARTY_NOTICES.md",
 ];
 
@@ -54,6 +55,7 @@ const requiredPackageFileEntries = [
   "scripts/check-licenses.mjs",
   "README.md",
   "SETUP.md",
+  "CHANGELOG.md",
   "THIRD_PARTY_NOTICES.md",
 ];
 

--- a/scripts/verify-release.d.mts
+++ b/scripts/verify-release.d.mts
@@ -1,0 +1,1 @@
+export function verifyRelease(root: string, requestedTag?: string): string[];

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dashboardSourceHash, dashboardStampPath } from "./dashboard-hash.mjs";
+import { verifyReviewVendor } from "./check-review-vendor.mjs";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function verifyRelease(root, requestedTag) {
+  const failures = [];
+  let pkg;
+  let lock;
+  let vendor;
+  let reviewManifest;
+  try {
+    pkg = readJson(join(root, "package.json"));
+    lock = readJson(join(root, "package-lock.json"));
+    vendor = readJson(join(root, "ui", "review", "vendor.json"));
+    reviewManifest = readJson(join(root, "ui", "review", "dist", "manifest.json"));
+  } catch (error) {
+    return [`could not read release metadata: ${error instanceof Error ? error.message : String(error)}`];
+  }
+
+  const expectedTag = `v${pkg.version}`;
+  const releaseTag = requestedTag || expectedTag;
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(releaseTag)) {
+    failures.push(`release tag must be a v-prefixed semantic version; found ${releaseTag || "missing"}`);
+  }
+  if (releaseTag !== expectedTag) failures.push(`tag ${releaseTag} does not match package version ${pkg.version}`);
+  if (lock.version !== pkg.version || lock.packages?.[""]?.version !== pkg.version) {
+    failures.push(`package-lock.json version must match package.json version ${pkg.version}`);
+  }
+
+  const changelogPath = join(root, "CHANGELOG.md");
+  if (!existsSync(changelogPath)) {
+    failures.push("CHANGELOG.md is missing");
+  } else {
+    const changelog = readFileSync(changelogPath, "utf8");
+    if (!new RegExp(`^## \\[${escapeRegExp(pkg.version)}\\](?:\\s|$)`, "m").test(changelog)) {
+      failures.push(`CHANGELOG.md has no release notes for ${pkg.version}`);
+    }
+  }
+
+  const webDir = join(root, "ui", "web");
+  const stampPath = dashboardStampPath(webDir);
+  const stampedHash = existsSync(stampPath) ? readFileSync(stampPath, "utf8").trim() : "";
+  const currentHash = dashboardSourceHash(webDir);
+  if (!stampedHash || stampedHash !== currentHash) failures.push("dashboard build hash is missing or stale");
+
+  failures.push(...verifyReviewVendor(root));
+  if (JSON.stringify(reviewManifest.vendor) !== JSON.stringify(vendor.package)) {
+    failures.push("review bundle vendor metadata does not match ui/review/vendor.json");
+  }
+  for (const [name, metadata] of Object.entries(reviewManifest.files ?? {})) {
+    const source = join(root, "ui", "review", "src", name);
+    const output = join(root, "ui", "review", "dist", metadata.path ?? "");
+    if (!existsSync(source) || sha256File(source) !== metadata.sourceSha256) failures.push(`review source hash mismatch: ${name}`);
+    if (!existsSync(output) || sha256File(output) !== metadata.sha256) failures.push(`review build hash mismatch: ${name}`);
+  }
+
+  try {
+    if (releaseTag === expectedTag && /^v\d/.test(releaseTag)) {
+      const head = git(root, ["rev-parse", "HEAD"]);
+      const tagged = git(root, ["rev-parse", `refs/tags/${releaseTag}^{commit}`]);
+      if (head !== tagged) failures.push(`tag ${releaseTag} does not point at HEAD`);
+    }
+    const status = git(root, ["status", "--porcelain=v1", "--untracked-files=all"]);
+    if (status) failures.push("Git index and worktree must be clean before publishing");
+  } catch (error) {
+    failures.push(`could not verify Git release state: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return failures;
+}
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const tagArgIndex = process.argv.indexOf("--tag");
+  const requestedTag = tagArgIndex >= 0 ? process.argv[tagArgIndex + 1] : process.env.RELEASE_TAG;
+  const failures = verifyRelease(root, requestedTag);
+  if (failures.length) {
+    console.error("✗ release verification failed:");
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+  const pkg = readJson(join(root, "package.json"));
+  console.log(`✓ verified v${pkg.version}, release notes, build/vendor hashes, and clean Git state`);
+}

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -12,7 +12,7 @@ test("Pi package manifest keeps a safe extension entrypoint", () => {
 });
 
 test("package includes runtime assets, prebuilt UIs, and review provenance", () => {
-  for (const entry of ["index.ts", "src/", "ui/web/dist/", "ui/review/dist/", "ui/review/vendor.json", "scripts/check-review-vendor.mjs"]) {
+  for (const entry of ["index.ts", "src/", "ui/web/dist/", "ui/review/dist/", "ui/review/vendor.json", "scripts/check-review-vendor.mjs", "CHANGELOG.md"]) {
     assert.ok(pkg.files.includes(entry), `files[] should include ${entry}`);
   }
 });
@@ -35,4 +35,6 @@ test("package scripts delegate to Justfile commands", () => {
   assert.equal(pkg.scripts.ci, "just ci");
   assert.equal(pkg.scripts.prepack, "just prepack");
   assert.equal(pkg.scripts.prepublishOnly, "just prepublish");
+  assert.equal(pkg.scripts["verify:release"], "just release-verify");
+  assert.equal(pkg.scripts["release:artifacts"], "just release-artifacts");
 });

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { dashboardSourceHash } from "../scripts/dashboard-hash.mjs";
+import { verifyRelease } from "../scripts/verify-release.mjs";
+
+function sha256(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function write(path: string, content: string | Buffer): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function writeJson(path: string, value: unknown): void {
+  write(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function releaseFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-release-"));
+  const version = "1.2.3";
+  const packageName = "@plannotator/pi-extension";
+  const vendorArtifact = "upstream review";
+  const integrity = "sha512-test-integrity";
+  const sources = {
+    "review.html": "<main>review</main>",
+    "review.css": "main { color: green; }",
+    "review.js": "console.log('review');",
+  };
+  const vendorPackage = {
+    name: packageName,
+    version: "0.23.1",
+    integrity,
+    artifact: "plannotator.html",
+    artifactSha256: sha256(vendorArtifact),
+  };
+
+  writeJson(join(root, "package.json"), {
+    name: "pi-hive",
+    version,
+    devDependencies: { [packageName]: vendorPackage.version },
+  });
+  writeJson(join(root, "package-lock.json"), {
+    name: "pi-hive",
+    version,
+    lockfileVersion: 3,
+    packages: {
+      "": { name: "pi-hive", version, devDependencies: { [packageName]: vendorPackage.version } },
+      [`node_modules/${packageName}`]: { version: vendorPackage.version, integrity },
+    },
+  });
+  write(join(root, "CHANGELOG.md"), `# Changelog\n\n## [${version}] - 2026-07-15\n\n- Tested release.\n`);
+  writeJson(join(root, "node_modules", packageName, "package.json"), { name: packageName, version: vendorPackage.version });
+  write(join(root, "node_modules", packageName, "plannotator.html"), vendorArtifact);
+
+  const derivedSources: Record<string, string> = {};
+  const manifestFiles: Record<string, unknown> = {};
+  for (const [name, content] of Object.entries(sources)) {
+    const output = Buffer.from(`compressed:${content}`);
+    write(join(root, "ui", "review", "src", name), content);
+    write(join(root, "ui", "review", "dist", `${name}.gz`), output);
+    derivedSources[name] = sha256(content);
+    manifestFiles[name] = { path: `${name}.gz`, sourceSha256: sha256(content), sha256: sha256(output) };
+  }
+  writeJson(join(root, "ui", "review", "vendor.json"), { schemaVersion: 1, package: vendorPackage, derivedSources });
+  writeJson(join(root, "ui", "review", "dist", "manifest.json"), { version: 2, vendor: vendorPackage, files: manifestFiles });
+
+  const webDir = join(root, "ui", "web");
+  writeJson(join(webDir, "package.json"), { name: "dashboard", version });
+  writeJson(join(webDir, "package-lock.json"), { name: "dashboard", version, lockfileVersion: 3, packages: {} });
+  write(join(webDir, "src", "main.ts"), "export {};\n");
+  write(join(webDir, "dist", ".build-hash"), `${dashboardSourceHash(webDir)}\n`);
+
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "Release Test"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "release@example.test"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "release"], { cwd: root });
+  execFileSync("git", ["tag", `v${version}`], { cwd: root });
+  return root;
+}
+
+test("release verification binds version, tag, notes, builds, vendor, and clean Git state", () => {
+  const root = releaseFixture();
+  assert.deepEqual(verifyRelease(root, "v1.2.3"), []);
+
+  write(join(root, "ui", "web", "src", "main.ts"), "export const stale = true;\n");
+  const failures = verifyRelease(root, "v1.2.3");
+  assert.ok(failures.includes("dashboard build hash is missing or stale"));
+  assert.ok(failures.includes("Git index and worktree must be clean before publishing"));
+});
+
+test("release verification rejects mismatched versions and release notes", () => {
+  const root = releaseFixture();
+  const failures = verifyRelease(root, "v1.2.4");
+  assert.ok(failures.some((failure) => failure.includes("does not match package version")));
+});
+
+test("release workflow uses protected OIDC publishing and attaches manifests", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+  const justfile = readFileSync(new URL("../Justfile", import.meta.url), "utf8");
+  assert.match(workflow, /environment: npm/);
+  assert.match(workflow, /id-token: write/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN/);
+  assert.match(workflow, /npm publish --provenance --access public/);
+  assert.match(workflow, /gh release view .*--json body/);
+  assert.match(workflow, /gh release upload .*release-artifacts\/\*/);
+  assert.match(justfile, /prepublish:.*typecheck.*test-db.*release-verify/);
+});


### PR DESCRIPTION
## Summary
- publish through the reviewer-protected `npm` GitHub environment using npm trusted publishing/OIDC with no long-lived token fallback
- make direct publish run TypeScript, Node, Bun, package, license, build/vendor hash, tag/version, release-note, and clean-tree checks
- generate package and dashboard CycloneDX SBOMs, a dependency/build manifest, and checksums, then attach them to the GitHub Release
- add maintained release notes and release operations documentation

## Repository configuration
- created the `npm` GitHub environment with `demetere` as a required reviewer
- npm registry trusted-publisher configuration is documented in `RELEASING.md`; it requires an authenticated npm maintainer session

## Verification
- `just ci`
- release artifact generation (two SBOMs, dependency manifest, and checksums)
- release workflow YAML parse
- protected environment API verification
