### PR TITLE
feat(runtime): add authoritative workflow journal

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -339,6 +339,9 @@ test-node-compat:
     tests/limits.test.ts \
     tests/project-identity.test.ts \
     tests/safe-path.test.ts \
+    tests/workflow-checkpoint.test.ts \
+    tests/workflow-journal.test.ts \
+    tests/workflow-ownership.test.ts \
     tests/yaml.test.ts
 
 # Separate from `test` because db.ts uses bun:sqlite and the core must load

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -6,8 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 export const PACKAGE_BASELINES = Object.freeze({
-  packedBytes: 421_000,
-  unpackedBytes: 1_378_000,
+  packedBytes: 455_000,
+  unpackedBytes: 1_525_000,
   reviewRawBytes: 12_625,
   reviewCompressedBytes: 4_304,
 });
@@ -39,7 +39,7 @@ const exactPackagePaths = new Set([
 ]);
 
 const allowedPackagePatterns = [
-  /^src\/(?:agents|artifacts|capabilities|config|core|engine|integration|observability|shared|ui\/tui)\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.ts$/,
+  /^src\/(?:agents|artifacts|capabilities|config|core|engine|integration|observability|shared|ui\/tui|workflows)\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.ts$/,
   /^schemas\/hive-(?:manifest|agent-frontmatter|workflow)-v1\.schema\.json$/,
   /^ui\/web\/dist\/assets\/[A-Za-z0-9_-]+\.(?:css|js)$/,
   /^ui\/web\/dist\/fonts\/[a-z0-9-]+\.woff2$/,

--- a/src/workflows/checkpoints.ts
+++ b/src/workflows/checkpoints.ts
@@ -1,0 +1,29 @@
+import { createHash, randomUUID } from "node:crypto";
+import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { readWorkflowJournal, workflowSessionDirectory, type JournalFaultStage } from "./journal";
+
+export const WORKFLOW_CHECKPOINT_FORMAT_VERSION = 1 as const;
+const MAX_CHECKPOINT_BYTES = 8 * 1024 * 1024;
+export interface WorkflowCheckpoint<State = unknown> { readonly formatVersion: 1; readonly sessionId: string; readonly lastSequence: number; readonly lastHash: string; readonly state: State; readonly createdAt: string; readonly checkpointHash: string }
+export interface CheckpointInput<State> { readonly lastSequence: number; readonly lastHash: string; readonly state: State }
+export interface CheckpointFaultOptions { readonly fault?: (stage: JournalFaultStage) => void }
+function hash(value: unknown): string { return createHash("sha256").update("pi-hive-workflow-checkpoint-v1\0").update(canonicalJson(value)).digest("hex"); }
+function directory(root: string, id: string): string { return join(workflowSessionDirectory(root, id), "checkpoints"); }
+function fsyncDir(path: string) { const fd = openSync(path, constants.O_RDONLY); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function validate<State>(value: WorkflowCheckpoint<State>): void { if (value.formatVersion !== 1 || !Number.isSafeInteger(value.lastSequence) || value.lastSequence < 1 || !/^[0-9a-f]{64}$/u.test(value.lastHash)) throw new Error("Checkpoint format invalid"); const { checkpointHash, ...identity } = value; if (hash(identity) !== checkpointHash) throw new Error("Checkpoint hash mismatch"); canonicalJson(value.state); }
+function deepFreeze<T>(value: T): T { if (value && typeof value === "object") { for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child); Object.freeze(value); } return value; }
+export function writeCheckpoint<State>(root: string, sessionId: string, input: CheckpointInput<State>, options: CheckpointFaultOptions = {}): WorkflowCheckpoint<State> {
+  const events = readWorkflowJournal(root, sessionId); const anchor = events[input.lastSequence - 1]; if (!anchor || anchor.eventHash !== input.lastHash) throw new Error("Checkpoint journal hash mismatch");
+  const identity = { formatVersion: 1 as const, sessionId, lastSequence: input.lastSequence, lastHash: input.lastHash, state: structuredClone(input.state), createdAt: new Date().toISOString() }; const value = Object.freeze({ ...identity, checkpointHash: hash(identity) }); const content = `${canonicalJson(value)}\n`; if (Buffer.byteLength(content) > MAX_CHECKPOINT_BYTES) throw new Error("Checkpoint size limit exceeded");
+  const dir = directory(root, sessionId); mkdirSync(dir, { recursive: true, mode: 0o700 }); if (!lstatSync(dir).isDirectory() || lstatSync(dir).isSymbolicLink()) throw new Error("Checkpoint directory invalid");
+  const name = `${String(input.lastSequence).padStart(16, "0")}-${input.lastHash}.json`; const target = join(dir, name); const temp = join(dir, `.${name}.${randomUUID()}.tmp`); let fd: number | undefined;
+  try { options.fault?.("beforeWrite"); fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; options.fault?.("afterFileFsync"); options.fault?.("beforeRename"); renameSync(temp, target); options.fault?.("afterRename"); options.fault?.("beforeDirFsync"); fsyncDir(dir); return value; }
+  finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } }
+}
+export function loadLatestCheckpoint<State>(root: string, sessionId: string): WorkflowCheckpoint<State> | undefined {
+  const dir = directory(root, sessionId); let names: string[]; try { names = readdirSync(dir).filter((name) => name.endsWith(".json")).sort().reverse(); } catch (error: any) { if (error?.code === "ENOENT") return undefined; throw error; }
+  for (const name of names) { let fd: number | undefined; try { const path = join(dir, name); if (lstatSync(path).isSymbolicLink()) continue; fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW); const stat = fstatSync(fd); if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_CHECKPOINT_BYTES) continue; const value = JSON.parse(readFileSync(fd, "utf8")) as WorkflowCheckpoint<State>; validate(value); return deepFreeze(value); } catch { continue; } finally { if (fd !== undefined) closeSync(fd); } }
+  return undefined;
+}

--- a/src/workflows/events.ts
+++ b/src/workflows/events.ts
@@ -1,0 +1,42 @@
+import { createHash, randomUUID } from "node:crypto";
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+
+export const WORKFLOW_EVENT_FORMAT_VERSION = 1 as const;
+export const WORKFLOW_EVENT_LIMITS = Object.freeze({ payloadBytes: 262_144, eventBytes: 524_288, idBytes: 256, diagnosticsBytes: 4_096 });
+export type WorkflowEventProducer = "runtime" | "dashboard" | "recovery" | "harness";
+export type WorkflowEventType = "session.created" | "session.linked" | "session.selected" | "session.orphaned" | "control.requested" | "run.transition" | "task.transition" | "question.transition" | "approval.recorded" | "artifact.recorded" | "handoff.recorded" | "knowledge.transition" | "terminal.recorded";
+const EVENT_TYPES = new Set<WorkflowEventType>(["session.created", "session.linked", "session.selected", "session.orphaned", "control.requested", "run.transition", "task.transition", "question.transition", "approval.recorded", "artifact.recorded", "handoff.recorded", "knowledge.transition", "terminal.recorded"]);
+const PRODUCERS = new Set<WorkflowEventProducer>(["runtime", "dashboard", "recovery", "harness"]);
+export interface WorkflowEventDraft { readonly eventId: string; readonly projectId: string; readonly sessionId: string; readonly runId?: string; readonly type: WorkflowEventType; readonly payload: JsonValue; readonly timestamp: string; readonly producer: WorkflowEventProducer; readonly correlationId?: string; readonly attemptId?: string }
+export interface WorkflowEventEnvelope extends WorkflowEventDraft { readonly formatVersion: 1; readonly sequence: number; readonly previousHash: string | null; readonly payloadHash: string; readonly eventHash: string }
+export interface CreateWorkflowEventInput extends Omit<WorkflowEventDraft, "eventId" | "timestamp"> { readonly eventId?: string; readonly timestamp?: string }
+
+function hash(domain: string, value: unknown): string { return createHash("sha256").update(`${domain}\0`).update(canonicalJson(value)).digest("hex"); }
+function unsafeId(value: string): boolean { for (const character of value) if (character === "/" || character === "\\" || character.codePointAt(0)! <= 0x1f) return true; return false; }
+function deepFreeze<T>(value: T): T { if (value && typeof value === "object") { for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child); Object.freeze(value); } return value; }
+function boundedId(value: string, label: string): string { if (!value || Buffer.byteLength(value, "utf8") > WORKFLOW_EVENT_LIMITS.idBytes || unsafeId(value)) throw new Error(`WORKFLOW_EVENT_${label}_INVALID`); return value; }
+function validateDraft(input: WorkflowEventDraft): void {
+  boundedId(input.eventId, "ID"); boundedId(input.projectId, "PROJECT"); boundedId(input.sessionId, "SESSION"); if (input.runId) boundedId(input.runId, "RUN"); if (input.correlationId) boundedId(input.correlationId, "CORRELATION"); if (input.attemptId) boundedId(input.attemptId, "ATTEMPT");
+  if (!EVENT_TYPES.has(input.type) || !PRODUCERS.has(input.producer) || !Number.isFinite(Date.parse(input.timestamp))) throw new Error("WORKFLOW_EVENT_ENVELOPE_INVALID");
+  const payload = canonicalJson(input.payload); if (Buffer.byteLength(payload, "utf8") > WORKFLOW_EVENT_LIMITS.payloadBytes) throw new Error("WORKFLOW_EVENT_PAYLOAD_LIMIT_EXCEEDED");
+}
+export function createWorkflowEvent(input: CreateWorkflowEventInput): WorkflowEventDraft {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const result = { eventId: boundedId(input.eventId ?? randomUUID(), "ID"), projectId: boundedId(input.projectId, "PROJECT"), sessionId: boundedId(input.sessionId, "SESSION"), ...(input.runId ? { runId: boundedId(input.runId, "RUN") } : {}), type: input.type, payload: deepFreeze(structuredClone(input.payload)), timestamp, producer: input.producer, ...(input.correlationId ? { correlationId: boundedId(input.correlationId, "CORRELATION") } : {}), ...(input.attemptId ? { attemptId: boundedId(input.attemptId, "ATTEMPT") } : {}) }; validateDraft(result); return Object.freeze(result);
+}
+export function sealWorkflowEvent(draft: WorkflowEventDraft, sequence: number, previousHash: string | null): WorkflowEventEnvelope {
+  validateDraft(draft);
+  if (!Number.isSafeInteger(sequence) || sequence < 1 || (previousHash !== null && !/^[0-9a-f]{64}$/u.test(previousHash))) throw new Error("WORKFLOW_EVENT_CHAIN_INVALID");
+  const payloadHash = hash("pi-hive-workflow-payload-v1", draft.payload);
+  const identity = { formatVersion: WORKFLOW_EVENT_FORMAT_VERSION, sequence, previousHash, payloadHash, ...draft };
+  const eventHash = hash("pi-hive-workflow-event-v1", identity);
+  const result = Object.freeze({ ...identity, eventHash });
+  if (Buffer.byteLength(canonicalJson(result), "utf8") > WORKFLOW_EVENT_LIMITS.eventBytes) throw new Error("WORKFLOW_EVENT_LIMIT_EXCEEDED");
+  return result;
+}
+export function verifyWorkflowEvent(value: WorkflowEventEnvelope): void {
+  if (value.formatVersion !== 1) throw new Error("Unknown workflow event version"); validateDraft(value);
+  const payloadHash = hash("pi-hive-workflow-payload-v1", value.payload); if (payloadHash !== value.payloadHash) throw new Error("Workflow payload hash mismatch");
+  const { eventHash, ...identity } = value; if (hash("pi-hive-workflow-event-v1", identity) !== eventHash) throw new Error("Workflow event hash mismatch");
+}

--- a/src/workflows/journal.ts
+++ b/src/workflows/journal.ts
@@ -1,0 +1,49 @@
+import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { withCrossProcessFileLock } from "../core/file-lock";
+import { resolveProjectPath } from "../core/safe-path";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { sealWorkflowEvent, verifyWorkflowEvent, WORKFLOW_EVENT_LIMITS, type WorkflowEventDraft, type WorkflowEventEnvelope } from "./events";
+
+export type JournalFaultStage = "beforeWrite" | "afterFileFsync" | "beforeRename" | "afterRename" | "beforeDirFsync";
+export interface JournalFaultOptions { readonly fault?: (stage: JournalFaultStage) => void }
+
+export function workflowSessionDirectory(projectRoot: string, sessionId: string): string {
+  let unsafe = false; for (const character of sessionId) if (character === "/" || character === "\\" || character.codePointAt(0) === 0) unsafe = true;
+  if (!sessionId || unsafe || Buffer.byteLength(sessionId, "utf8") > 256) throw new Error("WORKFLOW_SESSION_ID_INVALID");
+  const relative = `.pi/hive/sessions/${sessionId}`; const resolved = resolveProjectPath(projectRoot, relative, { allowMissing: true });
+  if (!resolved) throw new Error("WORKFLOW_SESSION_PATH_INVALID"); return resolved.lexicalPath;
+}
+function ensureDirectory(path: string): void { mkdirSync(path, { recursive: true, mode: 0o700 }); if (!lstatSync(path).isDirectory() || lstatSync(path).isSymbolicLink()) throw new Error("WORKFLOW_JOURNAL_DIRECTORY_INVALID"); }
+function fsyncDirectory(path: string): void { const fd = openSync(path, constants.O_RDONLY); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function journalDirectory(root: string, sessionId: string): string { return join(workflowSessionDirectory(root, sessionId), "journal"); }
+function deepFreeze<T>(value: T): T { if (value && typeof value === "object") { for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child); Object.freeze(value); } return value; }
+function parseEvent(path: string): WorkflowEventEnvelope {
+  let fd: number | undefined;
+  try { if (lstatSync(path).isSymbolicLink()) throw new Error("Workflow journal event symlink denied"); fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW); const stat = fstatSync(fd); if (!stat.isFile() || stat.size <= 0 || stat.size > WORKFLOW_EVENT_LIMITS.eventBytes) throw new Error("Workflow journal event size invalid"); const value = JSON.parse(readFileSync(fd, "utf8")) as WorkflowEventEnvelope; verifyWorkflowEvent(value); return deepFreeze(value); }
+  catch (error) { if (error instanceof Error && /Workflow journal/u.test(error.message)) throw error; throw new Error("Workflow journal event corruption"); }
+  finally { if (fd !== undefined) closeSync(fd); }
+}
+export function readWorkflowJournal(projectRoot: string, sessionId: string): readonly WorkflowEventEnvelope[] {
+  const dir = journalDirectory(projectRoot, sessionId); try { if (!lstatSync(dir).isDirectory() || lstatSync(dir).isSymbolicLink()) throw new Error("Workflow journal path invalid"); } catch (error: any) { if (error?.code === "ENOENT") return Object.freeze([]); throw error; }
+  const names = readdirSync(dir).filter((name) => name.endsWith(".json")).sort(); const events = names.map((name) => parseEvent(join(dir, name)));
+  let previous: string | null = null; let projectId: string | undefined;
+  for (let index = 0; index < events.length; index += 1) { const event = events[index]; if (event.sequence !== index + 1) throw new Error("Workflow journal sequence gap or duplicate"); if (event.previousHash !== previous) throw new Error("Workflow journal previous hash mismatch"); if (event.sessionId !== sessionId || (projectId !== undefined && event.projectId !== projectId)) throw new Error("Workflow journal identity mismatch"); const expectedName = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; if (names[index] !== expectedName) throw new Error("Workflow journal filename/hash mismatch"); projectId = event.projectId; previous = event.eventHash; }
+  return Object.freeze(events);
+}
+export function appendWorkflowEvent(projectRoot: string, draft: WorkflowEventDraft, options: JournalFaultOptions = {}): WorkflowEventEnvelope {
+  const dir = journalDirectory(projectRoot, draft.sessionId); ensureDirectory(dir); const lockResource = join(dir, "append");
+  return withCrossProcessFileLock(lockResource, () => {
+    const existing = readWorkflowJournal(projectRoot, draft.sessionId); if (existing.some((event) => event.eventId === draft.eventId)) throw new Error("Workflow journal duplicate event ID"); if (existing.length && existing[0].projectId !== draft.projectId) throw new Error("Workflow journal project identity mismatch");
+    const last = existing.at(-1); const event = sealWorkflowEvent(draft, existing.length + 1, last?.eventHash ?? null); const content = `${canonicalJson(event)}\n`;
+    const name = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; const target = join(dir, name); const temp = join(dir, `.${name}.${process.pid}.${randomUUID()}.tmp`); let fd: number | undefined;
+    try {
+      options.fault?.("beforeWrite"); fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; options.fault?.("afterFileFsync"); options.fault?.("beforeRename"); renameSync(temp, target); options.fault?.("afterRename"); options.fault?.("beforeDirFsync"); fsyncDirectory(dir); return event;
+    } finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } }
+  }, { timeoutMs: 5_000, staleMs: 30_000 });
+}
+export function inspectJournal(projectRoot: string, sessionId: string): Readonly<Record<string, unknown>> {
+  try { const events = readWorkflowJournal(projectRoot, sessionId); const last = events.at(-1); return Object.freeze({ sessionId: sessionId.slice(0, 256), eventCount: events.length, lastSequence: last?.sequence ?? 0, lastHash: last?.eventHash, lastType: last?.type, lastTimestamp: last?.timestamp }); }
+  catch (error) { return Object.freeze({ sessionId: sessionId.slice(0, 256), status: "invalid", diagnostic: String(error instanceof Error ? error.message : error).slice(0, 2_048) }); }
+}

--- a/src/workflows/ownership.ts
+++ b/src/workflows/ownership.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { withCrossProcessFileLock } from "../core/file-lock";
+import { workflowSessionDirectory, appendWorkflowEvent } from "./journal";
+import { createWorkflowEvent } from "./events";
+
+export const RUNTIME_OWNERSHIP_FORMAT_VERSION = 1 as const;
+export const RUNTIME_OWNERSHIP_TIMING = Object.freeze({ heartbeatMs: 10_000, staleMs: 60_000, appendLockTimeoutMs: 5_000 });
+export interface RuntimeOwner { readonly formatVersion: 1; readonly sessionId: string; readonly pid: number; readonly processMarker: string; readonly bootNonce: string; readonly ownerNonce: string; readonly acquiredAt: string; readonly heartbeatAt: string }
+export interface AcquireOwnershipOptions { readonly pid?: number; readonly processMarker?: string; readonly now?: number; readonly nonce?: string; readonly bootNonce?: string; readonly verifyDead?: (owner: RuntimeOwner) => boolean }
+export interface OwnershipResult { readonly ok: boolean; readonly reason: string; readonly owner?: RuntimeOwner; readonly recovered?: boolean }
+function pathFor(root: string, id: string) { return join(workflowSessionDirectory(root, id), "runtime-owner.json"); }
+function readOwner(path: string): RuntimeOwner | undefined { let fd: number | undefined; try { if (lstatSync(path).isSymbolicLink()) throw new Error("Runtime owner symlink denied"); fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW); const stat = fstatSync(fd); if (!stat.isFile() || stat.size <= 0 || stat.size > 16_384) throw new Error("Runtime owner size invalid"); const value = JSON.parse(readFileSync(fd, "utf8")) as RuntimeOwner; if (value.formatVersion !== 1 || !Number.isSafeInteger(value.pid) || value.pid < 1 || !value.ownerNonce || !Number.isFinite(Date.parse(value.heartbeatAt))) throw new Error("Runtime owner invalid"); return value; } catch (error: any) { if (error?.code === "ENOENT") return undefined; throw error; } finally { if (fd !== undefined) closeSync(fd); } }
+function writeAtomic(path: string, value: RuntimeOwner): void { const dir = dirname(path); mkdirSync(dir, { recursive: true, mode: 0o700 }); const temp = `${path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined; try { fd = openSync(temp, "wx", 0o600); writeFileSync(fd, `${JSON.stringify(value)}\n`); fsyncSync(fd); closeSync(fd); fd = undefined; renameSync(temp, path); const dirFd = openSync(dir, constants.O_RDONLY); try { fsyncSync(dirFd); } finally { closeSync(dirFd); } } finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } } }
+function defaultProcessMarker(pid: number): string { try { return readFileSync(`/proc/${pid}/stat`, "utf8").split(" ").slice(0, 22).join(" "); } catch { return `pid:${pid}`; } }
+function defaultBootNonce(): string { try { return readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim(); } catch { return "unknown-boot"; } }
+function defaultDead(owner: RuntimeOwner): boolean { try { process.kill(owner.pid, 0); return defaultProcessMarker(owner.pid) !== owner.processMarker || defaultBootNonce() !== owner.bootNonce; } catch (error: any) { return error?.code === "ESRCH"; } }
+export function acquireRuntimeOwnership(root: string, sessionId: string, options: AcquireOwnershipOptions = {}): OwnershipResult {
+  const path = pathFor(root, sessionId); mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  return withCrossProcessFileLock(path, () => {
+    const now = options.now ?? Date.now(); const existing = readOwner(path);
+    if (existing) { const stale = now - Date.parse(existing.heartbeatAt) >= RUNTIME_OWNERSHIP_TIMING.staleMs; if (!stale) return Object.freeze({ ok: false, reason: "runtime ownership heartbeat is fresh", owner: existing }); const dead = (options.verifyDead ?? defaultDead)(existing); if (!dead) return Object.freeze({ ok: false, reason: "stale owner is not verified dead", owner: existing }); }
+    const pid = options.pid ?? process.pid; const timestamp = new Date(now).toISOString(); const owner = Object.freeze({ formatVersion: 1 as const, sessionId, pid, processMarker: options.processMarker ?? defaultProcessMarker(pid), bootNonce: options.bootNonce ?? defaultBootNonce(), ownerNonce: options.nonce ?? randomUUID(), acquiredAt: timestamp, heartbeatAt: timestamp }); writeAtomic(path, owner); return Object.freeze({ ok: true, reason: existing ? "verified dead stale owner recovered" : "runtime ownership acquired", owner, recovered: Boolean(existing) });
+  }, { timeoutMs: 5_000, staleMs: 30_000 });
+}
+export function heartbeatRuntimeOwnership(root: string, sessionId: string, nonce: string, now = Date.now()): boolean { const path = pathFor(root, sessionId); return withCrossProcessFileLock(path, () => { const owner = readOwner(path); if (!owner || owner.ownerNonce !== nonce) return false; writeAtomic(path, Object.freeze({ ...owner, heartbeatAt: new Date(now).toISOString() })); return true; }); }
+export function releaseRuntimeOwnership(root: string, sessionId: string, nonce: string): boolean { const path = pathFor(root, sessionId); return withCrossProcessFileLock(path, () => { const owner = readOwner(path); if (!owner || owner.ownerNonce !== nonce) return false; unlinkSync(path); return true; }); }
+export function markWorkflowOrphaned(root: string, sessionId: string, projectId: string, reason: string): void { appendWorkflowEvent(root, createWorkflowEvent({ projectId, sessionId, type: "session.orphaned", payload: { reason: reason.slice(0, 2_048) }, producer: "recovery" })); }

--- a/src/workflows/replay.ts
+++ b/src/workflows/replay.ts
@@ -1,0 +1,26 @@
+import { verifyWorkflowEvent, type WorkflowEventEnvelope } from "./events";
+import { readWorkflowJournal } from "./journal";
+import { loadLatestCheckpoint } from "./checkpoints";
+
+export interface ReplayResult<State> { readonly state: State; readonly lastSequence: number; readonly lastHash: string | null }
+export type WorkflowReducer<State> = (state: State, event: WorkflowEventEnvelope) => State;
+
+export function replayWorkflowJournal<State>(events: readonly WorkflowEventEnvelope[], initialState: State, reducer: WorkflowReducer<State>, start: { sequence: number; hash: string | null } = { sequence: 0, hash: null }): ReplayResult<State> {
+  let state = structuredClone(initialState); let sequence = start.sequence; let hash = start.hash; const ids = new Set<string>();
+  for (const event of events) {
+    verifyWorkflowEvent(event);
+    if (ids.has(event.eventId)) throw new Error("Workflow journal duplicate event ID"); ids.add(event.eventId);
+    if (event.sequence !== sequence + 1) throw new Error("Workflow journal sequence gap or out-of-order event");
+    if (event.previousHash !== hash) throw new Error("Workflow journal hash chain mismatch");
+    state = reducer(state, event); sequence = event.sequence; hash = event.eventHash;
+  }
+  return Object.freeze({ state, lastSequence: sequence, lastHash: hash });
+}
+
+export function restoreWorkflowState<State>(projectRoot: string, sessionId: string, zero: State, reducer: WorkflowReducer<State>): ReplayResult<State> {
+  const events = readWorkflowJournal(projectRoot, sessionId); const checkpoint = loadLatestCheckpoint<State>(projectRoot, sessionId);
+  if (!checkpoint) return replayWorkflowJournal(events, zero, reducer);
+  const anchor = events[checkpoint.lastSequence - 1];
+  if (!anchor || anchor.eventHash !== checkpoint.lastHash) throw new Error("Checkpoint does not match authoritative journal");
+  return replayWorkflowJournal(events.slice(checkpoint.lastSequence), checkpoint.state, reducer, { sequence: checkpoint.lastSequence, hash: checkpoint.lastHash });
+}

--- a/tests/workflow-checkpoint.test.ts
+++ b/tests/workflow-checkpoint.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { appendWorkflowEvent } from "../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../src/workflows/events.ts";
+import { writeCheckpoint, loadLatestCheckpoint } from "../src/workflows/checkpoints.ts";
+import { restoreWorkflowState } from "../src/workflows/replay.ts";
+
+function setup() { const root = mkdtempSync(join(tmpdir(), "hive-checkpoint-")); const sessionId = "s1"; const projectId = "p1"; const e1 = appendWorkflowEvent(root, createWorkflowEvent({ projectId, sessionId, type: "session.created", payload: {}, producer: "runtime", eventId: "e1" })); const e2 = appendWorkflowEvent(root, createWorkflowEvent({ projectId, sessionId, type: "control.requested", payload: {}, producer: "dashboard", eventId: "e2" })); return { root, sessionId, e1, e2 }; }
+
+test("checkpoint plus tail restores deterministically and falls back after incomplete write", () => {
+  const f = setup(); writeCheckpoint(f.root, f.sessionId, { lastSequence: 1, lastHash: f.e1.eventHash, state: { count: 1 } });
+  assert.equal(loadLatestCheckpoint(f.root, f.sessionId)?.lastSequence, 1);
+  const restored = restoreWorkflowState(f.root, f.sessionId, { count: 0 }, (state) => ({ count: state.count + 1 }));
+  assert.deepEqual(restored.state, { count: 2 }); assert.equal(restored.lastSequence, 2);
+  assert.throws(() => writeCheckpoint(f.root, f.sessionId, { lastSequence: 2, lastHash: f.e2.eventHash, state: { count: 2 } }, { fault(stage) { if (stage === "beforeRename") throw new Error("crash"); } }));
+  assert.equal(loadLatestCheckpoint(f.root, f.sessionId)?.lastSequence, 1);
+});
+
+test("checkpoint hash mismatch fails closed", () => {
+  const f = setup();
+  assert.throws(() => writeCheckpoint(f.root, f.sessionId, { lastSequence: 2, lastHash: "0".repeat(64), state: {} }), /journal|hash/i);
+});

--- a/tests/workflow-journal.test.ts
+++ b/tests/workflow-journal.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { appendWorkflowEvent, inspectJournal, readWorkflowJournal } from "../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../src/workflows/events.ts";
+import { replayWorkflowJournal } from "../src/workflows/replay.ts";
+
+function fixture() { return { root: mkdtempSync(join(tmpdir(), "hive-journal-")), sessionId: "session-1", projectId: "project-1" }; }
+
+test("journal append is hash-chained and deterministic replay works from zero", () => {
+  const f = fixture();
+  const first = appendWorkflowEvent(f.root, createWorkflowEvent({ projectId: f.projectId, sessionId: f.sessionId, type: "session.created", payload: { name: "one" }, producer: "runtime", timestamp: "2026-01-01T00:00:00.000Z", eventId: "e1" }));
+  const second = appendWorkflowEvent(f.root, createWorkflowEvent({ projectId: f.projectId, sessionId: f.sessionId, type: "control.requested", payload: { action: "pause" }, producer: "dashboard", timestamp: "2026-01-01T00:00:01.000Z", eventId: "e2" }));
+  assert.equal(first.sequence, 1); assert.equal(second.previousHash, first.eventHash);
+  const events = readWorkflowJournal(f.root, f.sessionId); assert.equal(events.length, 2);
+  const replayed = replayWorkflowJournal(events, { count: 0 }, (state) => ({ count: state.count + 1 }));
+  assert.deepEqual(replayed.state, { count: 2 }); assert.equal(replayed.lastHash, second.eventHash);
+});
+
+test("partial, duplicate, gap, out-of-order, hash corrupt, and unknown versions fail closed", () => {
+  const f = fixture(); appendWorkflowEvent(f.root, createWorkflowEvent({ projectId: f.projectId, sessionId: f.sessionId, type: "session.created", payload: {}, producer: "runtime", eventId: "e1" }));
+  const dir = join(f.root, ".pi/hive/sessions", f.sessionId, "journal");
+  writeFileSync(join(dir, ".partial.tmp"), "{");
+  assert.equal(readWorkflowJournal(f.root, f.sessionId).length, 1, "incomplete unpublished temp is ignored");
+  const base = readWorkflowJournal(f.root, f.sessionId)[0];
+  for (const bad of [[base, base], [{ ...base, sequence: 2 }], [{ ...base, eventHash: "0".repeat(64) }], [{ ...base, formatVersion: 99 }]] as any[])
+    assert.throws(() => replayWorkflowJournal(bad, {}, (s) => s), /sequence|hash|version|duplicate/i);
+});
+
+test("dashboard-style appends serialize safely across processes", async () => {
+  const f = fixture();
+  const run = (eventId: string) => new Promise<void>((resolve, reject) => {
+    const script = `Promise.all([import('./src/workflows/journal.ts'),import('./src/workflows/events.ts')]).then(([j,e])=>j.appendWorkflowEvent(${JSON.stringify(f.root)},e.createWorkflowEvent({projectId:'project-1',sessionId:'session-1',type:'control.requested',payload:{},producer:'dashboard',eventId:${JSON.stringify(eventId)}})))`;
+    const child = spawn(process.execPath, ["--import", "tsx", "-e", script], { cwd: process.cwd(), stdio: "ignore" });
+    child.once("error", reject); child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`child ${eventId} exited ${code}`)));
+  });
+  await Promise.all([run("cross-1"), run("cross-2")]);
+  assert.deepEqual(readWorkflowJournal(f.root, f.sessionId).map((event) => event.sequence), [1, 2]);
+});
+
+test("append faults leave old or new valid journal and summaries are bounded/redacted", () => {
+  for (const stage of ["beforeWrite", "afterFileFsync", "beforeRename", "afterRename", "beforeDirFsync"] as const) {
+    const f = fixture();
+    try { appendWorkflowEvent(f.root, createWorkflowEvent({ projectId: f.projectId, sessionId: f.sessionId, type: "session.created", payload: { secret: "do-not-leak" }, producer: "runtime", eventId: "e1" }), { fault(stageNow) { if (stageNow === stage) throw new Error("crash"); } }); } catch { /* injected */ }
+    const events = readWorkflowJournal(f.root, f.sessionId); assert.ok(events.length === 0 || events.length === 1, stage);
+    if (events.length) assert.doesNotThrow(() => replayWorkflowJournal(events, {}, (s) => s));
+    assert.equal(readdirSync(join(f.root, ".pi/hive/sessions", f.sessionId, "journal")).filter((name) => name.endsWith(".json")).length, events.length);
+    const summary = inspectJournal(f.root, f.sessionId); assert.ok(Buffer.byteLength(JSON.stringify(summary)) < 4096); assert.equal(JSON.stringify(summary).includes("do-not-leak"), false);
+  }
+});

--- a/tests/workflow-ownership.test.ts
+++ b/tests/workflow-ownership.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { acquireRuntimeOwnership, heartbeatRuntimeOwnership, markWorkflowOrphaned, releaseRuntimeOwnership } from "../src/workflows/ownership.ts";
+import { appendWorkflowEvent } from "../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../src/workflows/events.ts";
+
+function root() { return mkdtempSync(join(tmpdir(), "hive-owner-")); }
+
+test("fresh runtime ownership is exclusive and only verified dead stale owner can be recovered", () => {
+  const project = root(); const now = Date.parse("2026-01-01T00:00:00Z");
+  const first = acquireRuntimeOwnership(project, "s1", { pid: 111, processMarker: "a", now, nonce: "n1", verifyDead: () => false }); assert.equal(first.ok, true);
+  assert.equal(acquireRuntimeOwnership(project, "s1", { pid: 222, processMarker: "b", now: now + 1000, nonce: "n2", verifyDead: () => true }).ok, false);
+  assert.equal(acquireRuntimeOwnership(project, "s1", { pid: 222, processMarker: "b", now: now + 120_000, nonce: "n2", verifyDead: () => false }).ok, false);
+  const takeover = acquireRuntimeOwnership(project, "s1", { pid: 222, processMarker: "b", now: now + 120_000, nonce: "n2", verifyDead: () => true }); assert.equal(takeover.ok, true);
+  assert.equal(heartbeatRuntimeOwnership(project, "s1", "n1", now + 121_000), false); assert.equal(heartbeatRuntimeOwnership(project, "s1", "n2", now + 121_000), true);
+  assert.equal(releaseRuntimeOwnership(project, "s1", "n1"), false); assert.equal(releaseRuntimeOwnership(project, "s1", "n2"), true);
+});
+
+test("short dashboard append does not acquire runtime ownership and missing Pi session preserves journal as orphan", () => {
+  const project = root(); appendWorkflowEvent(project, createWorkflowEvent({ projectId: "p", sessionId: "s", type: "control.requested", payload: {}, producer: "dashboard", eventId: "e" }));
+  assert.equal(existsSync(join(project, ".pi/hive/sessions/s/runtime-owner.json")), false);
+  markWorkflowOrphaned(project, "s", "p", "missing-pi-session");
+  assert.equal(existsSync(join(project, ".pi/hive/sessions/s/journal")), true);
+});


### PR DESCRIPTION
## Summary
- persist hash-chained workflow events through atomic immutable journal files
- restore reducer state from validated checkpoints and journal tails
- enforce exclusive heartbeat-based runtime ownership with conservative takeover

## Validation
- focused journal/checkpoint/ownership/lock tests (11/11)
- just verify (491 Node, 73 Bun)