### PR TITLE
feat(policy): enforce command and network capabilities

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -310,6 +310,9 @@ test-node-compat:
     tests/capability-filesystem-glob.test.ts \
     tests/capability-filesystem-policy.test.ts \
     tests/capability-filesystem-race.test.ts \
+    tests/capability-command-policy.test.ts \
+    tests/capability-network-policy.test.ts \
+    tests/capability-process-ownership.test.ts \
     tests/capability-resolution.test.ts \
     tests/capability-tools.test.ts \
     tests/config-budgets.test.ts \

--- a/src/capabilities/command.ts
+++ b/src/capabilities/command.ts
@@ -1,0 +1,134 @@
+import type { CompiledFilesystemPolicy, FilesystemAuthorizationDecision } from "./filesystem";
+import { authorizeFilesystemOperation } from "./filesystem";
+import { authorizeNetworkTargets } from "./network";
+import type { FilesystemOperation, NormalizedCapabilities, ShellCapability } from "./types";
+
+export const COMMAND_POLICY_VERSION = "pi-hive-command-policy-v1";
+const MAX_COMMAND_BYTES = 32_768;
+const MAX_TOKENS = 256;
+const MAX_EFFECTS = 64;
+
+export interface CommandEffect { readonly operation: FilesystemOperation; readonly path: string }
+export interface CommandAttemptMetadata {
+  readonly version: typeof COMMAND_POLICY_VERSION;
+  readonly command: string;
+  readonly executable?: string;
+  readonly classes: readonly ShellCapability[];
+  readonly effects: readonly CommandEffect[];
+  readonly networkTargets: readonly string[];
+  readonly git: boolean;
+  readonly mutating: boolean;
+  readonly idempotency: "idempotent" | "non-idempotent" | "unknown";
+  readonly processTreeOwned: true;
+  readonly acceptedRisks: readonly ("bare-filename-read" | "interpreter-hidden-write")[];
+  readonly valid: boolean;
+  readonly reason?: string;
+}
+export interface CommandAuthorization {
+  readonly ok: boolean;
+  readonly reason: string;
+  readonly metadata: CommandAttemptMetadata;
+  readonly filesystem: readonly FilesystemAuthorizationDecision[];
+}
+
+function tokenize(command: string): { tokens: string[]; compound: boolean } | undefined {
+  if (typeof command !== "string" || !command.trim() || Buffer.byteLength(command, "utf8") > MAX_COMMAND_BYTES || command.includes("\0")) return undefined;
+  const tokens: string[] = []; let current = ""; let quote = ""; let escaped = false; let compound = false;
+  const push = () => { if (current) { tokens.push(current); current = ""; } };
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+    if (escaped) { current += character; escaped = false; continue; }
+    if (character === "\\" && quote !== "'") { escaped = true; continue; }
+    if (quote) { if (character === quote) quote = ""; else current += character; continue; }
+    if (character === "'" || character === '"') { quote = character; continue; }
+    if (/\s/u.test(character)) { push(); continue; }
+    if (";|&<>`".includes(character) || (character === "$" && command[index + 1] === "(")) compound = true;
+    current += character;
+  }
+  if (quote || escaped) return undefined;
+  push();
+  if (tokens.length === 0 || tokens.length > MAX_TOKENS) return undefined;
+  return { tokens, compound };
+}
+const CLASS_ORDER: readonly ShellCapability[] = ["inspect", "test", "build", "package", "mutate", "execute-code"];
+function uniqueSorted<T extends string>(values: readonly T[]): readonly T[] { return Object.freeze([...new Set(values)].sort()); }
+function orderedClasses(values: readonly ShellCapability[]): readonly ShellCapability[] { const set = new Set(values); return Object.freeze(CLASS_ORDER.filter((value) => set.has(value))); }
+function effect(operation: FilesystemOperation, path: string): CommandEffect { return Object.freeze({ operation, path }); }
+function hasPathShape(value: string): boolean { return value === "." || value.includes("/") || value.startsWith("."); }
+function remoteGit(tokens: readonly string[]): boolean {
+  const sub = tokens.find((token, index) => index > 0 && !token.startsWith("-"));
+  return ["clone", "fetch", "pull", "push", "ls-remote"].includes(sub ?? "") || tokens.some((token) => /^(?:https?|ssh|git):\/\//u.test(token) || token.includes("@") && token.includes(":"));
+}
+function gitSubcommand(tokens: readonly string[]): string {
+  return tokens.find((token, index) => index > 0 && !token.startsWith("-") && tokens[index - 1] !== "-c") ?? "";
+}
+function networkTargets(tokens: readonly string[], executable: string, gitRemote: boolean): string[] {
+  const results: string[] = [];
+  if (["curl", "wget", "ssh", "scp", "gh"].includes(executable)) for (const token of tokens.slice(1)) if (!token.startsWith("-") && (token.includes("://") || token.includes("@") || token.includes("."))) results.push(token);
+  if (gitRemote) {
+    for (const token of tokens.slice(1)) if (/^(?:https?|ssh|git):\/\//u.test(token) || token.includes("@") && token.includes(":")) results.push(token);
+    if (results.length === 0) results.push("https://git-remote.invalid");
+  }
+  if (["npm", "pnpm", "yarn", "bun", "pip", "pip3"].includes(executable) && ["install", "add", "publish"].includes(tokens[1] ?? "")) results.push("https://registry.npmjs.org");
+  return [...new Set(results)].slice(0, 32);
+}
+
+export function analyzeCommand(command: string): CommandAttemptMetadata {
+  const parsed = tokenize(command);
+  const invalid = (reason: string): CommandAttemptMetadata => Object.freeze({ version: COMMAND_POLICY_VERSION, command: String(command).slice(0, MAX_COMMAND_BYTES), classes: Object.freeze([]), effects: Object.freeze([]), networkTargets: Object.freeze([]), git: false, mutating: false, idempotency: "unknown", processTreeOwned: true, acceptedRisks: Object.freeze([]), valid: false, reason });
+  if (!parsed) return invalid("command is malformed or exceeds policy bounds");
+  const { tokens, compound } = parsed; const executable = tokens[0];
+  const classes: ShellCapability[] = []; const effects: CommandEffect[] = []; const risks: Array<"bare-filename-read" | "interpreter-hidden-write"> = [];
+  let git = false; let mutating = false; let known = false; let opaque = false; let gitRemote = false; let forbiddenAlias = false; let ambiguousEffects = false;
+
+  if (["pwd", "ls", "cat", "head", "tail", "grep", "rg", "find", "stat", "wc", "which", "type", "echo", "printf"].includes(executable)) { classes.push("inspect"); known = true; }
+  if (["node", "python", "python3", "ruby", "perl", "sh", "bash", "zsh", "deno", "tsx"].includes(executable) || executable.startsWith("./")) { classes.push("execute-code"); known = true; opaque = true; }
+  if (["pytest", "jest", "vitest"].includes(executable) || ["npm", "pnpm", "yarn", "bun", "cargo", "go", "just"].includes(executable) && /^(?:run-)?test|^test/u.test(tokens[1] ?? "")) { classes.push("test", "execute-code"); known = true; opaque = true; }
+  if (["tsc", "make", "cmake"].includes(executable) || ["npm", "pnpm", "yarn", "bun", "cargo", "go", "just"].includes(executable) && /build|compile/u.test(tokens.slice(1, 3).join(" "))) { classes.push("build", "execute-code"); known = true; opaque = true; }
+  if (["npm", "pnpm", "yarn", "bun", "pip", "pip3"].includes(executable) && ["install", "add", "publish"].includes(tokens[1] ?? "")) { classes.push("package", "execute-code"); known = true; opaque = true; mutating = true; }
+  if (["npm", "pnpm", "yarn", "bun", "just"].includes(executable) && (tokens[1] === "run" || executable === "just") && !classes.includes("test") && !classes.includes("build")) { classes.push("execute-code"); known = true; opaque = true; }
+  if (executable === "rm") { classes.push("mutate"); known = true; mutating = true; for (const token of tokens.slice(1)) if (!token.startsWith("-")) effects.push(effect("delete", token)); }
+  if (executable === "find" && tokens.includes("-delete")) { classes.push("mutate"); mutating = true; const path = tokens[1]; if (path && !path.startsWith("-")) effects.push(effect("delete", path)); }
+  if (["mkdir", "touch"].includes(executable)) { classes.push("mutate"); known = true; mutating = true; for (const token of tokens.slice(1)) if (!token.startsWith("-")) effects.push(effect("create", token)); }
+  if (["mv", "cp"].includes(executable)) { classes.push("mutate"); known = true; mutating = true; const args = tokens.slice(1).filter((token) => !token.startsWith("-")); if (executable === "mv" && args[0]) effects.push(effect("delete", args[0])); if (args.at(-1)) effects.push(effect("create", args.at(-1)!)); }
+  if (executable === "git") {
+    known = true; git = true; const sub = gitSubcommand(tokens); gitRemote = remoteGit(tokens);
+    const readonly = new Set(["status", "diff", "log", "show", "branch", "tag", "rev-parse", "ls-files"]);
+    if (readonly.has(sub) && !tokens.includes("--delete") && !tokens.includes("-d") && !tokens.includes("-D")) classes.push("inspect");
+    else { classes.push("mutate"); mutating = true; }
+    forbiddenAlias = tokens.some((token) => token.startsWith("alias."));
+    if (mutating || tokens.includes("-c") || tokens.some((token) => token.startsWith("core.hooksPath")) || ["submodule", "hook"].includes(sub)) { classes.push("execute-code"); opaque = true; }
+    if (["checkout", "switch", "reset", "restore", "merge", "rebase", "pull", "submodule"].includes(sub)) { effects.push(effect("update", ".")); ambiguousEffects = true; }
+  }
+  if (["curl", "wget", "ssh", "scp", "gh"].includes(executable)) { classes.push("inspect"); known = true; }
+  if (opaque) risks.push("interpreter-hidden-write");
+  if (["cat", "head", "tail", "less", "more"].includes(executable) && tokens.slice(1).some((token) => !hasPathShape(token))) risks.push("bare-filename-read");
+  const targets = networkTargets(tokens, executable, gitRemote);
+  const pathlessMutation = mutating && effects.length === 0 && !(git && !["checkout", "switch", "reset", "restore", "merge", "rebase", "pull", "submodule"].includes(gitSubcommand(tokens)));
+  const valid = known && !compound && !forbiddenAlias && !ambiguousEffects && !pathlessMutation && effects.length <= MAX_EFFECTS;
+  return Object.freeze({ version: COMMAND_POLICY_VERSION, command, executable, classes: orderedClasses(classes), effects: Object.freeze(effects), networkTargets: Object.freeze(targets), git, mutating, idempotency: mutating ? "non-idempotent" : "idempotent", processTreeOwned: true, acceptedRisks: uniqueSorted(risks), valid, ...(valid ? {} : { reason: compound || forbiddenAlias ? "compound/ambiguous shell syntax" : ambiguousEffects ? "mutation effect set cannot be proven before execution" : pathlessMutation ? "pathless mutation" : "unknown or excessive command effects" }) });
+}
+
+export function authorizeCommand(command: string, capabilities: NormalizedCapabilities, filesystemPolicy?: CompiledFilesystemPolicy): CommandAuthorization {
+  const metadata = analyzeCommand(command); const filesystem: FilesystemAuthorizationDecision[] = [];
+  const deny = (reason: string): CommandAuthorization => Object.freeze({ ok: false, reason, metadata, filesystem: Object.freeze(filesystem) });
+  if (!metadata.valid) return deny(metadata.reason ?? "command classification failed closed");
+  for (const required of metadata.classes) if (!capabilities.shell.includes(required)) return deny(`shell capability ${required} is not granted`);
+  if (metadata.git && !capabilities.git) return deny("Git capability is not granted");
+  if (metadata.networkTargets.length) { const decision = authorizeNetworkTargets(metadata.networkTargets, capabilities.externalNetwork); if (!decision.ok) return deny(decision.reason); }
+  for (const request of metadata.effects) {
+    if (!filesystemPolicy) return deny("filesystem effect requires an effective filesystem policy");
+    const decision = authorizeFilesystemOperation(filesystemPolicy, request); filesystem.push(decision); if (!decision.ok) return deny(decision.reason);
+  }
+  return Object.freeze({ ok: true, reason: "all command classes and effects authorized", metadata, filesystem: Object.freeze(filesystem) });
+}
+
+export function createCommandPolicyHook(capabilities: NormalizedCapabilities, filesystemPolicy?: CompiledFilesystemPolicy): (event: { toolName?: unknown; input?: unknown }) => Promise<{ block: true; reason: string } | undefined> {
+  return async (event) => {
+    if (event.toolName !== "bash") return undefined;
+    const input = event.input && typeof event.input === "object" && !Array.isArray(event.input) ? event.input as Record<string, unknown> : {};
+    const command = typeof input.command === "string" ? input.command : "";
+    const decision = authorizeCommand(command, capabilities, filesystemPolicy);
+    return decision.ok ? undefined : { block: true, reason: decision.reason.slice(0, 2_048) };
+  };
+}

--- a/src/capabilities/network.ts
+++ b/src/capabilities/network.ts
@@ -1,0 +1,50 @@
+import { isIP } from "node:net";
+
+export type NetworkZone = "public" | "protected" | "invalid";
+export interface NetworkTargetDecision { readonly target: string; readonly hostname?: string; readonly zone: NetworkZone; readonly reason: string }
+export interface NetworkAuthorization { readonly ok: boolean; readonly reason: string; readonly targets: readonly NetworkTargetDecision[] }
+
+const MAX_TARGETS = 32;
+const MAX_TARGET_BYTES = 4_096;
+const PROTECTED_NAMES = new Set(["localhost", "localhost.localdomain", "metadata.google.internal", "metadata.azure.internal"]);
+
+function protectedIpv4(value: string): boolean {
+  const parts = value.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  const [a, b] = parts;
+  return a === 0 || a === 10 || a === 127 || (a === 100 && b >= 64 && b <= 127) || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || a >= 224;
+}
+function protectedIp(value: string): boolean {
+  const normalized = value.toLowerCase().replace(/^\[|\]$/g, "");
+  if (isIP(normalized) === 4) return protectedIpv4(normalized);
+  if (isIP(normalized) === 6) return normalized === "::" || normalized === "::1" || normalized.startsWith("fe80:") || normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("ff");
+  return false;
+}
+function hostnameProtected(hostname: string): boolean {
+  const lower = hostname.toLowerCase().replace(/\.$/, "");
+  return PROTECTED_NAMES.has(lower) || lower.endsWith(".localhost") || lower.endsWith(".local") || protectedIp(lower);
+}
+
+export function classifyNetworkTarget(target: string): NetworkTargetDecision {
+  if (typeof target !== "string" || !target || Buffer.byteLength(target, "utf8") > MAX_TARGET_BYTES || target.startsWith("unix:"))
+    return Object.freeze({ target: String(target), zone: target.startsWith?.("unix:") ? "protected" : "invalid", reason: "invalid or protected transport" });
+  try {
+    const url = new URL(target.includes("://") ? target : `https://${target}`);
+    if (!url.hostname || !["http:", "https:", "ssh:", "git:", "ftp:"].includes(url.protocol)) return Object.freeze({ target, zone: "invalid", reason: "unsupported network target" });
+    const zone = hostnameProtected(url.hostname) ? "protected" : "public";
+    return Object.freeze({ target, hostname: url.hostname, zone, reason: zone === "public" ? "public external target" : "loopback/private/link-local/metadata target" });
+  } catch { return Object.freeze({ target, zone: "invalid", reason: "malformed network target" }); }
+}
+
+export function authorizeNetworkTargets(targets: readonly string[], externalNetwork: boolean, resolvedAddresses: Readonly<Record<string, readonly string[]>> = {}): NetworkAuthorization {
+  if (!Array.isArray(targets) || targets.length === 0 || targets.length > MAX_TARGETS) return Object.freeze({ ok: false, reason: "network target list is missing or exceeds its bound", targets: Object.freeze([]) });
+  const decisions = Object.freeze(targets.map(classifyNetworkTarget));
+  if (decisions.some((item) => item.zone !== "public")) return Object.freeze({ ok: false, reason: "protected or invalid network zone", targets: decisions });
+  for (const decision of decisions) {
+    const addresses = decision.hostname ? resolvedAddresses[decision.hostname] : undefined;
+    if (addresses && (addresses.length === 0 || addresses.some(protectedIp))) return Object.freeze({ ok: false, reason: "resolved address enters a protected network zone", targets: decisions });
+  }
+  if (!externalNetwork) return Object.freeze({ ok: false, reason: "external-network capability is not granted", targets: decisions });
+  return Object.freeze({ ok: true, reason: "public external network authorized", targets: decisions });
+}

--- a/src/capabilities/process.ts
+++ b/src/capabilities/process.ts
@@ -1,0 +1,27 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+const OWNED = new WeakSet<object>();
+const TERMINATED = new WeakSet<object>();
+export interface OwnedProcessTree { readonly pid: number; readonly child: ChildProcess; readonly startedAt: number }
+
+export function spawnOwnedProcess(command: string, args: readonly string[], options: SpawnOptions = {}): OwnedProcessTree {
+  if (!command || !Array.isArray(args) || args.length > 256) throw new Error("OWNED_PROCESS_INPUT_INVALID");
+  const child = spawn(command, [...args], { ...options, detached: true });
+  if (typeof child.pid !== "number") { try { child.kill(); } catch { /* best effort */ } throw new Error("OWNED_PROCESS_START_FAILED"); }
+  const handle = Object.freeze({ pid: child.pid, child, startedAt: Date.now() });
+  OWNED.add(handle);
+  return handle;
+}
+
+/** A numeric PID is never authority: only a live handle minted above can signal its process group. */
+export function terminateOwnedProcess(handle: OwnedProcessTree | undefined, signal: NodeJS.Signals = "SIGTERM"): boolean {
+  if (!handle || !OWNED.has(handle) || TERMINATED.has(handle) || handle.child.pid !== handle.pid) return false;
+  TERMINATED.add(handle);
+  try {
+    if (process.platform !== "win32") process.kill(-handle.pid, signal);
+    else handle.child.kill(signal);
+    return true;
+  } catch {
+    try { return handle.child.kill(signal); } catch { return false; }
+  }
+}

--- a/tests/capability-command-policy.test.ts
+++ b/tests/capability-command-policy.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { analyzeCommand, authorizeCommand, createCommandPolicyHook } from "../src/capabilities/command.ts";
+import { normalizeCapabilities } from "../src/capabilities/policy.ts";
+
+const all = normalizeCapabilities({ shell: ["inspect", "test", "build", "package", "mutate", "execute-code"], git: true, "external-network": true });
+
+test("command classifier requires every applicable closed shell class", () => {
+  const rows: Array<[string, string[]]> = [
+    ["git status", ["inspect"]], ["npm test", ["test", "execute-code"]],
+    ["npm run build", ["build", "execute-code"]], ["npm install", ["package", "execute-code"]],
+    ["rm src/a.ts", ["mutate"]], ["node script.js", ["execute-code"]],
+  ];
+  for (const [command, classes] of rows) assert.deepEqual(analyzeCommand(command).classes, classes, command);
+  const denied = authorizeCommand("npm test", normalizeCapabilities({ shell: ["test"] }));
+  assert.equal(denied.ok, false); assert.match(denied.reason, /execute-code/);
+  assert.equal(authorizeCommand("npm test", all).ok, true);
+});
+
+test("opaque interpreters, scripts, package hooks, aliases, and multi-command syntax fail closed", () => {
+  for (const command of ["python -c 'open(\"x\",\"w\")'", "./script.sh", "sh script.sh", "npm run custom", "git alias.do '!rm x'"])
+    assert.equal(analyzeCommand(command).classes.includes("execute-code"), true, command);
+  for (const command of ["unknown-mutator x", "rm", "git -c alias.x='!rm x' x", "echo ok | mystery"])
+    assert.equal(authorizeCommand(command, all).ok, false, command);
+});
+
+test("Git forms are conservative and require Git, network, mutate, and execute-code as applicable", () => {
+  const rows = [
+    ["git status", false, false], ["git commit -m x", true, true], ["git push origin main", true, true],
+    ["git submodule update --init", true, true], ["git -c alias.x='!echo x' x", true, true],
+  ] as const;
+  for (const [command, mutating, opaque] of rows) { const a = analyzeCommand(command); assert.equal(a.git, true); assert.equal(a.mutating, mutating); if (opaque) assert.equal(a.classes.includes("execute-code"), true); }
+  assert.equal(authorizeCommand("git status", normalizeCapabilities({ shell: ["inspect"] })).ok, false);
+  assert.equal(authorizeCommand("git push origin main", normalizeCapabilities({ shell: ["mutate", "execute-code"], git: true })).ok, false);
+  assert.equal(authorizeCommand("git push origin main", all).ok, true);
+  assert.equal(analyzeCommand("git checkout other").valid, false, "worktree-wide effects remain ambiguous without an exact path set");
+  assert.equal(analyzeCommand("git submodule update --init").valid, false);
+});
+
+test("direct or re-enabled Bash calls remain independently checked", async () => {
+  const hook = createCommandPolicyHook(normalizeCapabilities({ shell: ["inspect"] }));
+  assert.equal(await hook({ toolName: "bash", input: { command: "pwd" } }), undefined);
+  assert.match((await hook({ toolName: "bash", input: { command: "node script.js" } }))?.reason ?? "", /execute-code/);
+  assert.equal(await hook({ toolName: "read", input: { path: "x" } }), undefined);
+});
+
+test("known filesystem effects are explicit and pathless mutations fail closed", () => {
+  assert.deepEqual(analyzeCommand("rm src/a.ts src/b.ts").effects, [{ operation: "delete", path: "src/a.ts" }, { operation: "delete", path: "src/b.ts" }]);
+  assert.equal(analyzeCommand("find src -delete").effects[0]?.operation, "delete");
+  assert.equal(authorizeCommand("rm", all).ok, false);
+  assert.equal(analyzeCommand("cat secrets.env").acceptedRisks.includes("bare-filename-read"), true);
+  assert.equal(analyzeCommand("node -e 'write()'").acceptedRisks.includes("interpreter-hidden-write"), true);
+});

--- a/tests/capability-network-policy.test.ts
+++ b/tests/capability-network-policy.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { authorizeNetworkTargets, classifyNetworkTarget } from "../src/capabilities/network.ts";
+
+test("public network requires an explicit grant", () => {
+  assert.equal(authorizeNetworkTargets(["https://example.com"], false).ok, false);
+  assert.equal(authorizeNetworkTargets(["https://example.com"], true).ok, true);
+});
+
+test("protected network zones remain denied regardless of grant", () => {
+  for (const target of ["http://127.0.0.1:43191", "http://localhost", "http://[::1]", "http://10.1.2.3", "http://172.16.1.1", "http://192.168.1.1", "http://169.254.169.254/latest/meta-data", "http://metadata.google.internal", "unix:///tmp/socket", "ssh://user@localhost"])
+    assert.equal(classifyNetworkTarget(target).zone, "protected", target);
+});
+
+test("host resolution evidence fails closed on private rebinding results", () => {
+  assert.equal(authorizeNetworkTargets(["https://public.example"], true, { "public.example": ["203.0.113.4"] }).ok, true);
+  assert.equal(authorizeNetworkTargets(["https://public.example"], true, { "public.example": ["127.0.0.1"] }).ok, false);
+  assert.equal(authorizeNetworkTargets(["not a target"], true).ok, false);
+});

--- a/tests/capability-process-ownership.test.ts
+++ b/tests/capability-process-ownership.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spawnOwnedProcess, terminateOwnedProcess } from "../src/capabilities/process.ts";
+
+test("owned process termination signals only a live handle-created process tree", async () => {
+  const owned = spawnOwnedProcess(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], { stdio: "ignore" });
+  assert.equal(typeof owned.pid, "number");
+  assert.equal(terminateOwnedProcess(owned, "SIGTERM"), true);
+  assert.equal(terminateOwnedProcess(owned, "SIGTERM"), false);
+});
+
+test("unowned or stale PID-shaped values are never kill authority", () => {
+  assert.equal(terminateOwnedProcess({ pid: process.pid } as never), false);
+  assert.equal(terminateOwnedProcess(undefined), false);
+});


### PR DESCRIPTION
## Summary
- classify commands into closed intersecting shell classes and filesystem effects
- gate Git and public network separately while protecting local control zones
- expose bounded attempt metadata and owned process-tree termination

## Validation
- focused policy/process suite (61/61)
- just verify (483 Node, 73 Bun)