### PR TITLE
test: add packaged Pi acceptance gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -345,6 +345,11 @@ verify-budgets:
 verify-licenses:
   node scripts/check-licenses.mjs
 
+# Install the packed artifact and load it in an isolated, non-opted Pi environment.
+[group('package')]
+verify-packed-install:
+  node scripts/verify-packed-install.mjs
+
 # Run tests plus verification gates, without packaging dry-run.
 [group('quality')]
 verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashboard-verify review-vendor-verify verify-package verify-budgets verify-licenses
@@ -352,7 +357,7 @@ verify: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db dashb
 
 # Run all local release/CI gates, including packaging dry-run.
 [group('quality')]
-ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated-verify verify-package verify-budgets verify-licenses pack-dry-run
+ci: typecheck lint dashboard-test-unit dashboard-test-e2e test test-db generated-verify verify-package verify-budgets verify-licenses pack-dry-run verify-packed-install
   @printf "{{GREEN}}CI gates passed.{{NC}}\n"
 
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test": "just test",
     "verify:dashboard": "just dashboard-verify",
     "verify:package": "just verify-package",
+    "verify:install": "just verify-packed-install",
     "verify:licenses": "just verify-licenses",
     "verify:release": "just release-verify",
     "release:artifacts": "just release-artifacts",

--- a/scripts/verify-packed-install.mjs
+++ b/scripts/verify-packed-install.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const sandbox = mkdtempSync(join(tmpdir(), "pi-hive-packed-install-"));
+const project = join(sandbox, "project");
+const piConfig = join(sandbox, "pi-agent");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
+      ...options.env,
+    },
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) {
+    const details = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} failed${result.status === null ? "" : ` with exit ${result.status}`}\n${details}`,
+      { cause: result.error },
+    );
+  }
+  return result.stdout;
+}
+
+try {
+  writeFileSync(
+    join(sandbox, "package.json"),
+    `${JSON.stringify({ private: true, type: "module" }, null, 2)}\n`,
+  );
+
+  const packed = JSON.parse(
+    run("npm", ["pack", "--json", "--ignore-scripts", "--pack-destination", sandbox]),
+  );
+  const tarballName = packed[0]?.filename;
+  if (typeof tarballName !== "string" || tarballName !== basename(tarballName)) {
+    throw new Error("npm pack did not return a safe tarball filename");
+  }
+  const tarball = resolve(sandbox, tarballName);
+  if (!existsSync(tarball)) throw new Error(`npm pack did not create ${tarballName}`);
+
+  run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball], {
+    cwd: sandbox,
+  });
+
+  const installedRoot = join(sandbox, "node_modules", "pi-hive");
+  const installedPackage = JSON.parse(
+    readFileSync(join(installedRoot, "package.json"), "utf8"),
+  );
+  if (installedPackage.pi?.extensions?.[0] !== "./index.ts") {
+    throw new Error("installed package does not expose index.ts as its Pi extension");
+  }
+  for (const relativePath of [
+    "index.ts",
+    "ui/web/dist/index.html",
+    "ui/review/dist/manifest.json",
+  ]) {
+    if (!existsSync(join(installedRoot, relativePath))) {
+      throw new Error(`installed package is missing ${relativePath}`);
+    }
+  }
+
+  mkdirSync(project);
+  writeFileSync(
+    join(project, ".keep"),
+    "No .pi/hive/hive-config.yaml: the installed extension must remain inert.\n",
+    { flag: "wx" },
+  );
+
+  const piCli = join(sandbox, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+  run(
+    process.execPath,
+    [
+      piCli,
+      "--no-extensions",
+      "--no-skills",
+      "--no-prompt-templates",
+      "--no-themes",
+      "--extension",
+      installedRoot,
+      "--list-models",
+    ],
+    {
+      cwd: project,
+      env: {
+        PI_CODING_AGENT_DIR: piConfig,
+        PI_OFFLINE: "1",
+        PI_TELEMETRY: "0",
+      },
+    },
+  );
+
+  console.log(
+    `✓ installed ${installedPackage.name}@${installedPackage.version} from its packed tarball and loaded it in a clean, non-opted Pi environment`,
+  );
+} finally {
+  rmSync(sandbox, { recursive: true, force: true });
+}

--- a/tests/openspec.test.ts
+++ b/tests/openspec.test.ts
@@ -184,6 +184,40 @@ test("editing approved bytes invalidates that artifact and downstream approvals"
   assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
 });
 
+test("plan advances through automated review and human approval before execution", () => {
+  const cwd = scratch();
+  const dir = changeDir(cwd);
+  writeFileSync(join(dir, "proposal.md"), "# Proposal\n\nAdd authentication.\n");
+  writeFileSync(join(dir, "design.md"), "# Design\n\nUse the existing session boundary.\n");
+  mkdirSync(join(dir, "specs", "auth"), { recursive: true });
+  writeFileSync(join(dir, "specs", "auth", "spec.md"), [
+    "# Authentication specification",
+    "",
+    "## ADDED Requirements",
+    "",
+    "### Requirement: Authenticate users",
+    "The system SHALL authenticate a user with a valid session.",
+    "",
+    "#### Scenario: Valid session",
+    "- **WHEN** a user presents a valid session",
+    "- **THEN** access is granted",
+    "",
+  ].join("\n"));
+  writeFileSync(join(dir, "tasks.md"), "# Tasks\n\n- [ ] 1.1 Implement authentication\n");
+
+  for (const artifact of openspec.ARTIFACT_ORDER) {
+    assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), artifact);
+    openspec.setAgentReviewVerdict(cwd, "add-auth", artifact, "green", "Plan Reviewer");
+    assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), false);
+    openspec.setArtifactApproval(cwd, "add-auth", artifact, "green", "Human Reviewer");
+  }
+
+  assert.equal(openspec.isAwaitingHumanApproval(cwd, "add-auth"), null);
+  assert.equal(openspec.isApprovedForExecution(cwd, "add-auth"), true);
+  openspec.markExecutionTaskComplete(cwd, "add-auth", "1.1", "Execution Lead", "acceptance suite passed");
+  assert.equal(openspec.executionTaskProgress(cwd, "add-auth")[0]?.completed, true);
+});
+
 test("denying an upstream artifact removes downstream human records", () => {
   const cwd = scratch();
   const dir = changeDir(cwd);


### PR DESCRIPTION
## Summary
- install the packed package into an isolated environment during `just ci`
- load the installed extension through Pi in a project without hive opt-in configuration
- cover the complete automated review, human approval, and execution transition

## Verification
- `just ci`
- `just verify`
- root and dashboard `npm audit --audit-level=high`
- focused approval, path, JSONL ingestion, daemon, and session lifecycle suites
