### PR TITLE
feat(policy): enforce filesystem capabilities

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -307,6 +307,9 @@ test:
 test-node-compat:
   node --import tsx --import ./tests/register-ts-loader.mjs --test \
     tests/artifact-contracts.test.ts \
+    tests/capability-filesystem-glob.test.ts \
+    tests/capability-filesystem-policy.test.ts \
+    tests/capability-filesystem-race.test.ts \
     tests/capability-resolution.test.ts \
     tests/capability-tools.test.ts \
     tests/config-budgets.test.ts \

--- a/src/capabilities/filesystem.ts
+++ b/src/capabilities/filesystem.ts
@@ -1,4 +1,3 @@
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { createHash } from "node:crypto";
 import { closeSync, constants, fstatSync, openSync, readSync, statSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
@@ -219,7 +218,12 @@ export interface QueuedMutationResult<T> {
   readonly decision: FilesystemAuthorizationDecision;
 }
 
-const defaultMutationQueue: FilesystemMutationQueue = (targetPath, task) => withFileMutationQueue(targetPath, task);
+const defaultMutationQueue: FilesystemMutationQueue = async (targetPath, task) => {
+  // Keep the Pi runtime dependency lazy so the core policy graph remains
+  // loadable on every supported Node line.
+  const { withFileMutationQueue } = await import("@earendil-works/pi-coding-agent");
+  return withFileMutationQueue(targetPath, task);
+};
 
 /**
  * Custom generic mutations must use this boundary. Authorization is performed

--- a/src/capabilities/filesystem.ts
+++ b/src/capabilities/filesystem.ts
@@ -1,0 +1,308 @@
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, openSync, readSync, statSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+import { isPathInside, resolveCanonicalPath, resolveProjectPath } from "../core/safe-path";
+import { compileFilesystemGlobList, matchFilesystemGlob, normalizeFilesystemRelativePath, type CompiledFilesystemGlob } from "./glob";
+import { checkProtectedPath, type ProtectedPathRoot } from "./reserved-paths";
+import type { EffectiveNodePolicy, FilesystemOperation, NormalizedFilesystemGrant } from "./types";
+
+const MAX_TOOL_PATHS = 32;
+const MAX_DIAGNOSTIC_BYTES = 2_048;
+const MAX_HASH_BYTES = 32 * 1024 * 1024;
+
+interface CompiledGrant {
+  readonly sourcePath: string;
+  readonly lexicalPath: string;
+  readonly canonicalPath: string;
+  readonly operations: ReadonlySet<FilesystemOperation>;
+  readonly include: readonly CompiledFilesystemGlob[];
+  readonly exclude: readonly CompiledFilesystemGlob[];
+  readonly ceilingClause: number;
+}
+export interface CompiledFilesystemPolicy {
+  readonly projectRoot: string;
+  readonly lexicalProjectRoot: string;
+  readonly workflowId: string;
+  readonly nodeId: string;
+  readonly grants: readonly CompiledGrant[];
+  readonly secretPaths: readonly string[];
+  readonly additionalProtectedRoots: readonly ProtectedPathRoot[];
+}
+export interface CompileFilesystemPolicyInput {
+  readonly projectRoot: string;
+  readonly effectivePolicy: EffectiveNodePolicy;
+  readonly secretPaths?: readonly string[];
+  readonly additionalProtectedRoots?: readonly ProtectedPathRoot[];
+  readonly platform?: NodeJS.Platform;
+}
+
+export type FilesystemDecisionCode = "FILESYSTEM_TARGET_INVALID" | "FILESYSTEM_EXISTENCE_MISMATCH" | "FILESYSTEM_PROTECTED" | "FILESYSTEM_SCOPE_DENIED";
+export interface FilesystemAuthorizationRequest { readonly operation: FilesystemOperation; readonly path: string }
+export interface FilesystemAuthorizationDecision {
+  readonly ok: boolean;
+  readonly code?: FilesystemDecisionCode;
+  readonly reason: string;
+  /** Harness-only canonical target. Agent-facing adapters must return `reason`, never this field. */
+  readonly targetPath?: string;
+  /** Harness-only lexical target preserving symlink mutation semantics. */
+  readonly mutationPath?: string;
+  readonly exists?: boolean;
+  readonly ceilingClause?: number;
+}
+
+function clipped(value: string): string {
+  if (Buffer.byteLength(value, "utf8") <= MAX_DIAGNOSTIC_BYTES) return value;
+  let result = value;
+  while (Buffer.byteLength(`${result}…`, "utf8") > MAX_DIAGNOSTIC_BYTES) result = result.slice(0, -1);
+  return `${result}…`;
+}
+function deny(policy: CompiledFilesystemPolicy, request: FilesystemAuthorizationRequest, code: FilesystemDecisionCode, detail: string): FilesystemAuthorizationDecision {
+  return Object.freeze({ ok: false, code, reason: clipped(`Filesystem ${request.operation} denied for ${policy.workflowId}/${policy.nodeId}: ${detail}.`) });
+}
+
+function canonicalGrant(projectRoot: string, grant: NormalizedFilesystemGrant): CompiledGrant {
+  const sourcePath = grant.path.normalize("NFC");
+  const relativePath = sourcePath === "." ? "." : normalizeFilesystemRelativePath(sourcePath);
+  const target = resolveProjectPath(projectRoot, relativePath, { allowMissing: true });
+  if (!target) throw new Error("FILESYSTEM_SCOPE_INVALID");
+  return Object.freeze({
+    sourcePath: relativePath,
+    lexicalPath: target.lexicalPath,
+    canonicalPath: target.canonicalPath,
+    operations: Object.freeze(new Set(grant.operations)),
+    include: compileFilesystemGlobList(grant.include),
+    exclude: compileFilesystemGlobList(grant.exclude),
+    ceilingClause: grant.ceilingClause,
+  });
+}
+
+export function compileFilesystemPolicy(input: CompileFilesystemPolicyInput): CompiledFilesystemPolicy {
+  if ((input.platform ?? process.platform) !== "linux") throw new Error("FILESYSTEM_PLATFORM_UNSUPPORTED");
+  const lexicalProjectRoot = resolve(input.projectRoot);
+  const canonical = resolveCanonicalPath(lexicalProjectRoot);
+  if (!canonical || !canonical.exists || !statSync(canonical.canonicalPath).isDirectory()) throw new Error("FILESYSTEM_PROJECT_ROOT_INVALID");
+  const grants = input.effectivePolicy.capabilities.filesystem.map((grant) => canonicalGrant(lexicalProjectRoot, grant));
+  return Object.freeze({
+    projectRoot: canonical.canonicalPath,
+    lexicalProjectRoot,
+    workflowId: input.effectivePolicy.workflowId,
+    nodeId: input.effectivePolicy.nodeId,
+    grants: Object.freeze(grants),
+    secretPaths: Object.freeze([...(input.secretPaths ?? [])]),
+    additionalProtectedRoots: Object.freeze([...(input.additionalProtectedRoots ?? [])]),
+  });
+}
+
+function grantMatches(grant: CompiledGrant, target: { lexicalPath: string; canonicalPath: string }, operation: FilesystemOperation): boolean {
+  if (!grant.operations.has(operation)) return false;
+  if (!isPathInside(grant.lexicalPath, target.lexicalPath) || !isPathInside(grant.canonicalPath, target.canonicalPath)) return false;
+  const relativeTarget = relative(grant.lexicalPath, target.lexicalPath).split(sep).join("/") || ".";
+  let normalized: string;
+  try { normalized = normalizeFilesystemRelativePath(relativeTarget); } catch { return false; }
+  if (grant.exclude.some((pattern) => matchFilesystemGlob(pattern, normalized))) return false;
+  return grant.include.length === 0 || grant.include.some((pattern) => matchFilesystemGlob(pattern, normalized));
+}
+
+export function authorizeFilesystemOperation(policy: CompiledFilesystemPolicy, request: FilesystemAuthorizationRequest): FilesystemAuthorizationDecision {
+  if (!request || !(["read", "create", "update", "delete"] as readonly string[]).includes(request.operation)
+    || typeof request.path !== "string" || !request.path || Buffer.byteLength(request.path, "utf8") > 4_096 || request.path.includes("\0")) {
+    return deny(policy, request ?? { operation: "read", path: "" }, "FILESYSTEM_TARGET_INVALID", "invalid bounded target");
+  }
+  const target = resolveProjectPath(policy.lexicalProjectRoot, request.path, { allowMissing: request.operation === "create" });
+  if (!target) return deny(policy, request, "FILESYSTEM_TARGET_INVALID", "target is not canonically contained in the project");
+  if ((request.operation === "create" && target.exists) || (request.operation !== "create" && !target.exists)) {
+    return deny(policy, request, "FILESYSTEM_EXISTENCE_MISMATCH", request.operation === "create" ? "target already exists" : "target does not exist");
+  }
+  const reservation = checkProtectedPath(policy.lexicalProjectRoot, request.path, {
+    allowMissing: request.operation === "create",
+    secretPaths: policy.secretPaths,
+    additionalRoots: policy.additionalProtectedRoots,
+  });
+  if (reservation.protected) return deny(policy, request, "FILESYSTEM_PROTECTED", `protected ${reservation.kind ?? "subsystem"} path`);
+  const grant = policy.grants.find((candidate) => grantMatches(candidate, target, request.operation));
+  if (!grant) return deny(policy, request, "FILESYSTEM_SCOPE_DENIED", "no effective scope permits the operation (includes must match and exclusions win)");
+  return Object.freeze({
+    ok: true,
+    reason: clipped(`Filesystem ${request.operation} authorized for ${policy.workflowId}/${policy.nodeId} by ceiling clause ${grant.ceilingClause}.`),
+    targetPath: target.canonicalPath,
+    mutationPath: target.lexicalPath,
+    exists: target.exists,
+    ceilingClause: grant.ceilingClause,
+  });
+}
+
+function extractPaths(toolName: string, input: unknown): string[] {
+  const record = input && typeof input === "object" && !Array.isArray(input) ? input as Record<string, unknown> : {};
+  const values: string[] = [];
+  const add = (value: unknown) => {
+    if (typeof value === "string" && value.trim()) values.push(value.trim());
+    else if (Array.isArray(value)) for (const item of value) add(item);
+  };
+  for (const key of ["path", "paths", "file", "files", "filename", "directory"]) add(record[key]);
+  if (["grep", "find", "ls"].includes(toolName) && values.length === 0) values.push(".");
+  const unique = [...new Set(values)];
+  if (unique.length > MAX_TOOL_PATHS) throw new Error("FILESYSTEM_TOOL_INPUT_LIMIT_EXCEEDED");
+  return unique;
+}
+
+export function classifyFilesystemToolCall(toolName: string, input: unknown, policy: CompiledFilesystemPolicy): FilesystemAuthorizationRequest[] {
+  const paths = extractPaths(toolName, input);
+  if (["read", "write", "edit", "delete"].includes(toolName) && paths.length === 0) throw new Error("FILESYSTEM_TOOL_TARGET_REQUIRED");
+  if (["read", "grep", "find", "ls"].includes(toolName)) return paths.map((path) => ({ operation: "read", path }));
+  if (toolName === "edit") return paths.map((path) => ({ operation: "update", path }));
+  if (toolName === "delete") return paths.map((path) => ({ operation: "delete", path }));
+  if (toolName === "write") return paths.map((path) => {
+    const resolved = resolveProjectPath(policy.lexicalProjectRoot, path, { allowMissing: true });
+    return { operation: resolved?.exists ? "update" : "create", path };
+  });
+  return [];
+}
+
+export function createFilesystemPolicyHook(policy: CompiledFilesystemPolicy): (event: { toolName?: unknown; input?: unknown }) => Promise<{ block: true; reason: string } | undefined> {
+  return async (event) => {
+    try {
+      for (const request of classifyFilesystemToolCall(String(event.toolName ?? ""), event.input, policy)) {
+        const decision = authorizeFilesystemOperation(policy, request);
+        if (!decision.ok) return { block: true, reason: decision.reason };
+      }
+      return undefined;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "invalid tool input";
+      return { block: true, reason: clipped(`Filesystem tool call denied for ${policy.workflowId}/${policy.nodeId}: ${detail}.`) };
+    }
+  };
+}
+
+export interface TrustedStatHashResult {
+  readonly ok: boolean;
+  readonly kind?: "file" | "directory" | "other";
+  readonly size?: number;
+  readonly mtimeMs?: number;
+  readonly sha256?: string;
+  readonly code?: "TARGET_INVALID" | "HASH_LIMIT_EXCEEDED" | "INSPECTION_FAILED";
+}
+export function trustedStatAndHash(projectRoot: string, requestedPath: string): TrustedStatHashResult {
+  const target = resolveProjectPath(projectRoot, requestedPath);
+  if (!target) return Object.freeze({ ok: false, code: "TARGET_INVALID" });
+  let descriptor: number | undefined;
+  try {
+    // Bind inspection to the already-authorized canonical object. O_NOFOLLOW
+    // turns a post-check symlink replacement into a denial instead of hashing a
+    // new referent. Content is consumed only by the digest and never returned.
+    descriptor = openSync(target.canonicalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = fstatSync(descriptor);
+    const kind = stat.isFile() ? "file" : stat.isDirectory() ? "directory" : "other";
+    if (!stat.isFile()) return Object.freeze({ ok: true, kind, size: stat.size, mtimeMs: stat.mtimeMs });
+    if (stat.size > MAX_HASH_BYTES) return Object.freeze({ ok: false, kind, size: stat.size, mtimeMs: stat.mtimeMs, code: "HASH_LIMIT_EXCEEDED" });
+    const hash = createHash("sha256");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let position = 0;
+    while (position < stat.size) {
+      const bytes = readSync(descriptor, buffer, 0, Math.min(buffer.length, stat.size - position), position);
+      if (bytes <= 0) throw new Error("short read");
+      hash.update(buffer.subarray(0, bytes));
+      position += bytes;
+    }
+    return Object.freeze({ ok: true, kind, size: stat.size, mtimeMs: stat.mtimeMs, sha256: hash.digest("hex") });
+  } catch {
+    return Object.freeze({ ok: false, code: "INSPECTION_FAILED" });
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export type FilesystemMutationQueue = <T>(targetPath: string, task: () => Promise<T>) => Promise<T>;
+export interface QueuedMutationResult<T> {
+  readonly ok: boolean;
+  readonly value?: T;
+  readonly decision: FilesystemAuthorizationDecision;
+}
+
+const defaultMutationQueue: FilesystemMutationQueue = (targetPath, task) => withFileMutationQueue(targetPath, task);
+
+/**
+ * Custom generic mutations must use this boundary. Authorization is performed
+ * before admission and again inside Pi's per-file queue immediately before the
+ * trusted callback. The second decision closes symlink/existence swaps while a
+ * mutation waits for the queue.
+ */
+export async function runQueuedFilesystemMutation<T>(
+  policy: CompiledFilesystemPolicy,
+  request: FilesystemAuthorizationRequest,
+  mutate: (canonicalTarget: string) => Promise<T>,
+  queue: FilesystemMutationQueue = defaultMutationQueue,
+): Promise<QueuedMutationResult<T>> {
+  const admitted = authorizeFilesystemOperation(policy, request);
+  if (!admitted.ok || !admitted.mutationPath) return Object.freeze({ ok: false, decision: admitted });
+  try {
+    return await queue(admitted.mutationPath, async () => {
+      const immediate = authorizeFilesystemOperation(policy, request);
+      if (!immediate.ok || !immediate.mutationPath) return Object.freeze({ ok: false, decision: immediate });
+      const value = await mutate(immediate.mutationPath);
+      return Object.freeze({ ok: true, value, decision: immediate });
+    });
+  } catch {
+    return Object.freeze({ ok: false, decision: deny(policy, request, "FILESYSTEM_TARGET_INVALID", "queued mutation failed closed") });
+  }
+}
+
+export interface QueuedSubsystemMutationInput<T> {
+  readonly projectRoot: string;
+  readonly subsystem: "artifact" | "knowledge";
+  readonly request: Readonly<{ operation: "create" | "update" | "delete"; path: string }>;
+  readonly mutate: (canonicalTarget: string) => Promise<T>;
+  readonly queue?: FilesystemMutationQueue;
+  readonly additionalRoots?: readonly ProtectedPathRoot[];
+}
+
+function authorizeSubsystemMutation<T>(input: QueuedSubsystemMutationInput<T>): FilesystemAuthorizationDecision {
+  const pseudoPolicy: CompiledFilesystemPolicy = Object.freeze({
+    projectRoot: resolve(input.projectRoot), lexicalProjectRoot: resolve(input.projectRoot), workflowId: input.subsystem,
+    nodeId: "trusted-facade", grants: Object.freeze([]), secretPaths: Object.freeze([]),
+    additionalProtectedRoots: Object.freeze([...(input.additionalRoots ?? [])]),
+  });
+  const target = resolveProjectPath(input.projectRoot, input.request.path, { allowMissing: input.request.operation === "create" });
+  if (!target) return deny(pseudoPolicy, input.request, "FILESYSTEM_TARGET_INVALID", "target is not canonically contained in the project");
+  if ((input.request.operation === "create" && target.exists) || (input.request.operation !== "create" && !target.exists)) {
+    return deny(pseudoPolicy, input.request, "FILESYSTEM_EXISTENCE_MISMATCH", input.request.operation === "create" ? "target already exists" : "target does not exist");
+  }
+  const reservation = checkProtectedPath(input.projectRoot, input.request.path, {
+    allowMissing: input.request.operation === "create", additionalRoots: input.additionalRoots,
+  });
+  if (!reservation.protected || reservation.kind !== input.subsystem) {
+    return deny(pseudoPolicy, input.request, "FILESYSTEM_PROTECTED", `target is not owned by the ${input.subsystem} facade`);
+  }
+  return Object.freeze({
+    ok: true,
+    reason: clipped(`Filesystem ${input.request.operation} authorized for ${input.subsystem}/trusted-facade.`),
+    targetPath: target.canonicalPath,
+    mutationPath: target.lexicalPath,
+    exists: target.exists,
+  });
+}
+
+/** Dedicated protected-path API for artifact and knowledge subsystem writers. */
+export async function runQueuedSubsystemMutation<T>(input: QueuedSubsystemMutationInput<T>): Promise<QueuedMutationResult<T>> {
+  const admitted = authorizeSubsystemMutation(input);
+  if (!admitted.ok || !admitted.mutationPath) return Object.freeze({ ok: false, decision: admitted });
+  const queue = input.queue ?? defaultMutationQueue;
+  try {
+    return await queue(admitted.mutationPath, async () => {
+      const immediate = authorizeSubsystemMutation(input);
+      if (!immediate.ok || !immediate.mutationPath) return Object.freeze({ ok: false, decision: immediate });
+      const value = await input.mutate(immediate.mutationPath);
+      return Object.freeze({ ok: true, value, decision: immediate });
+    });
+  } catch {
+    const pseudo = compileSubsystemFailurePolicy(input.projectRoot, input.subsystem, input.additionalRoots);
+    return Object.freeze({ ok: false, decision: deny(pseudo, input.request, "FILESYSTEM_TARGET_INVALID", "queued subsystem mutation failed closed") });
+  }
+}
+
+function compileSubsystemFailurePolicy(projectRoot: string, subsystem: "artifact" | "knowledge", roots: readonly ProtectedPathRoot[] | undefined): CompiledFilesystemPolicy {
+  return Object.freeze({
+    projectRoot: resolve(projectRoot), lexicalProjectRoot: resolve(projectRoot), workflowId: subsystem, nodeId: "trusted-facade",
+    grants: Object.freeze([]), secretPaths: Object.freeze([]), additionalProtectedRoots: Object.freeze([...(roots ?? [])]),
+  });
+}

--- a/src/capabilities/glob.ts
+++ b/src/capabilities/glob.ts
@@ -1,0 +1,95 @@
+export const FILESYSTEM_GLOB_LIMITS = Object.freeze({
+  patterns: 64,
+  patternBytes: 4_096,
+  segments: 128,
+  pathBytes: 4_096,
+});
+
+type CompiledSegment = Readonly<{ globstar: true } | { globstar: false; expression: RegExp }>;
+export interface CompiledFilesystemGlob {
+  readonly pattern: string;
+  readonly segments: readonly CompiledSegment[];
+}
+
+function invalid(code: "FILESYSTEM_GLOB_INVALID" | "FILESYSTEM_GLOB_LIMIT_EXCEEDED" | "FILESYSTEM_PATH_INVALID"): never {
+  throw new Error(code);
+}
+
+function hasControl(value: string): boolean {
+  for (const character of value) if (character.codePointAt(0)! <= 0x1f || character.codePointAt(0) === 0x7f) return true;
+  return false;
+}
+
+function normalizeSegments(value: string, kind: "glob" | "path"): string[] {
+  const normalized = value.normalize("NFC");
+  const byteLimit = kind === "glob" ? FILESYSTEM_GLOB_LIMITS.patternBytes : FILESYSTEM_GLOB_LIMITS.pathBytes;
+  const invalidCode = kind === "glob" ? "FILESYSTEM_GLOB_INVALID" : "FILESYSTEM_PATH_INVALID";
+  if (!normalized || Buffer.byteLength(normalized, "utf8") > byteLimit) {
+    if (Buffer.byteLength(normalized, "utf8") > byteLimit) invalid("FILESYSTEM_GLOB_LIMIT_EXCEEDED");
+    invalid(invalidCode);
+  }
+  if (normalized === "." && kind === "path") return [];
+  if (normalized === "." || normalized.startsWith("/") || normalized.startsWith("./") || normalized.includes("\\") || normalized.includes("//") || hasControl(normalized)) invalid(invalidCode);
+  const segments = normalized.split("/");
+  if (segments.length > FILESYSTEM_GLOB_LIMITS.segments) invalid("FILESYSTEM_GLOB_LIMIT_EXCEEDED");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) invalid(invalidCode);
+  return segments;
+}
+
+export function normalizeFilesystemRelativePath(value: string): string {
+  if (typeof value !== "string") invalid("FILESYSTEM_PATH_INVALID");
+  const segments = normalizeSegments(value, "path");
+  if (segments.some((segment) => segment.includes("*") || segment.includes("?") || segment.includes(":"))) invalid("FILESYSTEM_PATH_INVALID");
+  return segments.length === 0 ? "." : segments.join("/");
+}
+
+function escapeRegExp(value: string): string { return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&"); }
+
+function compileSegment(segment: string): CompiledSegment {
+  if (segment === "**") return Object.freeze({ globstar: true });
+  if (segment.includes("**") || segment.includes("[") || segment.includes("]") || /[{}()]/.test(segment)) invalid("FILESYSTEM_GLOB_INVALID");
+  let source = "^";
+  for (const character of segment) {
+    if (character === "*") source += "[^/]*";
+    else if (character === "?") source += "[^/]";
+    else source += escapeRegExp(character);
+  }
+  source += "$";
+  return Object.freeze({ globstar: false, expression: new RegExp(source, "u") });
+}
+
+export function compileFilesystemGlob(pattern: string): CompiledFilesystemGlob {
+  if (typeof pattern !== "string") invalid("FILESYSTEM_GLOB_INVALID");
+  const normalized = pattern.normalize("NFC");
+  if (normalized.startsWith("!") || normalized.includes(":")) invalid("FILESYSTEM_GLOB_INVALID");
+  const segments = normalizeSegments(normalized, "glob");
+  const compiled = Object.freeze(segments.map(compileSegment));
+  return Object.freeze({ pattern: segments.join("/"), segments: compiled });
+}
+
+export function compileFilesystemGlobList(patterns: readonly string[]): readonly CompiledFilesystemGlob[] {
+  if (!Array.isArray(patterns) || patterns.length > FILESYSTEM_GLOB_LIMITS.patterns) invalid("FILESYSTEM_GLOB_LIMIT_EXCEEDED");
+  return Object.freeze(patterns.map(compileFilesystemGlob));
+}
+
+export function matchFilesystemGlob(glob: CompiledFilesystemGlob, value: string): boolean {
+  const normalized = normalizeFilesystemRelativePath(value);
+  const pathSegments = normalized === "." ? [] : normalized.split("/");
+  const memo = new Map<string, boolean>();
+  const visit = (patternIndex: number, pathIndex: number): boolean => {
+    const key = `${patternIndex}:${pathIndex}`;
+    const known = memo.get(key);
+    if (known !== undefined) return known;
+    let result: boolean;
+    if (patternIndex === glob.segments.length) result = pathIndex === pathSegments.length;
+    else {
+      const segment = glob.segments[patternIndex];
+      result = segment.globstar
+        ? visit(patternIndex + 1, pathIndex) || (pathIndex < pathSegments.length && visit(patternIndex, pathIndex + 1))
+        : pathIndex < pathSegments.length && segment.expression.test(pathSegments[pathIndex]) && visit(patternIndex + 1, pathIndex + 1);
+    }
+    memo.set(key, result);
+    return result;
+  };
+  return visit(0, 0);
+}

--- a/src/capabilities/reserved-paths.ts
+++ b/src/capabilities/reserved-paths.ts
@@ -1,0 +1,76 @@
+import { basename, isAbsolute, relative, resolve, sep } from "node:path";
+import { isPathInside, resolveProjectPath } from "../core/safe-path";
+
+export type ProtectedPathKind =
+  | "project-boundary"
+  | "artifact"
+  | "knowledge"
+  | "runtime-session"
+  | "telemetry"
+  | "authority-config"
+  | "credential-secret"
+  | "dashboard-auth"
+  | "git-metadata";
+
+export interface ProtectedPathRoot { readonly path: string; readonly kind: ProtectedPathKind }
+
+export const DEFAULT_PROTECTED_PATHS: readonly ProtectedPathRoot[] = Object.freeze([
+  Object.freeze({ path: ".pi/hive/hive-config.yaml", kind: "authority-config" }),
+  Object.freeze({ path: ".pi/hive/workflows", kind: "authority-config" }),
+  Object.freeze({ path: ".pi/hive/agents", kind: "authority-config" }),
+  Object.freeze({ path: ".pi/hive/skills", kind: "authority-config" }),
+  Object.freeze({ path: ".pi/hive/knowledge", kind: "knowledge" }),
+  Object.freeze({ path: ".pi/hive/sessions", kind: "runtime-session" }),
+  Object.freeze({ path: ".pi/hive/telemetry", kind: "telemetry" }),
+  Object.freeze({ path: ".pi/hive/dashboard-auth", kind: "dashboard-auth" }),
+  // Keep the package-owned state namespace closed even when a future child
+  // directory has not yet been added to the specific registry above.
+  Object.freeze({ path: ".pi/hive", kind: "authority-config" }),
+  Object.freeze({ path: "openspec", kind: "artifact" }),
+  Object.freeze({ path: ".git", kind: "git-metadata" }),
+]);
+
+const CREDENTIAL_NAMES = new Set([
+  ".npmrc", ".pypirc", ".netrc", "credentials", "credentials.json", "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+  "identity", "secring.gpg", "private-key.pem", "private_key.pem",
+]);
+const CREDENTIAL_SUFFIXES = [".key", ".pem", ".p12", ".pfx", ".jks", ".keystore"];
+
+export interface ProtectedPathOptions {
+  readonly allowMissing?: boolean;
+  readonly secretPaths?: readonly string[];
+  readonly additionalRoots?: readonly ProtectedPathRoot[];
+}
+export interface ProtectedPathDecision {
+  readonly protected: boolean;
+  readonly kind?: ProtectedPathKind;
+}
+
+function credentialPath(candidate: string): boolean {
+  const lower = basename(candidate).toLocaleLowerCase("en-US");
+  return lower.startsWith(".env") || CREDENTIAL_NAMES.has(lower) || CREDENTIAL_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+function rootMatch(projectRoot: string, candidateLexical: string, candidateCanonical: string, root: ProtectedPathRoot): boolean {
+  if (!root.path || isAbsolute(root.path)) return false;
+  const protectedLexical = resolve(projectRoot, root.path);
+  const protectedCanonical = resolveProjectPath(projectRoot, root.path, { allowMissing: true });
+  return isPathInside(protectedLexical, candidateLexical)
+    || Boolean(protectedCanonical && isPathInside(protectedCanonical.canonicalPath, candidateCanonical));
+}
+
+export function checkProtectedPath(projectRoot: string, requestedPath: string, options: ProtectedPathOptions = {}): ProtectedPathDecision {
+  const candidate = resolveProjectPath(projectRoot, requestedPath, { allowMissing: options.allowMissing === true });
+  if (!candidate) return Object.freeze({ protected: true, kind: "project-boundary" });
+  if (credentialPath(candidate.lexicalPath) || credentialPath(candidate.canonicalPath)) return Object.freeze({ protected: true, kind: "credential-secret" });
+
+  for (const root of [...DEFAULT_PROTECTED_PATHS, ...(options.additionalRoots ?? [])]) {
+    if (rootMatch(projectRoot, candidate.lexicalPath, candidate.canonicalPath, root)) return Object.freeze({ protected: true, kind: root.kind });
+  }
+  for (const secret of options.secretPaths ?? []) {
+    if (!secret || (isAbsolute(secret) && !isPathInside(projectRoot, secret))) continue;
+    const root: ProtectedPathRoot = { path: relative(projectRoot, resolve(projectRoot, secret)).split(sep).join("/"), kind: "credential-secret" };
+    if (rootMatch(projectRoot, candidate.lexicalPath, candidate.canonicalPath, root)) return Object.freeze({ protected: true, kind: "credential-secret" });
+  }
+  return Object.freeze({ protected: false });
+}

--- a/tests/capability-filesystem-glob.test.ts
+++ b/tests/capability-filesystem-glob.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  FILESYSTEM_GLOB_LIMITS,
+  compileFilesystemGlob,
+  compileFilesystemGlobList,
+  matchFilesystemGlob,
+  normalizeFilesystemRelativePath,
+} from "../src/capabilities/glob.ts";
+
+test("filesystem glob grammar has deterministic segment semantics", () => {
+  const vectors: Array<[string, string, boolean]> = [
+    ["**", ".", true],
+    ["**", ".env", true],
+    ["src/**", "src", true],
+    ["src/**", "src/deep/file.ts", true],
+    ["src/**/file.ts", "src/file.ts", true],
+    ["src/**/file.ts", "src/deep/file.ts", true],
+    ["**/*.ts", "root.ts", true],
+    ["**/*.ts", "src/root.ts", true],
+    ["src/*.ts", "src/root.ts", true],
+    ["src/*.ts", "src/deep/root.ts", false],
+    ["src/?.ts", "src/é.ts", true],
+    ["src/?.ts", "src/ab.ts", false],
+    ["src/.*", "src/.env", true],
+    ["README.md", "readme.md", false],
+  ];
+  for (const [pattern, value, expected] of vectors) {
+    assert.equal(matchFilesystemGlob(compileFilesystemGlob(pattern), value), expected, `${pattern} :: ${value}`);
+  }
+});
+
+test("filesystem glob normalization is NFC, POSIX-only, and rejects ambiguous grammar", () => {
+  assert.equal(compileFilesystemGlob("cafe\u0301/**").pattern, "café/**");
+  assert.equal(normalizeFilesystemRelativePath("cafe\u0301/file.txt"), "café/file.txt");
+  assert.equal(matchFilesystemGlob(compileFilesystemGlob("café/**"), "cafe\u0301/file.txt"), true);
+
+  for (const pattern of ["", ".", "./src/**", "/src/**", "!src/**", "src\\**", "src//**", "src/../x", "src/./x", "src/**x", "src/[ab]", "src/{a,b}", "src/(a)", "src/\u0000x"]) {
+    assert.throws(() => compileFilesystemGlob(pattern), /FILESYSTEM_GLOB_INVALID/, pattern);
+  }
+  for (const value of ["../x", "/x", "src\\x", "src//x", "src/./x", "C:\\x"])
+    assert.throws(() => normalizeFilesystemRelativePath(value), /FILESYSTEM_PATH_INVALID/, value);
+});
+
+test("filesystem glob compilation and evaluation are bounded", () => {
+  assert.throws(
+    () => compileFilesystemGlobList(Array.from({ length: FILESYSTEM_GLOB_LIMITS.patterns + 1 }, (_, index) => `p${index}/**`)),
+    /FILESYSTEM_GLOB_LIMIT_EXCEEDED/,
+  );
+  assert.throws(() => compileFilesystemGlob(`${"a".repeat(FILESYSTEM_GLOB_LIMITS.patternBytes)}/**`), /FILESYSTEM_GLOB_LIMIT_EXCEEDED/);
+  assert.throws(() => compileFilesystemGlob(`${Array.from({ length: FILESYSTEM_GLOB_LIMITS.segments + 1 }, () => "a").join("/")}`), /FILESYSTEM_GLOB_LIMIT_EXCEEDED/);
+  const compiled = compileFilesystemGlobList(["src/**", "tests/**", "docs/**"]);
+  assert.equal(compiled.length, 3);
+  assert.equal(Object.isFrozen(compiled), true);
+});

--- a/tests/capability-filesystem-policy.test.ts
+++ b/tests/capability-filesystem-policy.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  authorizeFilesystemOperation,
+  classifyFilesystemToolCall,
+  compileFilesystemPolicy,
+  createFilesystemPolicyHook,
+  trustedStatAndHash,
+} from "../src/capabilities/filesystem.ts";
+import { normalizeCapabilities } from "../src/capabilities/policy.ts";
+import { DEFAULT_PROTECTED_PATHS, checkProtectedPath } from "../src/capabilities/reserved-paths.ts";
+import type { EffectiveNodePolicy, FilesystemOperation } from "../src/capabilities/types.ts";
+
+function effective(filesystem: EffectiveNodePolicy["capabilities"]["filesystem"]): EffectiveNodePolicy {
+  return {
+    workflowId: "delivery",
+    nodeId: "builder",
+    agentId: "generalist",
+    capabilities: { ...normalizeCapabilities({}), filesystem },
+    provenance: Object.freeze({
+      filesystem: Object.freeze(["agent-ceiling", "workflow-node"]), shell: Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]),
+      git: Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]), "external-network": Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]),
+      "human-input": Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]), artifact: Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]),
+      knowledge: Object.freeze(["agent-ceiling", "workflow-node-omitted-deny"]),
+    }) as EffectiveNodePolicy["provenance"],
+    tools: Object.freeze(["read", "write"]), budgets: Object.freeze({}), skills: Object.freeze([]), knowledge: Object.freeze([]), directMemberIds: Object.freeze([]),
+  };
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-policy-"));
+  mkdirSync(join(root, "workspace", "private"), { recursive: true });
+  mkdirSync(join(root, "workspace", "dir"), { recursive: true });
+  writeFileSync(join(root, "workspace", "existing.txt"), "visible value");
+  writeFileSync(join(root, "workspace", "private", "secret.txt"), "secret value");
+  const capabilities = normalizeCapabilities({
+    filesystem: [{ path: ".", operations: ["read", "create", "update", "delete"], include: ["workspace/**"], exclude: ["workspace/private/**"] }],
+  });
+  return { root, policy: compileFilesystemPolicy({ projectRoot: root, effectivePolicy: effective(capabilities.filesystem) }) };
+}
+
+function decision(policy: ReturnType<typeof compileFilesystemPolicy>, operation: FilesystemOperation, path: string) {
+  return authorizeFilesystemOperation(policy, { operation, path });
+}
+
+test("filesystem policy distinguishes read/create/update/delete and existence", () => {
+  const { policy } = fixture();
+  const rows: Array<[FilesystemOperation, string, boolean]> = [
+    ["read", "workspace/existing.txt", true], ["read", "workspace/dir", true], ["read", "workspace/missing.txt", false],
+    ["create", "workspace/new.txt", true], ["create", "workspace/new-dir", true], ["create", "workspace/existing.txt", false],
+    ["update", "workspace/existing.txt", true], ["update", "workspace/dir", true], ["update", "workspace/missing.txt", false],
+    ["delete", "workspace/existing.txt", true], ["delete", "workspace/dir", true], ["delete", "workspace/missing.txt", false],
+  ];
+  for (const [operation, path, expected] of rows) assert.equal(decision(policy, operation, path).ok, expected, `${operation} ${path}`);
+
+  const readOnly = normalizeCapabilities({ filesystem: [{ path: "workspace", operations: ["read"] }] });
+  const compiled = compileFilesystemPolicy({ projectRoot: policy.projectRoot, effectivePolicy: effective(readOnly.filesystem) });
+  assert.equal(decision(compiled, "read", "workspace/existing.txt").ok, true);
+  for (const operation of ["create", "update", "delete"] as const) assert.equal(decision(compiled, operation, "workspace/existing.txt").ok, false);
+});
+
+test("filesystem filters are scope-relative, exclusions always win, and diagnostics retain bounded provenance", () => {
+  const { policy } = fixture();
+  assert.equal(decision(policy, "read", "workspace/existing.txt").ok, true);
+  const denied = decision(policy, "read", "workspace/private/secret.txt");
+  assert.equal(denied.ok, false);
+  assert.equal(denied.code, "FILESYSTEM_SCOPE_DENIED");
+  assert.doesNotMatch(denied.reason, /secret\.txt|secret value/);
+  assert.match(denied.reason, /delivery\/builder/);
+  assert.ok(Buffer.byteLength(denied.reason, "utf8") <= 2_048);
+
+  const scoped = normalizeCapabilities({ filesystem: [{ path: "workspace", operations: ["read"], include: ["*.txt"], exclude: ["private/**"] }] });
+  const compiled = compileFilesystemPolicy({ projectRoot: policy.projectRoot, effectivePolicy: effective(scoped.filesystem) });
+  assert.equal(decision(compiled, "read", "workspace/existing.txt").ok, true);
+  assert.equal(decision(compiled, "read", "workspace/dir").ok, false);
+});
+
+test("filesystem canonicalization rejects traversal and symlink escape at target, intermediate, and missing-tail ancestors", () => {
+  const { root, policy } = fixture();
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-fs-outside-"));
+  writeFileSync(join(outside, "outside.txt"), "outside");
+  symlinkSync(join(root, "workspace", "existing.txt"), join(root, "workspace", "inside-link"));
+  symlinkSync(join(outside, "outside.txt"), join(root, "workspace", "target-escape"));
+  symlinkSync(outside, join(root, "workspace", "dir-escape"));
+
+  assert.equal(decision(policy, "read", "workspace/inside-link").ok, true);
+  assert.equal(decision(policy, "read", "workspace/target-escape").ok, false);
+  assert.equal(decision(policy, "create", "workspace/dir-escape/new.txt").ok, false);
+  assert.equal(decision(policy, "create", "workspace/../escape.txt").ok, false);
+  assert.equal(decision(policy, "read", join(outside, "outside.txt")).ok, false);
+});
+
+test("all protected subsystem and credential roots override a broad generic grant", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-reserved-"));
+  const broad = normalizeCapabilities({ filesystem: [{ path: ".", operations: ["read", "create", "update", "delete"] }] });
+  const policy = compileFilesystemPolicy({ projectRoot: root, effectivePolicy: effective(broad.filesystem), secretPaths: ["custom/secret-store"] });
+  const paths = [
+    ".pi/hive/hive-config.yaml", ".pi/hive/workflows/build.yaml", ".pi/hive/agents/a.md", ".pi/hive/skills/x/SKILL.md",
+    ".pi/hive/knowledge/shared/knowledge.md", ".pi/hive/sessions/run/journal.jsonl", ".pi/hive/telemetry/events.jsonl",
+    ".pi/hive/dashboard-auth/token", "openspec/changes/x/tasks.md", ".git/config", ".env.local", ".npmrc", "keys/id_ed25519",
+    "custom/secret-store/token.json",
+  ];
+  for (const path of paths) {
+    assert.equal(decision(policy, "create", path).ok, false, path);
+    assert.equal(checkProtectedPath(root, path, { allowMissing: true, secretPaths: ["custom/secret-store"] }).protected, true, path);
+  }
+  assert.ok(DEFAULT_PROTECTED_PATHS.length >= 8);
+});
+
+test("direct and re-enabled file tools are classified and independently policy checked", async () => {
+  const { policy } = fixture();
+  assert.deepEqual(classifyFilesystemToolCall("read", { path: "workspace/existing.txt" }, policy), [{ operation: "read", path: "workspace/existing.txt" }]);
+  assert.deepEqual(classifyFilesystemToolCall("write", { path: "workspace/new.txt" }, policy), [{ operation: "create", path: "workspace/new.txt" }]);
+  assert.deepEqual(classifyFilesystemToolCall("write", { path: "workspace/existing.txt" }, policy), [{ operation: "update", path: "workspace/existing.txt" }]);
+  assert.deepEqual(classifyFilesystemToolCall("edit", { path: "workspace/missing.txt" }, policy), [{ operation: "update", path: "workspace/missing.txt" }]);
+  assert.deepEqual(classifyFilesystemToolCall("delete", { path: "workspace/existing.txt" }, policy), [{ operation: "delete", path: "workspace/existing.txt" }]);
+
+  const hook = createFilesystemPolicyHook(policy);
+  assert.equal(await hook({ toolName: "read", input: { path: "workspace/existing.txt" } }), undefined);
+  const blocked = await hook({ toolName: "read", input: { path: "workspace/private/secret.txt" } });
+  assert.equal(blocked?.block, true);
+  assert.doesNotMatch(blocked?.reason ?? "", /secret\.txt/);
+  assert.equal((await hook({ toolName: "read", input: {} }))?.block, true, "recognized direct tools require an explicit target");
+  assert.equal((await hook({ toolName: "write", input: {} }))?.block, true, "pathless writes must fail closed");
+  assert.equal(await hook({ toolName: "foreign_tool", input: { path: "workspace/private/secret.txt" } }), undefined);
+});
+
+test("trusted stat/hash remains project-contained and exposes no file content", () => {
+  const { root } = fixture();
+  const result = trustedStatAndHash(root, "workspace/existing.txt");
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, "file");
+  assert.match(result.sha256 ?? "", /^[a-f0-9]{64}$/);
+  assert.equal(JSON.stringify(result).includes("visible value"), false);
+  assert.equal("content" in result, false);
+  assert.equal(trustedStatAndHash(root, "../outside.txt").ok, false);
+});
+
+test("first release rejects non-Linux filesystem policy activation explicitly", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-platform-"));
+  const broad = normalizeCapabilities({ filesystem: [{ path: ".", operations: ["read"] }] });
+  assert.throws(() => compileFilesystemPolicy({ projectRoot: root, effectivePolicy: effective(broad.filesystem), platform: "win32" }), /FILESYSTEM_PLATFORM_UNSUPPORTED/);
+});

--- a/tests/capability-filesystem-race.test.ts
+++ b/tests/capability-filesystem-race.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import {
+  authorizeFilesystemOperation,
+  compileFilesystemPolicy,
+  runQueuedFilesystemMutation,
+  runQueuedSubsystemMutation,
+} from "../src/capabilities/filesystem.ts";
+import { normalizeCapabilities } from "../src/capabilities/policy.ts";
+import type { EffectiveNodePolicy } from "../src/capabilities/types.ts";
+
+function policy(root: string) {
+  const capabilities = normalizeCapabilities({ filesystem: [{ path: "workspace", operations: ["create", "update", "delete"] }] });
+  const effective: EffectiveNodePolicy = {
+    workflowId: "wf", nodeId: "worker", agentId: "agent", capabilities,
+    provenance: {
+      filesystem: ["agent-ceiling", "inherited"], shell: ["agent-ceiling", "inherited"], git: ["agent-ceiling", "inherited"],
+      "external-network": ["agent-ceiling", "inherited"], "human-input": ["agent-ceiling", "inherited"], artifact: ["agent-ceiling", "inherited"], knowledge: ["agent-ceiling", "inherited"],
+    },
+    tools: ["write"], budgets: {}, skills: [], knowledge: [], directMemberIds: [],
+  };
+  return compileFilesystemPolicy({ projectRoot: root, effectivePolicy: effective });
+}
+
+test("queued generic mutation rechecks a missing target after an intermediate symlink swap", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-race-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-fs-race-outside-"));
+  mkdirSync(join(root, "workspace", "safe"), { recursive: true });
+  const compiled = policy(root);
+  const request = { operation: "create" as const, path: "workspace/safe/new.txt" };
+  assert.equal(authorizeFilesystemOperation(compiled, request).ok, true);
+
+  let mutated = false;
+  const result = await runQueuedFilesystemMutation(compiled, request, async (target) => {
+    mutated = true;
+    writeFileSync(target, "must not escape");
+  }, async (_target, task) => {
+    rmSync(join(root, "workspace", "safe"), { recursive: true });
+    symlinkSync(outside, join(root, "workspace", "safe"));
+    return task();
+  });
+  assert.equal(result.ok, false);
+  assert.equal(mutated, false);
+  assert.equal(existsSync(join(outside, "new.txt")), false);
+});
+
+test("queued generic mutation rechecks an existing target after a target symlink swap", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-race-target-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-hive-fs-race-target-outside-"));
+  mkdirSync(join(root, "workspace"), { recursive: true });
+  writeFileSync(join(root, "workspace", "target.txt"), "inside");
+  writeFileSync(join(outside, "outside.txt"), "outside");
+  const compiled = policy(root);
+  let mutated = false;
+  const result = await runQueuedFilesystemMutation(compiled, { operation: "update", path: "workspace/target.txt" }, async () => {
+    mutated = true;
+  }, async (_target, task) => {
+    rmSync(join(root, "workspace", "target.txt"));
+    symlinkSync(join(outside, "outside.txt"), join(root, "workspace", "target.txt"));
+    return task();
+  });
+  assert.equal(result.ok, false);
+  assert.equal(mutated, false);
+});
+
+test("queued mutation preserves lexical symlink semantics after canonical authorization", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-symlink-mutation-"));
+  mkdirSync(join(root, "workspace", "actual"), { recursive: true });
+  writeFileSync(join(root, "workspace", "actual", "target.txt"), "inside");
+  symlinkSync(join(root, "workspace", "actual", "target.txt"), join(root, "workspace", "link.txt"));
+  const compiled = policy(root);
+  let callbackTarget = "";
+  const result = await runQueuedFilesystemMutation(compiled, { operation: "delete", path: "workspace/link.txt" }, async (target) => {
+    callbackTarget = target;
+  }, async (_target, task) => task());
+  assert.equal(result.ok, true);
+  assert.equal(callbackTarget, join(root, "workspace", "link.txt"), "the mutation targets the authorized link, not its referent");
+});
+
+test("artifact and knowledge writes succeed only through their dedicated queued facade", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-fs-subsystem-"));
+  mkdirSync(join(root, "workspace"), { recursive: true });
+  mkdirSync(join(root, "openspec", "changes", "x"), { recursive: true });
+  mkdirSync(join(root, ".pi", "hive", "knowledge", "shared"), { recursive: true });
+  const compiled = policy(root);
+  assert.equal(authorizeFilesystemOperation(compiled, { operation: "create", path: "openspec/changes/x/tasks.md" }).ok, false);
+
+  const queued: string[] = [];
+  const queue = async <T>(target: string, task: () => Promise<T>): Promise<T> => { queued.push(target); return task(); };
+  const artifact = await runQueuedSubsystemMutation({
+    projectRoot: root, subsystem: "artifact", request: { operation: "create", path: "openspec/changes/x/tasks.md" }, queue,
+    mutate: async (target) => { mkdirSync(dirname(target), { recursive: true }); writeFileSync(target, "tasks"); return "artifact-ok"; },
+  });
+  const knowledge = await runQueuedSubsystemMutation({
+    projectRoot: root, subsystem: "knowledge", request: { operation: "create", path: ".pi/hive/knowledge/shared/new.md" }, queue,
+    mutate: async (target) => { writeFileSync(target, "knowledge"); return "knowledge-ok"; },
+  });
+  assert.deepEqual([artifact.ok, artifact.value, knowledge.ok, knowledge.value], [true, "artifact-ok", true, "knowledge-ok"]);
+  assert.equal(queued.length, 2);
+  assert.equal(existsSync(join(root, "openspec", "changes", "x", "tasks.md")), true);
+  assert.equal(existsSync(join(root, ".pi", "hive", "knowledge", "shared", "new.md")), true);
+
+  const wrongFacade = await runQueuedSubsystemMutation({
+    projectRoot: root, subsystem: "knowledge", request: { operation: "create", path: "openspec/changes/x/design.md" }, queue,
+    mutate: async () => "must-not-run",
+  });
+  assert.equal(wrongFacade.ok, false);
+});


### PR DESCRIPTION
## Summary
- enforce explicit read, create, update, and delete scopes with canonical containment
- protect subsystem and credential paths from generic tools
- reauthorize queued mutations against symlink and existence races

## Validation
- focused filesystem/glob/race tests (14/14)
- just verify (473 Node, 73 Bun)