### PR TITLE
feat(runtime): add durable delegation scheduler

### DIFF
--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -6,8 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 export const PACKAGE_BASELINES = Object.freeze({
-  packedBytes: 455_000,
-  unpackedBytes: 1_525_000,
+  packedBytes: 455_499,
+  unpackedBytes: 1_578_700,
   reviewRawBytes: 12_625,
   reviewCompressedBytes: 4_304,
 });

--- a/src/workflows/delegation.ts
+++ b/src/workflows/delegation.ts
@@ -1,0 +1,728 @@
+import { randomUUID } from "node:crypto";
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+import { createWorkflowEvent, sealWorkflowEvent, type WorkflowEventEnvelope } from "./events";
+import { appendWorkflowEventChecked, readWorkflowJournal, type JournalFaultStage } from "./journal";
+import { replayWorkflowJournal } from "./replay";
+import {
+  authorizeReferences,
+  validateStructuredReference,
+  type AuthorizedReference,
+  REFERENCE_AUTHORIZATION_LIMITS,
+  type ReferenceAuthorizer,
+  type StructuredReference,
+} from "./references";
+import { boundedId, boundedJson, boundedText, compareText, deepFreeze, exactKeys, plainRecord, utf8Prefix } from "./values";
+
+const FORMAT_VERSION = 1 as const;
+const bounded = boundedText;
+const compare = compareText;
+const LIMITS = Object.freeze({
+  objectiveBytes: 131_072,
+  deliverables: 128,
+  deliverableBytes: 2_048,
+  resultSummaryBytes: 8_192,
+  resultReferences: 128,
+  dataBytes: 65_536,
+  dataDepth: 16,
+  dataNodes: 4_096,
+  statusPage: 100,
+  statusObjectivePreviewBytes: 1_024,
+  cursorBytes: 512,
+});
+
+export type DelegationContextReference = StructuredReference;
+export type WorkerTerminalStatus = "completed" | "blocked" | "failed" | "cancelled";
+export type DelegationQueueState = "queued" | "active" | "suspended" | "terminal";
+
+export interface DelegationProvenance {
+  readonly source: "delegate_agent" | "runtime" | "recovery";
+  readonly correlationId?: string; readonly parentTaskId?: string;
+}
+export interface WorkerResultInput {
+  readonly status: WorkerTerminalStatus; readonly summary: string;
+  readonly outputRefs?: readonly StructuredReference[]; readonly evidenceRefs?: readonly StructuredReference[];
+  readonly data?: Readonly<Record<string, JsonValue>>;
+}
+export interface PersistedWorkerResult {
+  readonly status: WorkerTerminalStatus; readonly summary: string;
+  readonly outputRefs: readonly AuthorizedReference[]; readonly evidenceRefs: readonly AuthorizedReference[];
+  readonly data: Readonly<Record<string, JsonValue>>; readonly attemptId?: string;
+  readonly recordedAt: string; readonly recordedSequence: number;
+}
+export interface DelegationAttempt {
+  readonly attemptId: string; readonly startedSequence: number; readonly startedAt?: string;
+  readonly resultSequence?: number; readonly interruptedSequence?: number;
+}
+export interface PersistedDelegationTask {
+  readonly taskId: string; readonly runId: string;
+  readonly parentNodeId: string; readonly targetNodeId: string; readonly objective: string;
+  readonly contextRefs: readonly AuthorizedReference[]; readonly deliverables: readonly string[];
+  readonly provenance: DelegationProvenance; readonly creationSequence: number; readonly createdAt: string;
+  readonly queueState: DelegationQueueState; readonly attempts: readonly DelegationAttempt[];
+  readonly lastStartedSequence?: number; readonly suspendedOn?: readonly string[];
+  readonly resumedByResultSequence?: number; readonly result?: PersistedWorkerResult;
+  readonly resultDeliveryPreparedSequence?: number; readonly resultAcceptedSequence?: number;
+}
+export interface PreparedResultDelivery {
+  readonly deliveryId: string; readonly recipientNodeId: string; readonly taskIds: readonly string[];
+  readonly preparedSequence: number; readonly preparedAt: string; readonly acceptedSequence?: number;
+}
+export interface DelegationTopologyNode {
+  readonly nodeId: string; readonly agentId: string; readonly parentNodeId?: string;
+  readonly directMemberIds: readonly string[];
+}
+export interface DelegationState {
+  readonly sessionId: string; readonly runId: string; readonly rootNodeId: string;
+  readonly topology: Readonly<Record<string, DelegationTopologyNode>>;
+  readonly tasks: Readonly<Record<string, PersistedDelegationTask>>;
+  readonly deliveries: Readonly<Record<string, PreparedResultDelivery>>;
+  readonly schedulerStatus: "running" | "paused" | "closed";
+  readonly admissionOpen: boolean; readonly closedReason?: string;
+}
+export interface AcceptDelegationInput {
+  readonly targetNodeId: string; readonly objective: string;
+  readonly contextRefs?: readonly DelegationContextReference[]; readonly deliverables: readonly string[];
+  readonly provenance?: Readonly<{ correlationId?: string }>;
+}
+export interface DelegationRuntimeOptions {
+  readonly projectRoot: string; readonly projectId: string; readonly sessionId: string; readonly runId: string;
+  readonly snapshot: ActivationSnapshotFileV1; readonly createTaskId?: () => string; readonly now?: () => string;
+  readonly referenceAuthorizer?: ReferenceAuthorizer;
+  /** Fault-injection seam for durable delegation publication recovery tests. */
+  readonly journalFault?: (eventType: WorkflowEventEnvelope["type"], stage: JournalFaultStage) => void;
+}
+export interface DelegationExecutionContext {
+  readonly nodeId: string; readonly taskId?: string; readonly attemptId?: string;
+}
+export interface DelegationStatusItem {
+  readonly taskId: string; readonly parentNodeId: string; readonly targetNodeId: string;
+  readonly objectivePreview: string; readonly creationSequence: number; readonly queueState: DelegationQueueState;
+  readonly attempts: number; readonly terminalStatus?: WorkerTerminalStatus; readonly resultAccepted: boolean;
+}
+export interface DelegationStatusPage {
+  readonly summary: Readonly<Record<DelegationQueueState | WorkerTerminalStatus, number>>;
+  readonly items: readonly DelegationStatusItem[]; readonly nextCursor?: string;
+}
+export interface ResultDeliveryBatch {
+  readonly deliveryId: string; readonly recipientNodeId: string;
+  readonly items: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[];
+}
+
+const TRUSTED_CONTEXTS = new WeakMap<object, Readonly<{ sessionId: string; runId: string; bindingSequence: number }>>();
+const DELEGATION_EVENTS = new Set([
+  "task.accepted",
+  "task.started",
+  "task.suspended",
+  "task.interrupted",
+  "task.result.recorded",
+  "task.result.delivery.prepared",
+  "task.result.delivery.accepted",
+  "scheduler.paused",
+  "scheduler.resumed",
+  "scheduler.closed",
+]);
+
+function payloadRecord(event: WorkflowEventEnvelope): Record<string, unknown> {
+  if (!plainRecord(event.payload)) throw new Error("Delegation event payload is invalid");
+  if (event.payload.formatVersion !== FORMAT_VERSION) throw new Error("Delegation event payload format version is invalid");
+  return event.payload;
+}
+
+function topologyFromSnapshot(snapshot: ActivationSnapshotFileV1): { rootNodeId: string; topology: Record<string, DelegationTopologyNode> } {
+  const team = snapshot.payload.workflow.team as { rootId?: unknown; nodes?: unknown } | undefined;
+  if (!team || typeof team.rootId !== "string" || !Array.isArray(team.nodes)) throw new Error("Activation snapshot has no valid delegation topology");
+  const topology: Record<string, DelegationTopologyNode> = {};
+  for (const raw of team.nodes) {
+    if (!plainRecord(raw)) throw new Error("Activation snapshot team node is invalid");
+    const nodeId = boundedId(raw.id, "Team node ID");
+    const agentId = boundedId(raw.agentId, "Team agent ID");
+    if (topology[nodeId]) throw new Error("Activation snapshot contains duplicate team node IDs");
+    if (!Array.isArray(raw.memberIds) || raw.memberIds.length > 1_024) throw new Error("Activation snapshot direct members are invalid");
+    topology[nodeId] = Object.freeze({
+      nodeId,
+      agentId,
+      ...(raw.parentId === undefined ? {} : { parentNodeId: boundedId(raw.parentId, "Parent node ID") }),
+      directMemberIds: Object.freeze(raw.memberIds.map((member, index) => boundedId(member, `Direct member ${index}`))),
+    });
+  }
+  if (!topology[team.rootId]) throw new Error("Activation snapshot root node is missing");
+  for (const node of Object.values(topology)) {
+    for (const member of node.directMemberIds) {
+      if (!topology[member] || topology[member].parentNodeId !== node.nodeId) throw new Error("Activation snapshot delegation topology is inconsistent");
+    }
+  }
+  return { rootNodeId: team.rootId, topology };
+}
+
+export function createDelegationState(sessionId: string, runId: string, snapshot: ActivationSnapshotFileV1): DelegationState {
+  const { rootNodeId, topology } = topologyFromSnapshot(snapshot);
+  return deepFreeze({
+    sessionId: boundedId(sessionId, "Session ID"),
+    runId: boundedId(runId, "Run ID"),
+    rootNodeId,
+    topology,
+    tasks: {},
+    deliveries: {},
+    schedulerStatus: "running",
+    admissionOpen: true,
+  });
+}
+
+function parseProvenance(value: unknown): DelegationProvenance {
+  if (!plainRecord(value)) throw new Error("Delegation provenance is invalid");
+  exactKeys(value, ["source"], ["correlationId", "parentTaskId"], "Delegation provenance");
+  if (value.source !== "delegate_agent" && value.source !== "runtime" && value.source !== "recovery") throw new Error("Delegation provenance is invalid");
+  return Object.freeze({
+    source: value.source,
+    ...(value.correlationId === undefined ? {} : { correlationId: boundedId(value.correlationId, "Correlation ID") }),
+    ...(value.parentTaskId === undefined ? {} : { parentTaskId: boundedId(value.parentTaskId, "Parent task ID") }),
+  });
+}
+
+function parseAuthorizedRefs(value: unknown, label = "Authorized context references"): readonly AuthorizedReference[] {
+  if (!Array.isArray(value) || value.length > LIMITS.resultReferences) throw new Error(`${label} are invalid`);
+  let aggregateResolvedBytes = 0;
+  return Object.freeze(value.map((entry, index) => {
+    if (!plainRecord(entry)) throw new Error(`${label} ${index} is invalid`);
+    const ref = validateStructuredReference(entry.ref, `${label} ${index}`);
+    if (entry.authorization === "authorized") {
+      exactKeys(entry, ["ref", "authorization"], ["resolved"], `${label} ${index}`);
+      if (entry.resolved === undefined) return Object.freeze({ ref, authorization: "authorized" as const });
+      const resolved = boundedJson(entry.resolved, `${label} ${index} resolved content`, {
+        bytes: REFERENCE_AUTHORIZATION_LIMITS.resolvedItemBytes,
+        depth: REFERENCE_AUTHORIZATION_LIMITS.resolvedDepth,
+        nodes: REFERENCE_AUTHORIZATION_LIMITS.resolvedNodes,
+      });
+      aggregateResolvedBytes += Buffer.byteLength(canonicalJson(resolved), "utf8");
+      if (aggregateResolvedBytes > REFERENCE_AUTHORIZATION_LIMITS.resolvedAggregateBytes) throw new Error(`${label} resolved content exceeds its aggregate bound`);
+      return Object.freeze({ ref, authorization: "authorized" as const, resolved });
+    }
+    if (entry.authorization === "denied") {
+      exactKeys(entry, ["ref", "authorization", "diagnostic"], [], `${label} ${index}`);
+      return Object.freeze({ ref, authorization: "denied" as const, diagnostic: bounded(entry.diagnostic, "Reference denial diagnostic", 2_048) });
+    }
+    throw new Error(`${label} ${index} has an invalid decision`);
+  }));
+}
+
+function stringArray(value: unknown, label: string, limit: number, itemBytes: number): readonly string[] {
+  if (!Array.isArray(value) || value.length > limit) throw new Error(`${label} limit exceeded`);
+  return Object.freeze(value.map((item, index) => bounded(item, `${label} ${index}`, itemBytes)));
+}
+
+function dataRecord(value: unknown): Readonly<Record<string, JsonValue>> {
+  return deepFreeze(boundedJson(value, "Worker result data", {
+    bytes: LIMITS.dataBytes,
+    depth: LIMITS.dataDepth,
+    nodes: LIMITS.dataNodes,
+    rootRecord: true,
+  }) as Record<string, JsonValue>);
+}
+
+function resultRefs(value: unknown, label: string): readonly StructuredReference[] {
+  if (!Array.isArray(value) || value.length > LIMITS.resultReferences) throw new Error(`${label} limit exceeded`);
+  return Object.freeze(value.map((entry, index) => validateStructuredReference(entry, `${label} ${index}`)));
+}
+
+function parseResult(value: unknown, event: WorkflowEventEnvelope): PersistedWorkerResult {
+  if (!plainRecord(value)) throw new Error("Worker result is invalid");
+  exactKeys(value, ["status", "summary", "outputRefs", "evidenceRefs", "data"], ["attemptId"], "Worker result");
+  if (value.status !== "completed" && value.status !== "blocked" && value.status !== "failed" && value.status !== "cancelled") throw new Error("Worker result status is invalid");
+  return deepFreeze({
+    status: value.status,
+    summary: bounded(value.summary, "Worker result summary", LIMITS.resultSummaryBytes),
+    outputRefs: parseAuthorizedRefs(value.outputRefs, "Worker output references"),
+    evidenceRefs: parseAuthorizedRefs(value.evidenceRefs, "Worker evidence references"),
+    data: dataRecord(value.data),
+    ...(value.attemptId === undefined ? {} : { attemptId: boundedId(value.attemptId, "Worker result attempt ID") }),
+    recordedAt: event.timestamp,
+    recordedSequence: event.sequence,
+  });
+}
+
+function cloneState(state: DelegationState): DelegationState {
+  return structuredClone(state);
+}
+
+function queueHead(state: DelegationState, targetNodeId: string): PersistedDelegationTask | undefined {
+  return Object.values(state.tasks)
+    .filter((task) => task.targetNodeId === targetNodeId && task.queueState !== "terminal")
+    .sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))[0];
+}
+
+function dependenciesAccepted(state: DelegationState, task: PersistedDelegationTask): boolean {
+  return Boolean(task.suspendedOn?.length) && task.suspendedOn!.every((dependency) => state.tasks[dependency]?.resultAcceptedSequence !== undefined);
+}
+
+function validateEventPayload(event: WorkflowEventEnvelope, payload: Record<string, unknown>): void {
+  const specifications: Partial<Record<WorkflowEventEnvelope["type"], readonly [readonly string[], readonly string[]]>> = {
+    "task.accepted": [["formatVersion", "taskId", "parentNodeId", "targetNodeId", "objective", "contextRefs", "deliverables", "provenance"], []],
+    "task.started": [["formatVersion", "taskId", "attemptId"], []],
+    "task.suspended": [["formatVersion", "taskId", "dependencyTaskIds"], []],
+    "task.interrupted": [["formatVersion", "taskId", "attemptId", "reason"], []],
+    "task.result.recorded": [["formatVersion", "taskId", "result"], []],
+    "task.result.delivery.prepared": [["formatVersion", "deliveryId", "recipientNodeId", "taskIds"], []],
+    "task.result.delivery.accepted": [["formatVersion", "deliveryId", "recipientNodeId"], []],
+    "scheduler.paused": [["formatVersion", "reason"], []],
+    "scheduler.resumed": [["formatVersion"], []],
+    "scheduler.closed": [["formatVersion", "reason"], []],
+  };
+  const specification = specifications[event.type];
+  if (!specification) throw new Error("Unknown delegation event type");
+  exactKeys(payload, specification[0], specification[1], `${event.type} payload`);
+}
+
+export function reduceDelegationState(state: DelegationState, event: WorkflowEventEnvelope): DelegationState {
+  if (!DELEGATION_EVENTS.has(event.type)) return state;
+  if (event.sessionId !== state.sessionId) throw new Error("Delegation event session identity mismatch");
+  if (event.runId !== state.runId) return state;
+  const payload = payloadRecord(event);
+  validateEventPayload(event, payload);
+  const next = cloneState(state) as DelegationState;
+  const mutable = next as unknown as {
+    tasks: Record<string, PersistedDelegationTask>;
+    deliveries: Record<string, PreparedResultDelivery>;
+    schedulerStatus: DelegationState["schedulerStatus"];
+    admissionOpen: boolean;
+    closedReason?: string;
+  };
+  const tasks = mutable.tasks;
+
+  if (event.type === "scheduler.paused") {
+    if (event.producer !== "harness" || mutable.schedulerStatus !== "running") throw new Error("Scheduler pause transition is invalid");
+    mutable.schedulerStatus = "paused";
+    mutable.admissionOpen = false;
+    mutable.closedReason = bounded(payload.reason, "Scheduler pause reason", LIMITS.resultSummaryBytes);
+    return deepFreeze(next);
+  }
+  if (event.type === "scheduler.resumed") {
+    if (event.producer !== "harness" || mutable.schedulerStatus !== "paused") throw new Error("Scheduler resume transition is invalid");
+    mutable.schedulerStatus = "running";
+    mutable.admissionOpen = true;
+    delete mutable.closedReason;
+    return deepFreeze(next);
+  }
+  if (event.type === "scheduler.closed") {
+    if (event.producer !== "harness" || mutable.schedulerStatus === "closed") throw new Error("Only the harness may close scheduler admission once");
+    mutable.schedulerStatus = "closed";
+    mutable.admissionOpen = false;
+    mutable.closedReason = bounded(payload.reason, "Scheduler close reason", LIMITS.resultSummaryBytes);
+    return deepFreeze(next);
+  }
+
+  if (event.type === "task.result.delivery.prepared") {
+    if (event.producer !== "runtime") throw new Error("Result delivery preparation is unauthorized");
+    const deliveryId = boundedId(payload.deliveryId, "Result delivery ID");
+    const recipientNodeId = boundedId(payload.recipientNodeId, "Result recipient node ID");
+    const taskIds = stringArray(payload.taskIds, "Result delivery tasks", LIMITS.resultReferences, 256);
+    if (!taskIds.length || new Set(taskIds).size !== taskIds.length || mutable.deliveries[deliveryId]) throw new Error("Result delivery preparation is empty or duplicated");
+    if (Object.values(mutable.deliveries).some((delivery) => delivery.recipientNodeId === recipientNodeId && delivery.acceptedSequence === undefined)) throw new Error("Recipient already has an unaccepted result delivery");
+    for (const taskId of taskIds) {
+      const task = tasks[taskId];
+      if (!task?.result || task.parentNodeId !== recipientNodeId || task.resultAcceptedSequence !== undefined || task.resultDeliveryPreparedSequence !== undefined) throw new Error("Result delivery task is not pending for the recipient");
+      tasks[taskId] = deepFreeze({ ...task, resultDeliveryPreparedSequence: event.sequence });
+    }
+    mutable.deliveries[deliveryId] = deepFreeze({ deliveryId, recipientNodeId, taskIds, preparedSequence: event.sequence, preparedAt: event.timestamp });
+    return deepFreeze(next);
+  }
+
+  if (event.type === "task.result.delivery.accepted") {
+    if (event.producer !== "runtime") throw new Error("Result delivery acceptance is unauthorized");
+    const deliveryId = boundedId(payload.deliveryId, "Result delivery ID");
+    const recipientNodeId = boundedId(payload.recipientNodeId, "Result recipient node ID");
+    const delivery = mutable.deliveries[deliveryId];
+    if (!delivery || delivery.recipientNodeId !== recipientNodeId || delivery.acceptedSequence !== undefined) throw new Error("Result delivery acceptance is stale or duplicated");
+    mutable.deliveries[deliveryId] = deepFreeze({ ...delivery, acceptedSequence: event.sequence });
+    for (const taskId of delivery.taskIds) {
+      const task = tasks[taskId];
+      if (!task?.result || task.resultAcceptedSequence !== undefined) throw new Error("Result delivery task acceptance is invalid");
+      tasks[taskId] = deepFreeze({ ...task, resultAcceptedSequence: event.sequence });
+    }
+    for (const candidate of Object.values(tasks)) {
+      if (candidate.queueState === "suspended" && dependenciesAccepted(next, candidate)) {
+        tasks[candidate.taskId] = deepFreeze({ ...candidate, queueState: "active", resumedByResultSequence: event.sequence });
+      }
+    }
+    return deepFreeze(next);
+  }
+
+  const taskId = boundedId(payload.taskId, "Delegation task ID");
+  if (event.type === "task.accepted") {
+    if (event.producer !== "runtime" || !mutable.admissionOpen || tasks[taskId]) throw new Error("Delegation acceptance is unauthorized, closed, or duplicated");
+    const parentNodeId = boundedId(payload.parentNodeId, "Delegation parent node ID");
+    const targetNodeId = boundedId(payload.targetNodeId, "Delegation target node ID");
+    const parent = next.topology[parentNodeId];
+    if (!parent) throw new Error(`Unknown parent node ${parentNodeId}`);
+    if (!next.topology[targetNodeId] || !parent.directMemberIds.includes(targetNodeId)) throw new Error(`${targetNodeId} is not a direct member of ${parentNodeId}`);
+    const provenance = parseProvenance(payload.provenance);
+    const parentTask = provenance.parentTaskId ? tasks[provenance.parentTaskId] : undefined;
+    if (provenance.parentTaskId && (!parentTask || parentTask.targetNodeId !== parentNodeId || parentTask.queueState !== "active" || !parentTask.attempts.at(-1)?.attemptId)) {
+      throw new Error("Nested delegation parent is not the journal-active caller task");
+    }
+    tasks[taskId] = deepFreeze({
+      taskId,
+      runId: state.runId,
+      parentNodeId,
+      targetNodeId,
+      objective: bounded(payload.objective, "Delegation objective", LIMITS.objectiveBytes),
+      contextRefs: parseAuthorizedRefs(payload.contextRefs),
+      deliverables: stringArray(payload.deliverables, "Delegation deliverables", LIMITS.deliverables, LIMITS.deliverableBytes),
+      provenance,
+      creationSequence: event.sequence,
+      createdAt: event.timestamp,
+      queueState: "queued",
+      attempts: [],
+    });
+    if (parentTask) {
+      tasks[parentTask.taskId] = deepFreeze({
+        ...parentTask,
+        suspendedOn: [...(parentTask.suspendedOn ?? []), taskId],
+      });
+    }
+    return deepFreeze(next);
+  }
+
+  const task = tasks[taskId];
+  if (!task) throw new Error(`Unknown delegation task ${taskId}`);
+  if (event.type === "task.started") {
+    if (event.producer !== "harness" || queueHead(next, task.targetNodeId)?.taskId !== taskId) throw new Error("Delegation task cannot start out of FIFO order");
+    if (Object.values(tasks).some((other) => other.taskId !== taskId && other.targetNodeId === task.targetNodeId && other.queueState === "active")) throw new Error("Delegation node already has an active task");
+    const attemptId = boundedId(payload.attemptId, "Delegation attempt ID");
+    if (task.queueState === "active" && task.resumedByResultSequence !== undefined) {
+      if (task.attempts.at(-1)?.attemptId !== attemptId) throw new Error("Delegation continuation must preserve the active attempt ID");
+      const { resumedByResultSequence: _resumed, ...continued } = task;
+      tasks[taskId] = deepFreeze({ ...continued, lastStartedSequence: event.sequence });
+    } else {
+      if (task.queueState !== "queued") throw new Error("Delegation task cannot start outside queued or resumed state");
+      if (task.attempts.some((attempt) => attempt.attemptId === attemptId)) throw new Error("Delegation attempt ID is duplicated");
+      tasks[taskId] = deepFreeze({
+        ...task,
+        queueState: "active",
+        suspendedOn: undefined,
+        attempts: [...task.attempts, { attemptId, startedSequence: event.sequence, startedAt: event.timestamp }],
+        lastStartedSequence: event.sequence,
+      });
+    }
+  } else if (event.type === "task.suspended") {
+    if ((event.producer !== "harness" && event.producer !== "recovery") || task.queueState !== "active") throw new Error("Only an active worker task can suspend");
+    const dependencyTaskIds = stringArray(payload.dependencyTaskIds, "Delegation dependencies", 128, 256);
+    if (!dependencyTaskIds.length || new Set(dependencyTaskIds).size !== dependencyTaskIds.length) throw new Error("Delegation suspension dependencies are empty or duplicated");
+    if (!task.suspendedOn || canonicalJson([...task.suspendedOn].sort(compare)) !== canonicalJson([...dependencyTaskIds].sort(compare))) {
+      throw new Error("Delegation suspension dependencies do not match durable child acceptance linkage");
+    }
+    for (const dependencyId of dependencyTaskIds) {
+      const dependency = tasks[dependencyId];
+      if (!dependency || dependency.parentNodeId !== task.targetNodeId || (dependency.queueState === "terminal" && !dependency.result)) throw new Error("Delegation suspension dependency is not a direct child task");
+    }
+    tasks[taskId] = deepFreeze({ ...task, queueState: "suspended", suspendedOn: dependencyTaskIds });
+  } else if (event.type === "task.interrupted") {
+    const attemptId = boundedId(payload.attemptId, "Interrupted attempt ID");
+    const latestAttempt = task.attempts.at(-1);
+    const authorized = event.producer === "recovery" || (event.producer === "harness" && mutable.schedulerStatus === "paused");
+    if (!authorized || task.queueState !== "active" || latestAttempt?.attemptId !== attemptId) throw new Error("Task interruption requires the current active attempt and interruption authority");
+    bounded(payload.reason, "Task interruption reason", LIMITS.resultSummaryBytes);
+    const attempts = task.attempts.map((attempt, index) => index === task.attempts.length - 1 ? { ...attempt, interruptedSequence: event.sequence } : attempt);
+    tasks[taskId] = deepFreeze({ ...task, queueState: "queued", attempts });
+  } else if (event.type === "task.result.recorded") {
+    if (event.producer !== "harness" || task.queueState === "terminal") throw new Error("Worker result is unauthorized or duplicated");
+    const result = parseResult(payload.result, event);
+    if (result.status !== "cancelled" && task.suspendedOn?.some((dependencyId) => tasks[dependencyId]?.resultAcceptedSequence === undefined)) {
+      throw new Error("Worker cannot publish a terminal result while durable child dependencies are pending");
+    }
+    if (task.queueState !== "active" && task.queueState !== "suspended" && !(result.status === "cancelled" && !mutable.admissionOpen && task.queueState === "queued")) throw new Error("Worker result does not match task execution state");
+    const activeAttemptId = task.attempts.at(-1)?.attemptId;
+    if ((task.queueState === "active" || task.queueState === "suspended") && (!activeAttemptId || result.attemptId !== activeAttemptId)) throw new Error("Worker result does not match the journal-active attempt");
+    if (task.queueState === "queued" && result.attemptId !== undefined) throw new Error("Queued cancellation cannot claim a worker attempt");
+    const attempts = task.attempts.map((attempt) => attempt.attemptId === result.attemptId ? { ...attempt, resultSequence: event.sequence } : attempt);
+    tasks[taskId] = deepFreeze({ ...task, queueState: "terminal", suspendedOn: undefined, attempts, result });
+  }
+  return deepFreeze(next);
+}
+
+function normalizedResult(input: WorkerResultInput, task: PersistedDelegationTask, authorizer?: ReferenceAuthorizer): Record<string, JsonValue> {
+  if (!plainRecord(input)) throw new Error("Worker result must be an object");
+  if (input.status !== "completed" && input.status !== "blocked" && input.status !== "failed" && input.status !== "cancelled") throw new Error("Worker result status is invalid");
+  return {
+    status: input.status,
+    summary: bounded(input.summary, "Worker result summary", LIMITS.resultSummaryBytes),
+    outputRefs: authorizeReferences(resultRefs(input.outputRefs ?? [], "Worker output references"), task.parentNodeId, authorizer) as unknown as JsonValue,
+    evidenceRefs: authorizeReferences(resultRefs(input.evidenceRefs ?? [], "Worker evidence references"), task.parentNodeId, authorizer) as unknown as JsonValue,
+    data: dataRecord(input.data ?? {}) as Record<string, JsonValue>,
+  };
+}
+
+export class DelegationRuntime {
+  readonly options: DelegationRuntimeOptions;
+  private readonly zero: DelegationState;
+
+  constructor(options: DelegationRuntimeOptions) {
+    this.options = options;
+    this.zero = createDelegationState(options.sessionId, options.runId, options.snapshot);
+  }
+
+  restore(): DelegationState {
+    return replayWorkflowJournal(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), this.zero, reduceDelegationState).state;
+  }
+
+  private context(nodeId: string, taskId?: string, attemptId?: string, bindingSequence = 0): DelegationExecutionContext {
+    const context = Object.freeze({ nodeId, ...(taskId ? { taskId } : {}), ...(attemptId ? { attemptId } : {}) });
+    TRUSTED_CONTEXTS.set(context, { sessionId: this.options.sessionId, runId: this.options.runId, bindingSequence });
+    return context;
+  }
+
+  rootExecutionContext(): DelegationExecutionContext {
+    if (!this.restore().admissionOpen) throw new Error("Trusted root execution context requires an open delegation run");
+    return this.context(this.zero.rootNodeId);
+  }
+
+  workerExecutionContext(taskId: string, attemptId: string): DelegationExecutionContext {
+    const task = this.restore().tasks[boundedId(taskId, "Worker task ID")];
+    if (!task || task.queueState !== "active" || task.attempts.at(-1)?.attemptId !== attemptId) throw new Error("Trusted execution context requires the current active worker task");
+    const bindingSequence = Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0);
+    return this.context(task.targetNodeId, task.taskId, attemptId, bindingSequence);
+  }
+
+  private assertContext(context: DelegationExecutionContext): DelegationExecutionContext {
+    if (!context || typeof context !== "object") throw new Error("A trusted execution context is required");
+    const authority = TRUSTED_CONTEXTS.get(context as object);
+    if (!authority || authority.sessionId !== this.options.sessionId || authority.runId !== this.options.runId) throw new Error("A trusted execution context is required");
+    if (!this.zero.topology[context.nodeId]) throw new Error("Trusted execution context targets an unknown node");
+    const state = this.restore();
+    if (context.nodeId === state.rootNodeId && context.taskId === undefined && context.attemptId === undefined) {
+      if (!state.admissionOpen) throw new Error("Trusted root execution context is no longer current");
+      return context;
+    }
+    const task = context.taskId ? state.tasks[context.taskId] : undefined;
+    const bindingSequence = task ? Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0) : -1;
+    if (!task || task.queueState !== "active" || task.targetNodeId !== context.nodeId
+      || task.attempts.at(-1)?.attemptId !== context.attemptId || authority.bindingSequence !== bindingSequence) {
+      throw new Error("Trusted worker execution context is no longer the active matching task attempt");
+    }
+    return context;
+  }
+
+  assertExecutionContext(context: DelegationExecutionContext): void {
+    this.assertContext(context);
+  }
+
+  private assertDelegatingContext(context: DelegationExecutionContext): DelegationExecutionContext {
+    return this.assertContext(context);
+  }
+
+  private append(
+    type: "task.accepted" | "task.started" | "task.suspended" | "task.interrupted" | "task.result.recorded" | "task.result.delivery.prepared" | "task.result.delivery.accepted" | "scheduler.paused" | "scheduler.resumed" | "scheduler.closed",
+    payload: Record<string, JsonValue>,
+    producer: "runtime" | "harness" | "recovery",
+  ): WorkflowEventEnvelope {
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId,
+      sessionId: this.options.sessionId,
+      runId: this.options.runId,
+      type,
+      payload,
+      producer,
+      timestamp: this.options.now?.() ?? new Date().toISOString(),
+    });
+    return appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+      const replayed = replayWorkflowJournal(events, this.zero, reduceDelegationState);
+      const prospective = sealWorkflowEvent(draft, replayed.lastSequence + 1, replayed.lastHash);
+      reduceDelegationState(replayed.state, prospective);
+    }, { fault: (stage) => this.options.journalFault?.(type, stage) });
+  }
+
+  accept(context: DelegationExecutionContext, input: AcceptDelegationInput): Readonly<{ accepted: true; queued: true; taskId: string }> {
+    const caller = this.assertDelegatingContext(context);
+    const state = this.restore();
+    if (!state.admissionOpen) throw new Error(`Delegation admission is closed: ${state.closedReason ?? "new work rejected"}`);
+    const parent = state.topology[caller.nodeId];
+    if (!state.topology[input.targetNodeId]) throw new Error(`Unknown target node ${input.targetNodeId}`);
+    if (!parent.directMemberIds.includes(input.targetNodeId)) throw new Error(`${input.targetNodeId} is not a direct member of ${caller.nodeId}`);
+    const taskId = boundedId(this.options.createTaskId?.() ?? `task-${randomUUID()}`, "Delegation task ID");
+    const contextRefs = authorizeReferences(input.contextRefs, input.targetNodeId, this.options.referenceAuthorizer);
+    if (input.provenance !== undefined) {
+      if (!plainRecord(input.provenance)) throw new Error("Delegation provenance is invalid");
+      exactKeys(input.provenance, [], ["correlationId"], "Delegation provenance");
+    }
+    const provenance: DelegationProvenance = Object.freeze({
+      source: "delegate_agent",
+      ...(input.provenance?.correlationId === undefined ? {} : { correlationId: boundedId(input.provenance.correlationId, "Correlation ID") }),
+      ...(caller.taskId ? { parentTaskId: caller.taskId } : {}),
+    });
+    this.append("task.accepted", {
+      formatVersion: FORMAT_VERSION,
+      taskId,
+      parentNodeId: caller.nodeId,
+      targetNodeId: input.targetNodeId,
+      objective: bounded(input.objective, "Delegation objective", LIMITS.objectiveBytes),
+      contextRefs: contextRefs as unknown as JsonValue,
+      deliverables: [...stringArray(input.deliverables, "Delegation deliverables", LIMITS.deliverables, LIMITS.deliverableBytes)],
+      provenance: provenance as unknown as JsonValue,
+    }, "runtime");
+    return Object.freeze({ accepted: true, queued: true, taskId });
+  }
+
+  start(taskId: string, attemptId: string): void {
+    this.append("task.started", { formatVersion: FORMAT_VERSION, taskId: boundedId(taskId, "Task ID"), attemptId: boundedId(attemptId, "Attempt ID") }, "harness");
+  }
+
+  suspend(taskId: string, dependencyTaskIds: readonly string[]): void {
+    this.append("task.suspended", { formatVersion: FORMAT_VERSION, taskId: boundedId(taskId, "Task ID"), dependencyTaskIds: [...dependencyTaskIds] }, "harness");
+  }
+
+  interrupt(taskId: string, reason: string): void {
+    const task = this.restore().tasks[taskId];
+    const attemptId = task?.attempts.at(-1)?.attemptId;
+    if (!attemptId) throw new Error("Task interruption requires an active attempt");
+    this.append("task.interrupted", { formatVersion: FORMAT_VERSION, taskId, attemptId, reason: bounded(reason, "Task interruption reason", LIMITS.resultSummaryBytes) }, "harness");
+  }
+
+  reconcileActiveAfterTakeover(verified: boolean, reason = "Verified runtime takeover interrupted the prior attempt"): number {
+    const active = Object.values(this.restore().tasks).filter((task) => task.queueState === "active" && task.resumedByResultSequence === undefined);
+    if (active.length && !verified) throw new Error("Active delegation recovery requires verified takeover");
+    for (const task of active.sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))) {
+      const attemptId = task.attempts.at(-1)?.attemptId;
+      if (!attemptId) throw new Error("Active delegation task has no attempt to reconcile");
+      const pendingDependencies = task.suspendedOn?.filter((dependencyId) => this.restore().tasks[dependencyId]?.resultAcceptedSequence === undefined) ?? [];
+      if (pendingDependencies.length) {
+        this.append("task.suspended", { formatVersion: FORMAT_VERSION, taskId: task.taskId, dependencyTaskIds: [...task.suspendedOn!] }, "recovery");
+      } else {
+        this.append("task.interrupted", { formatVersion: FORMAT_VERSION, taskId: task.taskId, attemptId, reason: bounded(reason, "Task interruption reason", LIMITS.resultSummaryBytes) }, "recovery");
+      }
+    }
+    return active.length;
+  }
+
+  recordResult(taskId: string, input: WorkerResultInput): void {
+    const state = this.restore();
+    const task = state.tasks[taskId];
+    if (!task) throw new Error(`Unknown delegation task ${taskId}`);
+    const result = normalizedResult(input, task, this.options.referenceAuthorizer);
+    if (task.queueState !== "queued") result.attemptId = task.attempts.at(-1)!.attemptId;
+    this.append("task.result.recorded", { formatVersion: FORMAT_VERSION, taskId, result }, "harness");
+  }
+
+  pauseAdmission(reason: string): void {
+    if (this.restore().schedulerStatus === "running") this.append("scheduler.paused", { formatVersion: FORMAT_VERSION, reason: bounded(reason, "Scheduler pause reason", LIMITS.resultSummaryBytes) }, "harness");
+  }
+
+  resumeAdmission(): void {
+    if (this.restore().schedulerStatus === "paused") this.append("scheduler.resumed", { formatVersion: FORMAT_VERSION }, "harness");
+  }
+
+  closeAdmission(reason: string): void {
+    if (this.restore().schedulerStatus !== "closed") this.append("scheduler.closed", { formatVersion: FORMAT_VERSION, reason: bounded(reason, "Scheduler close reason", LIMITS.resultSummaryBytes) }, "harness");
+  }
+
+  cancelPending(reason: string): void {
+    this.closeAdmission(reason);
+    for (const task of Object.values(this.restore().tasks).sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))) {
+      if (task.queueState === "queued" || task.queueState === "suspended") {
+        this.recordResult(task.taskId, { status: "cancelled", summary: utf8Prefix(reason, LIMITS.resultSummaryBytes), outputRefs: [], evidenceRefs: [] });
+      }
+    }
+  }
+
+  private preparedForRecipient(recipientNodeId: string): ResultDeliveryBatch | undefined {
+    const state = this.restore();
+    const delivery = Object.values(state.deliveries).find((candidate) => candidate.recipientNodeId === recipientNodeId && candidate.acceptedSequence === undefined);
+    if (!delivery) return undefined;
+    const items = delivery.taskIds.map((taskId) => {
+      const result = state.tasks[taskId]?.result;
+      if (!result) throw new Error("Prepared result delivery references a missing result");
+      return Object.freeze({ taskId, result });
+    });
+    return deepFreeze({ deliveryId: delivery.deliveryId, recipientNodeId, items });
+  }
+
+  preparedResultDelivery(context: DelegationExecutionContext): ResultDeliveryBatch | undefined {
+    return this.preparedForRecipient(this.assertContext(context).nodeId);
+  }
+
+  private prepareForRecipient(recipientNodeId: string, deliveryId: string, options: { limit?: number } = {}): ResultDeliveryBatch {
+    const existing = this.preparedForRecipient(recipientNodeId);
+    if (existing) {
+      if (existing.deliveryId !== deliveryId) throw new Error("An unaccepted result delivery already exists for this recipient");
+      return existing;
+    }
+    const state = this.restore();
+    const limit = Number.isSafeInteger(options.limit) && Number(options.limit) > 0 ? Math.min(LIMITS.statusPage, Number(options.limit)) : 20;
+    const pending = Object.values(state.tasks)
+      .filter((task) => task.parentNodeId === recipientNodeId && task.result && task.resultAcceptedSequence === undefined && task.resultDeliveryPreparedSequence === undefined)
+      .sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))
+      .slice(0, limit);
+    if (!pending.length) throw new Error("No durable worker results are pending for this recipient");
+    this.append("task.result.delivery.prepared", {
+      formatVersion: FORMAT_VERSION,
+      deliveryId: boundedId(deliveryId, "Result delivery ID"),
+      recipientNodeId,
+      taskIds: pending.map((task) => task.taskId),
+    }, "runtime");
+    return this.preparedForRecipient(recipientNodeId)!;
+  }
+
+  prepareResultDelivery(context: DelegationExecutionContext, deliveryId: string, options: { limit?: number } = {}): ResultDeliveryBatch {
+    return this.prepareForRecipient(this.assertContext(context).nodeId, deliveryId, options);
+  }
+
+  private acceptForRecipient(recipientNodeId: string, deliveryId: string): void {
+    const prepared = this.preparedForRecipient(recipientNodeId);
+    if (!prepared || prepared.deliveryId !== deliveryId) throw new Error("Result delivery acceptance does not match a durable preparation");
+    this.append("task.result.delivery.accepted", { formatVersion: FORMAT_VERSION, deliveryId, recipientNodeId }, "runtime");
+  }
+
+  acceptResultDelivery(context: DelegationExecutionContext, deliveryId: string): void {
+    this.acceptForRecipient(this.assertContext(context).nodeId, deliveryId);
+  }
+
+  prepareResultDeliveryForSuspendedTask(taskId: string, deliveryId: string, options: { limit?: number } = {}): ResultDeliveryBatch {
+    const task = this.restore().tasks[boundedId(taskId, "Suspended parent task ID")];
+    if (!task || task.queueState !== "suspended" || !task.attempts.at(-1)?.attemptId) throw new Error("Result delivery bridge requires the current suspended parent task");
+    return this.prepareForRecipient(task.targetNodeId, deliveryId, options);
+  }
+
+  deliverPendingResultsToSuspendedTask(taskId: string, deliveryId: string, options: { limit?: number } = {}): ResultDeliveryBatch {
+    const task = this.restore().tasks[boundedId(taskId, "Suspended parent task ID")];
+    if (!task || task.queueState !== "suspended" || !task.attempts.at(-1)?.attemptId) throw new Error("Result delivery bridge requires the current suspended parent task");
+    const prepared = this.prepareForRecipient(task.targetNodeId, deliveryId, options);
+    this.acceptForRecipient(task.targetNodeId, prepared.deliveryId);
+    return prepared;
+  }
+
+  status(context: DelegationExecutionContext, options: { limit?: number; cursor?: string } = {}): DelegationStatusPage {
+    const caller = this.assertContext(context);
+    const state = this.restore();
+    const limit = Number.isSafeInteger(options.limit) && Number(options.limit) > 0 ? Math.min(LIMITS.statusPage, Number(options.limit)) : 20;
+    let after = 0;
+    if (options.cursor !== undefined) {
+      if (Buffer.byteLength(options.cursor, "utf8") > LIMITS.cursorBytes || !/^[1-9][0-9]*$/u.test(options.cursor)) throw new Error("Delegation status cursor is invalid");
+      after = Number(options.cursor);
+      if (!Number.isSafeInteger(after)) throw new Error("Delegation status cursor is invalid");
+    }
+    const visible = Object.values(state.tasks)
+      .filter((task) => caller.nodeId === state.rootNodeId || task.parentNodeId === caller.nodeId || task.targetNodeId === caller.nodeId)
+      .sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId));
+    const summary: Record<DelegationQueueState | WorkerTerminalStatus, number> = { queued: 0, active: 0, suspended: 0, terminal: 0, completed: 0, blocked: 0, failed: 0, cancelled: 0 };
+    for (const task of visible) {
+      summary[task.queueState]++;
+      if (task.result) summary[task.result.status]++;
+    }
+    const page = visible.filter((task) => task.creationSequence > after).slice(0, limit);
+    const items = page.map((task): DelegationStatusItem => Object.freeze({
+      taskId: task.taskId,
+      parentNodeId: task.parentNodeId,
+      targetNodeId: task.targetNodeId,
+      objectivePreview: utf8Prefix(task.objective, LIMITS.statusObjectivePreviewBytes),
+      creationSequence: task.creationSequence,
+      queueState: task.queueState,
+      attempts: task.attempts.length,
+      ...(task.result ? { terminalStatus: task.result.status } : {}),
+      resultAccepted: task.resultAcceptedSequence !== undefined,
+    }));
+    const hasMore = visible.some((task) => task.creationSequence > (page.at(-1)?.creationSequence ?? after));
+    return deepFreeze({ summary, items, ...(hasMore && page.length ? { nextCursor: String(page.at(-1)!.creationSequence) } : {}) });
+  }
+}
+
+export { LIMITS as DELEGATION_LIMITS, FORMAT_VERSION as DELEGATION_FORMAT_VERSION };

--- a/src/workflows/events.ts
+++ b/src/workflows/events.ts
@@ -20,6 +20,16 @@ export type WorkflowEventType =
   | "run.cancel.settlement.failed"
   | "run.pause.release.confirmed"
   | "run.terminal.prepared"
+  | "task.accepted"
+  | "task.started"
+  | "task.suspended"
+  | "task.interrupted"
+  | "task.result.recorded"
+  | "task.result.delivery.prepared"
+  | "task.result.delivery.accepted"
+  | "scheduler.paused"
+  | "scheduler.resumed"
+  | "scheduler.closed"
   | "task.transition"
   | "question.transition"
   | "approval.recorded"
@@ -30,7 +40,11 @@ export type WorkflowEventType =
 const EVENT_TYPES = new Set<WorkflowEventType>([
   "session.created", "session.linked", "session.selected", "session.orphaned", "control.requested",
   "run.started", "run.input.recorded", "run.input.delivery.prepared", "run.input.delivered",
-  "run.transition", "run.cancel.requested", "run.cancel.settlement.failed", "run.pause.release.confirmed", "run.terminal.prepared", "task.transition", "question.transition", "approval.recorded",
+  "run.transition", "run.cancel.requested", "run.cancel.settlement.failed", "run.pause.release.confirmed", "run.terminal.prepared",
+  "task.accepted", "task.started", "task.suspended", "task.interrupted", "task.result.recorded",
+  "task.result.delivery.prepared", "task.result.delivery.accepted",
+  "scheduler.paused", "scheduler.resumed", "scheduler.closed",
+  "task.transition", "question.transition", "approval.recorded",
   "artifact.recorded", "handoff.recorded", "knowledge.transition", "terminal.recorded",
 ]);
 const PRODUCERS = new Set<WorkflowEventProducer>(["runtime", "dashboard", "recovery", "harness"]);

--- a/src/workflows/orchestration.ts
+++ b/src/workflows/orchestration.ts
@@ -1,0 +1,355 @@
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import type { JsonValue } from "../config/types";
+import {
+  DelegationRuntime,
+  type AcceptDelegationInput,
+  type DelegationExecutionContext,
+  type DelegationState,
+  type DelegationStatusPage,
+  type ResultDeliveryBatch,
+} from "./delegation";
+import { routeDirectMembers, type RouteDirectMembersInput, type RouteRecommendation } from "./routing";
+import {
+  CANCELLATION_TIMING,
+  WorkflowRunLifecycle,
+  isOpenRunStatus,
+  type CancellationCoordinator,
+  type CancellationResult,
+  type CompletionValidationHooks,
+  type PauseCoordinator,
+  type ResumeCoordinator,
+  type WorkflowRunLifecycleOptions,
+} from "./runs";
+import { DurableDelegationScheduler } from "./scheduler";
+import { WorkerSessionPool, type WorkerSessionFactory } from "./workers";
+
+export interface RunOrchestrationServiceOptions {
+  readonly projectRoot: string; readonly projectId: string; readonly sessionId: string;
+  readonly snapshot: ActivationSnapshotFileV1; readonly runtimeOwnerNonce: string; readonly maxParallel: number;
+  readonly workerFactory: WorkerSessionFactory;
+  readonly createRunId?: () => string; readonly createTaskId?: () => string; readonly createAttemptId?: () => string;
+  readonly now?: () => string; readonly referenceAuthorizer?: DelegationRuntime["options"]["referenceAuthorizer"];
+  readonly verifiedTakeover?: () => boolean | Promise<boolean>;
+  readonly completion?: Omit<CompletionValidationHooks, "descendants">;
+  /** Fault-injection seam for workflow lifecycle crash-recovery tests. */
+  readonly journalFault?: WorkflowRunLifecycleOptions["journalFault"];
+  readonly pauseAuthority: PauseCoordinator; readonly resumeAuthority: ResumeCoordinator;
+  readonly cancellationAuthority: Pick<CancellationCoordinator, "terminateProcessTrees" | "capturePartialState" | "releaseLeases">;
+}
+export interface BoundDelegationServices {
+  readonly context: DelegationExecutionContext;
+  route(input: RouteDirectMembersInput): readonly RouteRecommendation[];
+  delegate(input: AcceptDelegationInput): Readonly<{ accepted: true; queued: true; taskId: string }>;
+  status(options?: { limit?: number; cursor?: string }): DelegationStatusPage;
+  preparedResultDelivery(): ResultDeliveryBatch | undefined;
+  prepareResultDelivery(deliveryId: string, options?: { limit?: number }): ResultDeliveryBatch;
+  acceptResultDelivery(deliveryId: string): void;
+}
+interface RunResources {
+  readonly runId: string; readonly runtime: DelegationRuntime;
+  readonly scheduler: DurableDelegationScheduler; readonly workers: WorkerSessionPool;
+}
+
+function rootNodeId(snapshot: ActivationSnapshotFileV1): string {
+  const team = snapshot.payload.workflow.team as { rootId?: unknown } | undefined;
+  if (typeof team?.rootId !== "string" || !team.rootId) throw new Error("Activation snapshot root node is invalid");
+  return team.rootId;
+}
+
+export class RunOrchestrationService {
+  readonly lifecycle: WorkflowRunLifecycle;
+  private readonly options: RunOrchestrationServiceOptions;
+  private current?: RunResources;
+  private readonly cleanup = new Set<Promise<void>>();
+
+  constructor(options: RunOrchestrationServiceOptions) {
+    this.options = options;
+    const completion: CompletionValidationHooks = {
+      ...(options.completion ?? {}),
+      descendants: () => this.descendantGate(),
+      settleTerminal: async (settlement) => {
+        await this.settleTerminalResources(settlement.runId);
+        await options.completion?.settleTerminal?.(settlement);
+      },
+    };
+    this.lifecycle = new WorkflowRunLifecycle({
+      projectRoot: options.projectRoot,
+      projectId: options.projectId,
+      sessionId: options.sessionId,
+      snapshotId: options.snapshot.snapshotHash,
+      rootNodeId: rootNodeId(options.snapshot),
+      runtimeOwnerNonce: options.runtimeOwnerNonce,
+      createRunId: options.createRunId,
+      now: options.now,
+      completion,
+      journalFault: options.journalFault,
+    });
+  }
+
+  private trackCleanup(promise: Promise<void>): void {
+    this.cleanup.add(promise);
+    void promise.finally(() => { this.cleanup.delete(promise); }).catch(() => undefined);
+  }
+
+  private reconcileDurableNestedDeliveries(runtime: DelegationRuntime): void {
+    for (;;) {
+      const state = runtime.restore();
+      const parent = Object.values(state.tasks)
+        .filter((task) => task.queueState === "suspended" && task.suspendedOn?.some((taskId) => {
+          const dependency = state.tasks[taskId];
+          return dependency?.result !== undefined && dependency.resultAcceptedSequence === undefined;
+        }))
+        .sort((a, b) => a.creationSequence - b.creationSequence || (a.taskId < b.taskId ? -1 : a.taskId > b.taskId ? 1 : 0))[0];
+      if (!parent) return;
+      const existing = Object.values(state.deliveries).find((delivery) => delivery.recipientNodeId === parent.targetNodeId && delivery.acceptedSequence === undefined);
+      const dependency = parent.suspendedOn!.map((taskId) => state.tasks[taskId]).find((task) => task?.result && task.resultAcceptedSequence === undefined);
+      if (!dependency) return;
+      runtime.deliverPendingResultsToSuspendedTask(
+        parent.taskId,
+        existing?.deliveryId ?? `delivery-${dependency.taskId}-${dependency.result!.recordedSequence}`,
+      );
+    }
+  }
+
+  private createResources(runId: string): RunResources {
+    const runtime = new DelegationRuntime({
+      projectRoot: this.options.projectRoot,
+      projectId: this.options.projectId,
+      sessionId: this.options.sessionId,
+      runId,
+      snapshot: this.options.snapshot,
+      createTaskId: this.options.createTaskId,
+      now: this.options.now,
+      referenceAuthorizer: this.options.referenceAuthorizer,
+    });
+    const workers = new WorkerSessionPool({
+      projectRoot: this.options.projectRoot,
+      sessionId: this.options.sessionId,
+      runId,
+      snapshot: this.options.snapshot,
+      factory: this.options.workerFactory,
+    });
+    workers.rebuildBoundaries(Object.values(runtime.restore().tasks));
+    const scheduler = new DurableDelegationScheduler({
+      runtime,
+      maxParallel: this.options.maxParallel,
+      createAttemptId: this.options.createAttemptId,
+      verifiedTakeover: this.options.verifiedTakeover,
+      onRecoveryReconciled: () => this.reconcileDurableNestedDeliveries(runtime),
+      execute: (task, control) => {
+        const state = runtime.restore();
+        const deliveredResults = (task.suspendedOn ?? []).flatMap((taskId) => {
+          const child = state.tasks[taskId];
+          return child?.result && child.resultAcceptedSequence !== undefined ? [Object.freeze({ taskId, result: child.result })] : [];
+        });
+        return workers.execute(task, control.signal, this.bind(control.executionContext, { runId, runtime }), deliveredResults);
+      },
+      onResultDurable: (task) => {
+        const parentTaskId = task.provenance.parentTaskId;
+        const state = runtime.restore();
+        const parent = parentTaskId ? state.tasks[parentTaskId] : undefined;
+        if (parent?.queueState === "suspended" && parent.suspendedOn?.includes(task.taskId)) {
+          runtime.deliverPendingResultsToSuspendedTask(parent.taskId, `delivery-${task.taskId}-${task.result?.recordedSequence ?? task.creationSequence}`);
+        }
+        workers.rebuildBoundaries(Object.values(runtime.restore().tasks));
+      },
+    });
+    const resources = { runId, runtime, scheduler, workers };
+    const run = this.lifecycle.restore().latestRun;
+    if (run?.runId === runId && run.pendingTerminal) this.failClosedForTerminal(resources);
+    else this.reconcileDurableNestedDeliveries(runtime);
+    return resources;
+  }
+
+  private failClosedForTerminal(resources: RunResources): void {
+    resources.scheduler.closeAdmission("workflow terminal settlement");
+    resources.scheduler.cancelPending("workflow terminal settlement");
+    resources.scheduler.abortOwnedWork("workflow terminal settlement");
+  }
+
+  private resources(): RunResources {
+    const run = this.lifecycle.restore().latestRun;
+    if (!run || !isOpenRunStatus(run.status)) throw new Error("Run-scoped orchestration requires a current open workflow run");
+    if (this.current?.runId !== run.runId) {
+      if (this.current) this.trackCleanup(this.current.workers.closeSessions());
+      this.current = this.createResources(run.runId);
+    }
+    if (run.pendingTerminal) {
+      this.failClosedForTerminal(this.current);
+      throw new Error("Run-scoped orchestration is unavailable while terminal settlement is finalizing");
+    }
+    return this.current;
+  }
+
+  private async settleTerminalResources(runId: string): Promise<void> {
+    const run = this.lifecycle.restore().latestRun;
+    if (!run || run.runId !== runId || !isOpenRunStatus(run.status) || !run.pendingTerminal) throw new Error("Terminal resource settlement does not target the current finalizing run");
+    const resources = this.current?.runId === runId ? this.current : this.createResources(runId);
+    this.current = resources;
+    this.failClosedForTerminal(resources);
+    await resources.workers.closeSessions();
+    const [schedulerSettled, workersSettled] = await Promise.all([
+      resources.scheduler.waitForSettlement(CANCELLATION_TIMING.killSettleMs),
+      resources.workers.waitForSettlement(CANCELLATION_TIMING.killSettleMs),
+    ]);
+    if (!schedulerSettled || !workersSettled) throw new Error("Worker execution did not settle during terminal finish");
+    await resources.scheduler.runUntilSettled();
+    resources.scheduler.cancelPending("workflow terminal settlement");
+    const unsettled = Object.values(resources.runtime.restore().tasks).filter((task) => task.queueState !== "terminal");
+    if (unsettled.length) throw new Error(`${unsettled.length} descendant task(s) remain unsettled during terminal finish`);
+  }
+
+  private descendantGate(): Readonly<{ state: "satisfied" | "unsatisfied"; issues?: readonly string[] }> {
+    const run = this.lifecycle.restore().latestRun;
+    if (!run) return Object.freeze({ state: "unsatisfied", issues: Object.freeze(["no workflow run is active"]) });
+    const resources = this.resources();
+    const tasks = Object.values(resources.runtime.restore().tasks);
+    const unsettled = tasks.filter((task) => task.queueState !== "terminal");
+    const undelivered = tasks.filter((task) => task.parentNodeId === resources.runtime.restore().rootNodeId && task.result && task.resultAcceptedSequence === undefined);
+    if (!unsettled.length && !undelivered.length) return Object.freeze({ state: "satisfied" });
+    return Object.freeze({
+      state: "unsatisfied",
+      issues: Object.freeze([
+        ...(unsettled.length ? [`${unsettled.length} descendant task(s) are queued, active, or suspended`] : []),
+        ...(undelivered.length ? [`${undelivered.length} durable descendant result(s) have not been accepted by the parent`] : []),
+      ]),
+    });
+  }
+
+  private bind(context: DelegationExecutionContext, resources: Pick<RunResources, "runId" | "runtime">): BoundDelegationServices {
+    const assertCurrent = (): void => {
+      const run = this.lifecycle.restore().latestRun;
+      if (run?.runId === resources.runId && run.pendingTerminal) {
+        const current = this.current?.runId === resources.runId ? this.current : undefined;
+        if (current) this.failClosedForTerminal(current);
+        throw new Error("Delegation services are unavailable while terminal settlement is finalizing");
+      }
+      if (!run || !isOpenRunStatus(run.status) || run.runId !== resources.runId || this.current?.runId !== resources.runId || !resources.runtime.restore().admissionOpen) {
+        throw new Error("Delegation services are stale and do not target the current open run");
+      }
+      resources.runtime.assertExecutionContext(context);
+    };
+    return Object.freeze({
+      context,
+      route: (input: RouteDirectMembersInput) => { assertCurrent(); return routeDirectMembers(this.options.snapshot, context.nodeId, input); },
+      delegate: (input: AcceptDelegationInput) => { assertCurrent(); return resources.runtime.accept(context, input); },
+      status: (options: { limit?: number; cursor?: string } = {}) => { assertCurrent(); return resources.runtime.status(context, options); },
+      preparedResultDelivery: () => { assertCurrent(); return resources.runtime.preparedResultDelivery(context); },
+      prepareResultDelivery: (deliveryId: string, options: { limit?: number } = {}) => { assertCurrent(); return resources.runtime.prepareResultDelivery(context, deliveryId, options); },
+      acceptResultDelivery: (deliveryId: string) => { assertCurrent(); resources.runtime.acceptResultDelivery(context, deliveryId); },
+    });
+  }
+
+  rootServices(): BoundDelegationServices {
+    const resources = this.resources();
+    return this.bind(resources.runtime.rootExecutionContext(), resources);
+  }
+
+  servicesFor(context: DelegationExecutionContext): BoundDelegationServices {
+    const resources = this.resources();
+    resources.runtime.status(context, { limit: 1 });
+    return this.bind(context, resources);
+  }
+
+  delegationState(): DelegationState {
+    const run = this.lifecycle.restore().latestRun;
+    if (!run || !isOpenRunStatus(run.status)) {
+      if (this.current) return this.current.runtime.restore();
+      throw new Error("Delegation state requires a current workflow run");
+    }
+    if (this.current?.runId !== run.runId) {
+      if (this.current) this.trackCleanup(this.current.workers.closeSessions());
+      this.current = this.createResources(run.runId);
+    }
+    if (run.pendingTerminal) this.failClosedForTerminal(this.current);
+    return this.current.runtime.restore();
+  }
+
+  async runWorkers(): Promise<void> {
+    const resources = this.resources();
+    const run = this.lifecycle.restore().latestRun;
+    if (!run || run.runId !== resources.runId || !isOpenRunStatus(run.status) || run.status === "paused" || run.cancellationRequested) {
+      throw new Error("Workers can run only for the current running workflow run");
+    }
+    await resources.scheduler.runUntilSettled();
+  }
+
+  private async suspendResources(reason: string): Promise<void> {
+    const resources = this.resources();
+    resources.scheduler.pauseAdmission(reason);
+    resources.scheduler.abortOwnedWork(reason);
+    if (!await resources.scheduler.waitForSettlement(CANCELLATION_TIMING.settleGraceMs)) throw new Error("Worker scheduler did not settle during pause");
+    await resources.workers.closeSessions();
+    if (!await resources.workers.waitForSettlement(CANCELLATION_TIMING.killSettleMs)) throw new Error("Worker sessions did not settle during pause");
+  }
+
+  async pause(reason: string): Promise<boolean> {
+    return this.lifecycle.pause(reason, {
+      ...this.options.pauseAuthority,
+      suspendOwnedWork: async () => {
+        await this.suspendResources(reason);
+        await this.options.pauseAuthority.suspendOwnedWork?.();
+      },
+    });
+  }
+
+  async resume(): Promise<boolean> {
+    const resumed = await this.lifecycle.resume(this.options.resumeAuthority);
+    if (!resumed) return false;
+    const run = this.lifecycle.restore().latestRun;
+    if (!run) throw new Error("Resumed workflow run disappeared");
+    if (this.current) await this.current.workers.closeSessions();
+    this.current = this.createResources(run.runId);
+    this.current.scheduler.resume();
+    return true;
+  }
+
+  private cancellationCoordinator(reason: string): CancellationCoordinator {
+    const resources = this.resources();
+    return {
+      rejectNewWork: () => { resources.scheduler.closeAdmission(reason); },
+      cancelQueuedWork: () => { resources.scheduler.cancelPending(reason); },
+      abortOwnedWork: async () => {
+        resources.scheduler.abortOwnedWork(reason);
+        await resources.workers.closeSessions();
+      },
+      waitForSettlement: async (timeoutMs) => {
+        const [schedulerSettled, workersSettled] = await Promise.all([
+          resources.scheduler.waitForSettlement(timeoutMs),
+          resources.workers.waitForSettlement(timeoutMs),
+        ]);
+        return schedulerSettled && workersSettled;
+      },
+      terminateProcessTrees: this.options.cancellationAuthority.terminateProcessTrees,
+      capturePartialState: async () => {
+        const base = await this.options.cancellationAuthority.capturePartialState?.() ?? {};
+        return {
+          ...base,
+          delegation: {
+            runId: resources.runId,
+            schedulerStatus: resources.runtime.restore().schedulerStatus,
+            taskCount: Object.keys(resources.runtime.restore().tasks).length,
+          },
+        } as Readonly<Record<string, JsonValue>>;
+      },
+      releaseLeases: this.options.cancellationAuthority.releaseLeases,
+    };
+  }
+
+  async cancel(reason: string): Promise<CancellationResult> {
+    const result = await this.lifecycle.cancel(reason, this.cancellationCoordinator(reason));
+    if (this.current) await this.current.workers.closeSessions();
+    return result;
+  }
+
+  async shutdown(reason = "process shutdown"): Promise<void> {
+    const run = this.lifecycle.restore().latestRun;
+    if (run && isOpenRunStatus(run.status)) await this.pause(reason);
+    if (this.current) await this.current.workers.closeSessions();
+    if (this.cleanup.size) await Promise.allSettled([...this.cleanup]);
+  }
+
+  hasLiveHandles(): boolean {
+    return Boolean(this.current?.scheduler.hasLiveHandles() || this.current?.workers.hasLiveHandles() || this.cleanup.size);
+  }
+}

--- a/src/workflows/references.ts
+++ b/src/workflows/references.ts
@@ -1,0 +1,112 @@
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+import { boundedJson, boundedText, plainRecord, utf8Prefix } from "./values";
+
+const LIMITS = Object.freeze({
+  references: 128,
+  kindBytes: 128,
+  idBytes: 2_048,
+  diagnosticBytes: 2_048,
+  resolvedItemBytes: 65_536,
+  resolvedAggregateBytes: 131_072,
+  resolvedDepth: 16,
+  resolvedNodes: 4_096,
+});
+const JSON_BOUNDS = {
+  bytes: LIMITS.resolvedItemBytes,
+  depth: LIMITS.resolvedDepth,
+  nodes: LIMITS.resolvedNodes,
+} as const;
+
+export const NO_DLP_PROSE_LIMITATION =
+  "Capabilities re-authorize structured references; free-form prose is not DLP or information-flow control.";
+
+export interface StructuredReference {
+  readonly kind: string;
+  readonly id: string;
+}
+
+export type ReferenceAuthorizationDecision =
+  | Readonly<{ authorized: true; resolved?: JsonValue }>
+  | Readonly<{ authorized: false; diagnostic: string }>;
+
+export interface ReferenceAuthorizer {
+  authorize(reference: StructuredReference, recipientNodeId: string): ReferenceAuthorizationDecision;
+}
+
+export type AuthorizedReference =
+  | Readonly<{ ref: StructuredReference; authorization: "authorized"; resolved?: JsonValue }>
+  | Readonly<{ ref: StructuredReference; authorization: "denied"; diagnostic: string }>;
+
+export function validateStructuredReference(value: unknown, label = "Reference"): StructuredReference {
+  if (!plainRecord(value) || Object.keys(value).some((key) => key !== "kind" && key !== "id")) {
+    throw new Error(`${label} has an invalid closed shape`);
+  }
+  return Object.freeze({
+    kind: boundedText(value.kind, `${label} kind`, LIMITS.kindBytes),
+    id: boundedText(value.id, `${label} id`, LIMITS.idBytes),
+  });
+}
+
+function denied(ref: StructuredReference, diagnostic: string): AuthorizedReference {
+  return Object.freeze({
+    ref,
+    authorization: "denied" as const,
+    diagnostic: utf8Prefix(diagnostic, LIMITS.diagnosticBytes),
+  });
+}
+
+function authorizeOne(
+  raw: StructuredReference,
+  index: number,
+  recipientNodeId: string,
+  authorizer?: ReferenceAuthorizer,
+): AuthorizedReference {
+  const ref = validateStructuredReference(raw, `Context reference ${index}`);
+  if (!authorizer) return denied(ref, "No reference authorization service is available");
+  let decision: ReferenceAuthorizationDecision;
+  try {
+    decision = authorizer.authorize(ref, recipientNodeId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return denied(ref, `Authorization failed: ${utf8Prefix(message, LIMITS.diagnosticBytes - 22)}`);
+  }
+  if (!decision?.authorized) {
+    const diagnostic = typeof decision?.diagnostic === "string" && decision.diagnostic.trim()
+      ? decision.diagnostic
+      : "Recipient is not authorized for this reference";
+    return denied(ref, diagnostic);
+  }
+  if (decision.resolved === undefined) return Object.freeze({ ref, authorization: "authorized" as const });
+  try {
+    return Object.freeze({
+      ref,
+      authorization: "authorized" as const,
+      resolved: boundedJson(decision.resolved, `Resolved context reference ${index}`, JSON_BOUNDS),
+    });
+  } catch {
+    return denied(ref, "Authorized reference content exceeds the recipient context bound");
+  }
+}
+
+export function authorizeReferences(
+  references: readonly StructuredReference[] | undefined,
+  recipientNodeId: string,
+  authorizer?: ReferenceAuthorizer,
+): readonly AuthorizedReference[] {
+  if (!references) return Object.freeze([]);
+  if (!Array.isArray(references) || references.length > LIMITS.references) {
+    throw new Error("Context reference limit exceeded");
+  }
+  let aggregate = 0;
+  return Object.freeze(references.map((raw, index) => {
+    const result = authorizeOne(raw, index, recipientNodeId, authorizer);
+    if (result.authorization !== "authorized" || result.resolved === undefined) return result;
+    aggregate += Buffer.byteLength(canonicalJson(result.resolved), "utf8");
+    return aggregate <= LIMITS.resolvedAggregateBytes
+      ? result
+      : denied(result.ref, "Authorized reference content exceeds the recipient context bound");
+  }));
+}
+
+export { LIMITS as REFERENCE_AUTHORIZATION_LIMITS };

--- a/src/workflows/routing.ts
+++ b/src/workflows/routing.ts
@@ -1,0 +1,145 @@
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import { compareText, plainRecord } from "./values";
+
+export interface RouteCapabilityRequirements {
+  filesystem?: boolean;
+  shell?: readonly string[];
+  git?: boolean;
+  externalNetwork?: boolean;
+  humanInput?: boolean;
+  artifact?: readonly string[];
+  knowledge?: readonly string[];
+}
+
+export interface RouteDirectMembersInput {
+  objective: string;
+  requiredCapabilities?: RouteCapabilityRequirements;
+  limit?: number;
+  includeUnmatched?: boolean;
+}
+
+export interface RouteRecommendation {
+  nodeId: string;
+  agentId: string;
+  score: number;
+  reasons: readonly string[];
+}
+
+type RecordValue = Readonly<Record<string, unknown>>;
+const REQUIREMENT_VALUES = {
+  shell: new Set(["inspect", "test", "build", "package", "mutate", "execute-code"]),
+  artifact: new Set(["read", "write", "review"]),
+  knowledge: new Set(["read", "propose", "curate"]),
+} as const;
+const BOOLEAN_REQUIREMENTS = ["filesystem", "git", "externalNetwork", "humanInput"] as const;
+const LIST_REQUIREMENTS = ["shell", "artifact", "knowledge"] as const;
+const REQUIREMENT_KEYS: ReadonlySet<string> = new Set([...BOOLEAN_REQUIREMENTS, ...LIST_REQUIREMENTS]);
+
+function record(value: unknown): RecordValue | undefined {
+  return plainRecord(value) ? value : undefined;
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringList(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function tokens(value: unknown): readonly string[] {
+  if (typeof value !== "string") return [];
+  const terms = value.normalize("NFC").toLowerCase().split(/[^\p{L}\p{N}_-]+/u).filter((term) => term.length > 1);
+  return Object.freeze([...new Set(terms)].sort(compareText));
+}
+
+function validateRequirements(value: RouteCapabilityRequirements | undefined): void {
+  if (value === undefined) return;
+  const raw = record(value);
+  if (!raw || Object.keys(raw).some((key) => !REQUIREMENT_KEYS.has(key))) {
+    throw new Error("Routing capability requirement contains an unknown or invalid capability");
+  }
+  for (const key of BOOLEAN_REQUIREMENTS) {
+    if (raw[key] !== undefined && typeof raw[key] !== "boolean") {
+      throw new Error(`Routing capability requirement ${key} is invalid`);
+    }
+  }
+  for (const key of LIST_REQUIREMENTS) {
+    const list = raw[key];
+    if (list === undefined) continue;
+    if (!Array.isArray(list) || list.length > 64 || new Set(list).size !== list.length
+      || list.some((entry) => typeof entry !== "string" || !REQUIREMENT_VALUES[key].has(entry))) {
+      throw new Error(`Routing capability requirement ${key} contains an unknown or invalid capability`);
+    }
+  }
+}
+
+function satisfies(node: RecordValue | undefined, requirement: RouteCapabilityRequirements | undefined): boolean {
+  if (!requirement) return true;
+  const capabilities = record(record(node?.capabilities)?.effective);
+  if (!capabilities) return false;
+  if (requirement.filesystem && (!Array.isArray(capabilities.filesystem) || !capabilities.filesystem.length)) return false;
+  if (requirement.git && capabilities.git !== true) return false;
+  if (requirement.externalNetwork && capabilities["external-network"] !== true) return false;
+  if (requirement.humanInput && capabilities["human-input"] !== true) return false;
+  for (const key of LIST_REQUIREMENTS) {
+    const required = requirement[key];
+    if (required?.some((item) => !new Set(stringList(capabilities[key])).has(item))) return false;
+  }
+  return true;
+}
+
+function scoreMember(
+  node: RecordValue,
+  agent: RecordValue | undefined,
+  objectiveTokens: readonly string[],
+): Readonly<{ score: number; reasons: readonly string[] }> {
+  const frontmatter = record(agent?.frontmatter);
+  const fields: Array<readonly [string, string]> = [
+    ["role", text(node.role)],
+    ...stringList(node.responsibilities).map((item) => ["responsibility", item] as const),
+    ["consult-when", text(node.consultWhen)],
+    ["description", text(agent?.description) || text(frontmatter?.description)],
+    ...stringList(agent?.tags).map((item) => ["tag", item] as const),
+  ];
+  let score = 0;
+  const reasons: string[] = [];
+  for (const [label, value] of fields) {
+    const metadata = new Set(tokens(value));
+    const matches = objectiveTokens.filter((token) => metadata.has(token));
+    score += matches.length;
+    if (matches.length) reasons.push(`${label}:${matches.join(",")}`);
+  }
+  return { score, reasons: Object.freeze([...new Set(reasons)].sort(compareText)) };
+}
+
+export function routeDirectMembers(
+  snapshot: ActivationSnapshotFileV1,
+  callerNodeId: string,
+  input: RouteDirectMembersInput,
+): readonly RouteRecommendation[] {
+  validateRequirements(input.requiredCapabilities);
+  const team = record(snapshot.payload.workflow.team);
+  const nodes = Array.isArray(team?.nodes) ? team.nodes.map(record).filter((node): node is RecordValue => Boolean(node)) : [];
+  const caller = nodes.find((node) => node.id === callerNodeId);
+  if (!caller) throw new Error(`Unknown node ${callerNodeId}`);
+  const memberIds = stringList(caller.memberIds);
+  if (!memberIds.length) throw new Error(`Node ${callerNodeId} has no direct members to route`);
+  if (typeof input.objective !== "string" || !input.objective.trim()
+    || Buffer.byteLength(input.objective, "utf8") > 131_072) throw new Error("Routing objective is empty or too large");
+
+  const agents = new Map((snapshot.payload.agents ?? []).map((agent) => [text(agent.id), agent as RecordValue]));
+  const authority = new Map(snapshot.payload.authority.nodes.map((node) => [text(node.nodeId), node as RecordValue]));
+  const limit = Number.isSafeInteger(input.limit) && Number(input.limit) > 0 ? Math.min(100, Number(input.limit)) : 10;
+  const objectiveTokens = tokens(input.objective);
+  const output: RouteRecommendation[] = [];
+  for (const nodeId of memberIds) {
+    const node = nodes.find((candidate) => candidate.id === nodeId);
+    if (!node || node.parentId !== callerNodeId || !satisfies(authority.get(nodeId), input.requiredCapabilities)) continue;
+    const agentId = text(node.agentId);
+    const ranking = scoreMember(node, agents.get(agentId), objectiveTokens);
+    if (ranking.score || input.includeUnmatched) output.push(Object.freeze({ nodeId, agentId, ...ranking }));
+  }
+  output.sort((a, b) => b.score - a.score || compareText(a.nodeId, b.nodeId));
+  return Object.freeze(output.slice(0, limit));
+}

--- a/src/workflows/runs.ts
+++ b/src/workflows/runs.ts
@@ -1212,7 +1212,7 @@ export class WorkflowRunLifecycle {
         if (!lockedRun || lockedRun.runId !== run.runId || !isOpenRunStatus(lockedRun.status)) throw new Error("run changed during finish validation");
         if (lockedRun.cancellationRequested || lockedRun.pendingTerminal) throw new Error("cancellation or terminal settlement started during finish validation");
         if (lockedRun.pendingDelivery || lockedRun.deliveredThrough !== lockedRun.inputs.length) throw new Error("input arrived during finish validation and must be delivered");
-      });
+      }, { fault: (stage) => this.options.journalFault?.("run.terminal.prepared", stage) });
     } catch (error) {
       return Object.freeze({ ok: false, issues: Object.freeze([String(error instanceof Error ? error.message : error)]) });
     }

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from "node:crypto";
+import {
+  DELEGATION_LIMITS,
+  type DelegationExecutionContext,
+  type DelegationRuntime,
+  type PersistedDelegationTask,
+  type WorkerResultInput,
+} from "./delegation";
+import { compareText as compare, utf8Prefix } from "./values";
+
+export type SchedulerExecutionResult = WorkerResultInput | Readonly<{ status: "suspended"; dependencyTaskIds: readonly string[] }>;
+
+export interface SchedulerTaskControl {
+  readonly signal: AbortSignal; readonly attemptId: string;
+  readonly executionContext: DelegationExecutionContext;
+}
+export interface SchedulerAttemptHooks {
+  readonly onAttemptStarted?: (task: PersistedDelegationTask, attemptId: string) => void | Promise<void>;
+  readonly onAttemptSettled?: (task: PersistedDelegationTask, attemptId: string, result: SchedulerExecutionResult) => void | Promise<void>;
+}
+export interface DurableDelegationSchedulerOptions {
+  readonly runtime: DelegationRuntime; readonly maxParallel: number;
+  readonly execute: (task: PersistedDelegationTask, control: SchedulerTaskControl) => SchedulerExecutionResult | Promise<SchedulerExecutionResult>;
+  readonly createAttemptId?: () => string; readonly hooks?: SchedulerAttemptHooks;
+  readonly verifiedTakeover?: () => boolean | Promise<boolean>;
+  readonly onRecoveryReconciled?: () => void | Promise<void>;
+  readonly onResultDurable?: (task: PersistedDelegationTask) => void | Promise<void>;
+}
+interface ActiveExecution {
+  readonly nodeId: string; readonly attemptId: string;
+  readonly controller: AbortController; readonly promise: Promise<void>;
+}
+
+function validateExecutionResult(value: SchedulerExecutionResult): void {
+  if (!value || typeof value !== "object") throw new Error("Worker executor returned no result");
+  if (value.status === "suspended") {
+    if (!Array.isArray(value.dependencyTaskIds) || value.dependencyTaskIds.length === 0) throw new Error("Suspended worker returned no dependency tasks");
+    return;
+  }
+  if (value.status !== "completed" && value.status !== "blocked" && value.status !== "failed" && value.status !== "cancelled") {
+    throw new Error("Worker executor returned an invalid terminal status");
+  }
+}
+
+/**
+ * Fairness v1: preserve FIFO within each node, then choose the eligible node
+ * with the least recent durable start sequence; creation sequence, node ID,
+ * and task ID are stable tie-breakers.
+ */
+export function selectNextDelegationTask(runtime: DelegationRuntime, activeNodes: ReadonlySet<string> = new Set()): PersistedDelegationTask | undefined {
+  const state = runtime.restore();
+  const nodeQueues = new Map<string, PersistedDelegationTask[]>();
+  const lastDispatched = new Map<string, number>();
+  for (const task of Object.values(state.tasks)) {
+    if (task.lastStartedSequence !== undefined) {
+      lastDispatched.set(task.targetNodeId, Math.max(lastDispatched.get(task.targetNodeId) ?? 0, task.lastStartedSequence));
+    }
+    if (task.queueState === "terminal") continue;
+    const queue = nodeQueues.get(task.targetNodeId) ?? [];
+    queue.push(task);
+    nodeQueues.set(task.targetNodeId, queue);
+  }
+  const eligible: PersistedDelegationTask[] = [];
+  for (const [nodeId, queue] of nodeQueues) {
+    if (activeNodes.has(nodeId)) continue;
+    const head = queue.sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))[0];
+    if (head?.queueState === "queued" || (head?.queueState === "active" && head.resumedByResultSequence !== undefined)) eligible.push(head);
+  }
+  return eligible.sort((a, b) =>
+    (lastDispatched.get(a.targetNodeId) ?? 0) - (lastDispatched.get(b.targetNodeId) ?? 0)
+    || a.creationSequence - b.creationSequence
+    || compare(a.targetNodeId, b.targetNodeId)
+    || compare(a.taskId, b.taskId))[0];
+}
+
+export class DurableDelegationScheduler {
+  private readonly options: DurableDelegationSchedulerOptions;
+  private readonly active = new Map<string, ActiveExecution>();
+  private closing = false;
+  private paused = false;
+  private reason = "Scheduler stopped";
+  private runPromise?: Promise<void>;
+  private recoveryComplete = false;
+
+  constructor(options: DurableDelegationSchedulerOptions) {
+    if (!Number.isSafeInteger(options.maxParallel) || options.maxParallel < 1 || options.maxParallel > 1_024) {
+      throw new Error("Scheduler maxParallel must be an integer from 1 through 1024");
+    }
+    this.options = options;
+    const status = options.runtime.restore().schedulerStatus;
+    this.paused = status === "paused";
+    this.closing = status === "closed";
+  }
+
+  get activeCount(): number {
+    return this.active.size;
+  }
+
+  hasLiveHandles(): boolean {
+    return this.active.size > 0 || this.runPromise !== undefined;
+  }
+
+  private activeNodes(): ReadonlySet<string> {
+    return new Set([...this.active.values()].map((entry) => entry.nodeId));
+  }
+
+  private async reconcileTakeover(): Promise<void> {
+    if (this.recoveryComplete) return;
+    const hasActive = Object.values(this.options.runtime.restore().tasks).some((task) => task.queueState === "active" && task.resumedByResultSequence === undefined);
+    if (hasActive) {
+      if (!this.options.verifiedTakeover || !await this.options.verifiedTakeover()) throw new Error("Journal-active delegation tasks require verified takeover before recovery");
+      this.options.runtime.reconcileActiveAfterTakeover(true);
+    }
+    await this.options.onRecoveryReconciled?.();
+    this.recoveryComplete = true;
+  }
+
+  private failureResult(error: unknown): WorkerResultInput {
+    return {
+      status: this.closing ? "cancelled" : "failed",
+      summary: utf8Prefix(String(error instanceof Error ? error.message : error) || "Worker execution failed", DELEGATION_LIMITS.resultSummaryBytes),
+      outputRefs: [],
+      evidenceRefs: [],
+      data: {},
+    };
+  }
+
+  private launch(task: PersistedDelegationTask): void {
+    const continuingAttempt = task.queueState === "active";
+    const attemptId = continuingAttempt
+      ? task.attempts.at(-1)?.attemptId
+      : this.options.createAttemptId?.() ?? `attempt-${randomUUID()}`;
+    if (!attemptId) throw new Error("Resumed delegation task has no current attempt");
+    this.options.runtime.start(task.taskId, attemptId);
+    const startedTask = this.options.runtime.restore().tasks[task.taskId];
+    if (!startedTask) throw new Error("Started delegation task could not be restored");
+    const executionContext = this.options.runtime.workerExecutionContext(task.taskId, attemptId);
+    const controller = new AbortController();
+    const promise = this.executeAttempt(startedTask, attemptId, executionContext, controller)
+      .finally(() => { this.active.delete(task.taskId); });
+    this.active.set(task.taskId, { nodeId: task.targetNodeId, attemptId, controller, promise });
+  }
+
+  private async executeAttempt(
+    task: PersistedDelegationTask,
+    attemptId: string,
+    executionContext: DelegationExecutionContext,
+    controller: AbortController,
+  ): Promise<void> {
+    let result: SchedulerExecutionResult;
+    try {
+      await this.options.hooks?.onAttemptStarted?.(task, attemptId);
+      result = await this.options.execute(task, { signal: controller.signal, attemptId, executionContext });
+      validateExecutionResult(result);
+    } catch (error) {
+      result = this.failureResult(error);
+    }
+
+    if (controller.signal.aborted && this.closing) {
+      result = { status: "cancelled", summary: utf8Prefix(this.reason, DELEGATION_LIMITS.resultSummaryBytes), outputRefs: [], evidenceRefs: [], data: {} };
+    }
+    const currentState = this.options.runtime.restore();
+    const current = currentState.tasks[task.taskId];
+    if (!current || current.queueState === "terminal") return;
+    const pendingDependencies = current.suspendedOn?.filter((dependencyId) => currentState.tasks[dependencyId]?.resultAcceptedSequence === undefined) ?? [];
+    if (controller.signal.aborted && this.paused && !this.closing) {
+      if (pendingDependencies.length) this.options.runtime.suspend(task.taskId, [...current.suspendedOn!]);
+      else this.options.runtime.interrupt(task.taskId, this.reason);
+      return;
+    }
+    let settledResult = result;
+    if (pendingDependencies.length && !this.closing) {
+      settledResult = Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...current.suspendedOn!]) });
+      this.options.runtime.suspend(task.taskId, [...current.suspendedOn!]);
+    } else if (result.status === "suspended") {
+      this.options.runtime.suspend(task.taskId, [...result.dependencyTaskIds]);
+    } else {
+      this.options.runtime.recordResult(task.taskId, result);
+      const durable = this.options.runtime.restore().tasks[task.taskId];
+      if (durable) await this.options.onResultDurable?.(durable);
+    }
+    await this.options.hooks?.onAttemptSettled?.(task, attemptId, settledResult);
+  }
+
+  private async runLoop(): Promise<void> {
+    await this.reconcileTakeover();
+    for (;;) {
+      if (!this.closing && !this.paused) {
+        while (this.active.size < this.options.maxParallel) {
+          const task = selectNextDelegationTask(this.options.runtime, this.activeNodes());
+          if (!task) break;
+          this.launch(task);
+        }
+      }
+      if (!this.active.size) return;
+      await Promise.race([...this.active.values()].map((entry) => entry.promise));
+    }
+  }
+
+  runUntilSettled(): Promise<void> {
+    if (this.runPromise) return this.runPromise;
+    const running = this.runLoop();
+    const tracked = running.finally(() => {
+      if (this.runPromise === tracked) this.runPromise = undefined;
+    });
+    this.runPromise = tracked;
+    return tracked;
+  }
+
+  pauseAdmission(reason: string): void {
+    if (this.closing) throw new Error("Closed scheduler cannot be paused");
+    if (this.paused) return;
+    this.paused = true;
+    this.reason = utf8Prefix(reason.trim() || "Scheduler paused", DELEGATION_LIMITS.resultSummaryBytes);
+    this.options.runtime.pauseAdmission(this.reason);
+  }
+
+  closeAdmission(reason: string): void {
+    if (this.closing) return;
+    this.closing = true;
+    this.paused = true;
+    this.reason = utf8Prefix(reason.trim() || "Scheduler closed", DELEGATION_LIMITS.resultSummaryBytes);
+    this.options.runtime.closeAdmission(this.reason);
+  }
+
+  cancelPending(reason = this.reason): void {
+    this.options.runtime.cancelPending(utf8Prefix(reason.trim() || this.reason, DELEGATION_LIMITS.resultSummaryBytes));
+  }
+
+  abortOwnedWork(reason = this.reason): void {
+    this.reason = utf8Prefix(reason.trim() || this.reason, DELEGATION_LIMITS.resultSummaryBytes);
+    for (const execution of this.active.values()) execution.controller.abort(this.reason);
+  }
+
+  async waitForSettlement(timeoutMs: number): Promise<boolean> {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 0) throw new Error("Settlement timeout is invalid");
+    const pending = [...this.active.values()].map((entry) => entry.promise);
+    if (!pending.length) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        Promise.allSettled(pending).then(() => true),
+        new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  async pause(reason: string, timeoutMs = 2_000): Promise<boolean> {
+    this.pauseAdmission(reason);
+    this.abortOwnedWork(reason);
+    return this.waitForSettlement(timeoutMs);
+  }
+
+  async shutdown(reason = "Process shutdown", timeoutMs = 2_000): Promise<boolean> {
+    return this.pause(reason, timeoutMs);
+  }
+
+  resume(): void {
+    if (this.closing) throw new Error("Closed scheduler cannot resume");
+    if (!this.paused) return;
+    if (this.active.size) throw new Error("Scheduler cannot resume until paused workers settle");
+    this.options.runtime.resumeAdmission();
+    this.paused = false;
+  }
+
+  async cancel(reason: string, timeoutMs = 2_000): Promise<boolean> {
+    this.closeAdmission(reason);
+    this.cancelPending(reason);
+    this.abortOwnedWork(reason);
+    const settled = await this.waitForSettlement(timeoutMs);
+    this.cancelPending(reason);
+    return settled;
+  }
+}

--- a/src/workflows/values.ts
+++ b/src/workflows/values.ts
@@ -1,0 +1,86 @@
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+
+export function compareText(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function exactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  const extra = Object.keys(value).find((key) => !allowed.has(key));
+  const missing = required.find((key) => !(key in value));
+  if (extra) throw new Error(`${label} contains unsupported field ${extra}`);
+  if (missing) throw new Error(`${label} is missing required field ${missing}`);
+}
+
+export function boundedText(value: unknown, label: string, bytes: number): string {
+  if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > bytes) {
+    throw new Error(`${label} is empty, invalid, or exceeds its limit`);
+  }
+  return value;
+}
+
+export function boundedId(value: unknown, label: string): string {
+  return boundedText(value, label, 256);
+}
+
+export function utf8Prefix(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  let output = "";
+  let used = 0;
+  for (const character of value) {
+    const bytes = Buffer.byteLength(character, "utf8");
+    if (used + bytes > maxBytes) break;
+    output += character;
+    used += bytes;
+  }
+  return output;
+}
+
+export function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+interface JsonBounds {
+  readonly bytes: number;
+  readonly depth: number;
+  readonly nodes: number;
+  readonly rootRecord?: boolean;
+}
+
+export function boundedJson(value: unknown, label: string, bounds: JsonBounds): JsonValue {
+  if (bounds.rootRecord && !plainRecord(value)) throw new Error(`${label} must be a plain JSON object`);
+  const pending = [{ value, depth: 0 }];
+  let nodes = 0;
+  while (pending.length) {
+    const current = pending.pop()!;
+    if (++nodes > bounds.nodes || current.depth > bounds.depth) throw new Error(`${label} exceeds structural limits`);
+    const item = current.value;
+    if (item === null || typeof item === "string" || typeof item === "boolean") continue;
+    if (typeof item === "number" && Number.isFinite(item)) continue;
+    if (Array.isArray(item)) {
+      for (let index = item.length - 1; index >= 0; index--) pending.push({ value: item[index], depth: current.depth + 1 });
+      continue;
+    }
+    if (!plainRecord(item)) throw new Error(`${label} is not JSON`);
+    for (const child of Object.values(item)) pending.push({ value: child, depth: current.depth + 1 });
+  }
+  const clone = structuredClone(value) as JsonValue;
+  if (Buffer.byteLength(canonicalJson(clone), "utf8") > bounds.bytes) throw new Error(`${label} exceeds its byte limit`);
+  return clone;
+}

--- a/src/workflows/workers.ts
+++ b/src/workflows/workers.ts
@@ -1,0 +1,441 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { resolveProjectPath } from "../core/safe-path";
+import {
+  DELEGATION_LIMITS,
+  type AcceptDelegationInput,
+  type DelegationStatusPage,
+  type PersistedDelegationTask,
+  type PersistedWorkerResult,
+  type ResultDeliveryBatch,
+  type WorkerResultInput,
+} from "./delegation";
+import type { RouteDirectMembersInput, RouteRecommendation } from "./routing";
+import { NO_DLP_PROSE_LIMITATION } from "./references";
+import { deepFreeze, utf8Prefix } from "./values";
+
+export interface WorkerSessionFactoryInput {
+  readonly sessionId: string; readonly runId: string; readonly nodeId: string; readonly agentId: string;
+  readonly modelId: string; readonly thinking: string; readonly transcriptPath: string; readonly tools: readonly string[];
+}
+export interface WorkerPromptTaskContract {
+  readonly taskId: string; readonly runId: string; readonly parentNodeId: string; readonly targetNodeId: string;
+  readonly objective: string; readonly contextRefs: PersistedDelegationTask["contextRefs"];
+  readonly deliverables: readonly string[]; readonly provenance: PersistedDelegationTask["provenance"];
+  readonly creationSequence: number; readonly createdAt: string;
+  readonly deliveredResults: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[];
+}
+export interface WorkerPromptContext {
+  readonly snapshotHash: string; readonly workflowId: string; readonly nodeId: string; readonly agentId: string;
+  readonly agentPrompt: string; readonly sharedInstructions: string; readonly rootInstructions?: string;
+  readonly role?: string; readonly responsibilities: readonly string[];
+  readonly skills: readonly Readonly<Record<string, unknown>>[];
+  readonly knowledge: readonly Readonly<Record<string, unknown>>[];
+  readonly adapterContract: Readonly<Record<string, unknown>>;
+  readonly effectivePolicy: Readonly<Record<string, unknown>>;
+  readonly taskContract: WorkerPromptTaskContract;
+}
+export interface WorkerDelegationServices {
+  route(input: RouteDirectMembersInput): readonly RouteRecommendation[];
+  delegate(input: AcceptDelegationInput): Readonly<{ accepted: true; queued: true; taskId: string }>;
+  status(options?: { limit?: number; cursor?: string }): DelegationStatusPage;
+  preparedResultDelivery(): ResultDeliveryBatch | undefined;
+  prepareResultDelivery(deliveryId: string, options?: { limit?: number }): ResultDeliveryBatch;
+  acceptResultDelivery(deliveryId: string): void;
+}
+export interface WorkerPromptInvocation {
+  readonly promptContext: WorkerPromptContext;
+  readonly delegation?: WorkerDelegationServices;
+}
+export interface WorkerSessionHandle {
+  readonly linkedSessionId: string;
+  prompt(text: string, signal?: AbortSignal, invocation?: WorkerPromptInvocation): string | Promise<string>;
+  abort?(): void | Promise<void>; dispose(): void | Promise<void>;
+}
+export type WorkerSessionFactory = (input: WorkerSessionFactoryInput) => WorkerSessionHandle | Promise<WorkerSessionHandle>;
+export interface WorkerSessionPoolOptions {
+  readonly projectRoot: string; readonly sessionId: string; readonly runId: string;
+  readonly snapshot: ActivationSnapshotFileV1; readonly factory: WorkerSessionFactory; readonly resultSummaryBytes?: number;
+}
+export type WorkerExecutionResult = WorkerResultInput | Readonly<{ status: "suspended"; dependencyTaskIds: readonly string[] }>;
+
+interface WorkerExecutionConfig {
+  readonly agentId: string; readonly modelId: string; readonly thinking: string; readonly tools: readonly string[];
+}
+interface PooledSession {
+  readonly nodeId: string; readonly transcriptPath: string; readonly session: WorkerSessionHandle;
+}
+interface BoundaryRecord {
+  readonly formatVersion: 1; readonly runId: string; readonly nodeId: string; readonly taskId: string;
+  readonly kind: "start" | "result"; readonly creationSequence: number; readonly payloadHash: string;
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedId(value: string, label: string): string {
+  const unsafe = [...value].some((character) => character === "/" || character === "\\" || character.codePointAt(0)! <= 0x1f);
+  if (!value || Buffer.byteLength(value, "utf8") > 256 || unsafe) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function workerDirectory(projectRoot: string, sessionId: string, runId: string): string {
+  boundedId(sessionId, "Worker session ID");
+  boundedId(runId, "Worker run ID");
+  const resolved = resolveProjectPath(projectRoot, `.pi/hive/sessions/${sessionId}/runs/${runId}/workers`, { allowMissing: true });
+  if (!resolved) throw new Error("Worker transcript path escapes project");
+  return resolved.lexicalPath;
+}
+
+export function workerTranscriptPath(projectRoot: string, sessionId: string, runId: string, nodeId: string): string {
+  return join(workerDirectory(projectRoot, sessionId, runId), `${boundedId(nodeId, "Worker node ID")}.jsonl`);
+}
+
+function ensureTranscript(path: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  closeSync(openSync(path, constants.O_CREAT | constants.O_APPEND | constants.O_WRONLY, 0o600));
+  chmodSync(path, 0o600);
+}
+
+function boundaryHash(value: unknown): string {
+  return createHash("sha256").update("pi-hive-worker-boundary-v1\0").update(canonicalJson(value)).digest("hex");
+}
+
+function writeBoundary(base: string, task: PersistedDelegationTask, kind: "start" | "result", payload: unknown): void {
+  const directory = join(base, `${boundedId(task.targetNodeId, "Worker node ID")}.boundaries`);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const record: BoundaryRecord = {
+    formatVersion: 1,
+    runId: task.runId,
+    nodeId: task.targetNodeId,
+    taskId: task.taskId,
+    kind,
+    creationSequence: task.creationSequence,
+    payloadHash: boundaryHash(payload),
+  };
+  const content = `${canonicalJson(record)}\n`;
+  const path = join(directory, `${String(task.creationSequence).padStart(16, "0")}-${kind === "start" ? 0 : 1}-${kind}-${boundedId(task.taskId, "Worker task ID")}.json`);
+  if (existsSync(path)) {
+    if (readFileSync(path, "utf8") !== content) throw new Error("Worker boundary conflict with authoritative journal projection");
+    return;
+  }
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    writeFileSync(descriptor, content);
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporary, path);
+    const directoryDescriptor = openSync(directory, constants.O_RDONLY);
+    try { fsyncSync(directoryDescriptor); } finally { closeSync(directoryDescriptor); }
+  } finally {
+    if (descriptor !== undefined) {
+      try { closeSync(descriptor); } catch { /* best effort */ }
+    }
+    try { unlinkSync(temporary); } catch { /* published or absent */ }
+  }
+}
+
+function renderTask(task: PersistedDelegationTask, deliveredResults: WorkerPromptTaskContract["deliveredResults"]): string {
+  const references = task.contextRefs.map((entry) => entry.authorization === "authorized"
+    ? { ref: entry.ref, authorization: entry.authorization, ...(entry.resolved === undefined ? {} : { resolved: entry.resolved }) }
+    : { ref: entry.ref, authorization: entry.authorization, diagnostic: entry.diagnostic });
+  return [
+    "## Delegation task boundary",
+    `task_id: ${task.taskId}`,
+    `run_id: ${task.runId}`,
+    `node_id: ${task.targetNodeId}`,
+    "",
+    "### Objective",
+    task.objective,
+    "",
+    "### Authorized structured context",
+    canonicalJson(references),
+    "",
+    "### Deliverables",
+    ...task.deliverables.map((deliverable) => `- ${deliverable}`),
+    ...(deliveredResults.length ? ["", "### Durably delivered child results", canonicalJson(deliveredResults)] : []),
+    "",
+    `Safety limitation: ${NO_DLP_PROSE_LIMITATION}`,
+    "Return a concise bounded result. Do not attempt to finish or close the workflow run.",
+  ].join("\n");
+}
+
+function snapshotExecutionConfig(snapshot: ActivationSnapshotFileV1, nodeId: string): WorkerExecutionConfig {
+  const team = snapshot.payload.workflow.team as { nodes?: unknown } | undefined;
+  const nodes = Array.isArray(team?.nodes) ? team.nodes : [];
+  const node = nodes.find((entry) => plainRecord(entry) && entry.id === nodeId);
+  if (!plainRecord(node) || typeof node.agentId !== "string" || !node.agentId) throw new Error(`Snapshot target node ${nodeId} is missing`);
+  const authority = snapshot.payload.authority.nodes.find((entry) => entry.nodeId === nodeId);
+  const model = snapshot.payload.models.find((entry) => entry.nodeId === nodeId);
+  const agent = snapshot.payload.agents.find((entry) => entry.id === node.agentId);
+  if (!plainRecord(authority) || !model || !plainRecord(agent)) throw new Error(`Snapshot execution configuration for ${nodeId} is incomplete`);
+  if (!Array.isArray(authority.tools) || authority.tools.some((tool) => typeof tool !== "string")) throw new Error(`Snapshot tools for ${nodeId} are invalid`);
+  if (authority.tools.includes("workflow_finish")) throw new Error(`Worker snapshot tools for ${nodeId} illegally include workflow_finish`);
+  if (typeof model.modelId !== "string" || !model.modelId || typeof model.thinking !== "string" || !model.thinking) throw new Error(`Snapshot model configuration for ${nodeId} is invalid`);
+  return Object.freeze({
+    agentId: node.agentId,
+    modelId: model.modelId,
+    thinking: model.thinking,
+    tools: Object.freeze([...authority.tools]),
+  });
+}
+
+function resolvedAttachmentIds(value: unknown): readonly string[] {
+  if (!plainRecord(value) || !Array.isArray(value.resolved) || value.resolved.some((entry) => typeof entry !== "string")) return Object.freeze([]);
+  return Object.freeze([...value.resolved].sort());
+}
+
+function frozenRecord(value: Record<string, unknown>): Readonly<Record<string, unknown>> {
+  return deepFreeze(structuredClone(value));
+}
+
+export function deriveWorkerPromptContext(
+  snapshot: ActivationSnapshotFileV1,
+  task: PersistedDelegationTask,
+  deliveredResults: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[] = [],
+): WorkerPromptContext {
+  const workflow = snapshot.payload.workflow;
+  const team = plainRecord(workflow.team) ? workflow.team : undefined;
+  const nodes = Array.isArray(team?.nodes) ? team.nodes : [];
+  const node = nodes.find((entry) => plainRecord(entry) && entry.id === task.targetNodeId);
+  if (!plainRecord(node) || typeof node.agentId !== "string") throw new Error(`Snapshot prompt context for ${task.targetNodeId} is missing`);
+  const agent = snapshot.payload.agents.find((entry) => entry.id === node.agentId);
+  const authority = snapshot.payload.authority.nodes.find((entry) => entry.nodeId === task.targetNodeId);
+  if (!plainRecord(agent) || typeof agent.prompt !== "string" || !plainRecord(authority) || !plainRecord(authority.capabilities)) {
+    throw new Error(`Snapshot prompt context for ${task.targetNodeId} is incomplete`);
+  }
+  const instructions = plainRecord(workflow.instructions) ? workflow.instructions : {};
+  const skillIds = new Set(resolvedAttachmentIds(node.skills));
+  const knowledgeIds = new Set(resolvedAttachmentIds(node.knowledge));
+  const responsibilities = Array.isArray(node.responsibilities) && node.responsibilities.every((entry) => typeof entry === "string")
+    ? node.responsibilities as string[]
+    : [];
+  const skills = snapshot.payload.skills
+    .filter((entry) => typeof entry.id === "string" && skillIds.has(entry.id))
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+    .map(frozenRecord);
+  const knowledge = snapshot.payload.knowledge
+    .filter((entry) => typeof entry.id === "string" && knowledgeIds.has(entry.id))
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+    .map(frozenRecord);
+  const adapter = plainRecord(workflow.artifact) ? workflow.artifact : {};
+  const taskContract: WorkerPromptTaskContract = deepFreeze({
+    taskId: task.taskId,
+    runId: task.runId,
+    parentNodeId: task.parentNodeId,
+    targetNodeId: task.targetNodeId,
+    objective: task.objective,
+    contextRefs: structuredClone(task.contextRefs),
+    deliverables: [...task.deliverables],
+    provenance: structuredClone(task.provenance),
+    creationSequence: task.creationSequence,
+    createdAt: task.createdAt,
+    deliveredResults: structuredClone(deliveredResults),
+  });
+  return deepFreeze({
+    snapshotHash: snapshot.snapshotHash,
+    workflowId: typeof workflow.id === "string" ? workflow.id : "",
+    nodeId: task.targetNodeId,
+    agentId: node.agentId,
+    agentPrompt: agent.prompt,
+    sharedInstructions: typeof instructions.shared === "string" ? instructions.shared : "",
+    ...(task.targetNodeId === team?.rootId && typeof instructions.root === "string" ? { rootInstructions: instructions.root } : {}),
+    ...(typeof node.role === "string" ? { role: node.role } : {}),
+    responsibilities: [...responsibilities],
+    skills,
+    knowledge,
+    adapterContract: frozenRecord(adapter),
+    effectivePolicy: frozenRecord(authority.capabilities),
+    taskContract,
+  });
+}
+
+export class WorkerSessionPool {
+  private readonly options: WorkerSessionPoolOptions;
+  private readonly sessions = new Map<string, PooledSession>();
+  private readonly opening = new Map<string, Promise<PooledSession>>();
+  private readonly activeExecutions = new Set<Promise<WorkerExecutionResult>>();
+  private closed = false;
+  private closing?: Promise<void>;
+
+  constructor(options: WorkerSessionPoolOptions) {
+    boundedId(options.sessionId, "Worker session ID");
+    boundedId(options.runId, "Worker run ID");
+    if (options.resultSummaryBytes !== undefined && (!Number.isSafeInteger(options.resultSummaryBytes) || options.resultSummaryBytes < 1 || options.resultSummaryBytes > DELEGATION_LIMITS.resultSummaryBytes)) {
+      throw new Error("Worker result bound invalid");
+    }
+    this.options = options;
+  }
+
+  get activeSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  get activeExecutionCount(): number {
+    return this.activeExecutions.size;
+  }
+
+  hasLiveHandles(): boolean {
+    return this.sessions.size > 0 || this.opening.size > 0 || this.activeExecutions.size > 0 || this.closing !== undefined;
+  }
+
+  private async get(task: PersistedDelegationTask): Promise<PooledSession> {
+    if (this.closed) throw new Error("Worker session pool is closed");
+    if (task.runId !== this.options.runId) throw new Error("Worker task belongs to another run");
+    const existing = this.sessions.get(task.targetNodeId);
+    if (existing) return existing;
+    const pending = this.opening.get(task.targetNodeId);
+    if (pending) return pending;
+    const opening = (async (): Promise<PooledSession> => {
+      const transcriptPath = workerTranscriptPath(this.options.projectRoot, this.options.sessionId, this.options.runId, task.targetNodeId);
+      ensureTranscript(transcriptPath);
+      const config = snapshotExecutionConfig(this.options.snapshot, task.targetNodeId);
+      const session = await this.options.factory({
+        sessionId: this.options.sessionId,
+        runId: this.options.runId,
+        nodeId: task.targetNodeId,
+        agentId: config.agentId,
+        modelId: config.modelId,
+        thinking: config.thinking,
+        transcriptPath,
+        tools: config.tools,
+      });
+      if (!session?.linkedSessionId || typeof session.prompt !== "function" || typeof session.dispose !== "function") throw new Error("Invalid linked worker session");
+      if (this.closed) {
+        try { await session.abort?.(); } finally { await session.dispose(); }
+        throw new Error("Worker pool closed during creation");
+      }
+      const pooled = { nodeId: task.targetNodeId, transcriptPath, session };
+      this.sessions.set(task.targetNodeId, pooled);
+      return pooled;
+    })().finally(() => { this.opening.delete(task.targetNodeId); });
+    this.opening.set(task.targetNodeId, opening);
+    return opening;
+  }
+
+  execute(
+    task: PersistedDelegationTask,
+    signal?: AbortSignal,
+    services?: WorkerDelegationServices,
+    deliveredResults: WorkerPromptTaskContract["deliveredResults"] = [],
+  ): Promise<WorkerExecutionResult> {
+    const delegatedTaskIds: string[] = [];
+    const delegation = services ? Object.freeze({
+      route: (input: RouteDirectMembersInput) => services.route(input),
+      delegate: (input: AcceptDelegationInput) => {
+        const accepted = services.delegate(input);
+        delegatedTaskIds.push(accepted.taskId);
+        return accepted;
+      },
+      status: (options: { limit?: number; cursor?: string } = {}) => services.status(options),
+      preparedResultDelivery: () => services.preparedResultDelivery(),
+      prepareResultDelivery: (deliveryId: string, options: { limit?: number } = {}) => services.prepareResultDelivery(deliveryId, options),
+      acceptResultDelivery: (deliveryId: string) => services.acceptResultDelivery(deliveryId),
+    }) satisfies WorkerDelegationServices : undefined;
+    const promptContext = deriveWorkerPromptContext(this.options.snapshot, task, deliveredResults);
+    const invocation: WorkerPromptInvocation = Object.freeze({ promptContext, ...(delegation ? { delegation } : {}) });
+    const execution = (async (): Promise<WorkerExecutionResult> => {
+      try {
+        const pooled = await this.get(task);
+        if (signal?.aborted) throw new Error("Worker task cancelled before model execution");
+        const output = await pooled.session.prompt(renderTask(task, deliveredResults), signal, invocation);
+        if (delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+          return Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...new Set(delegatedTaskIds)]) });
+        }
+        return {
+          status: signal?.aborted || this.closed ? "cancelled" : "completed",
+          summary: utf8Prefix(String(output || "[no worker output]"), this.options.resultSummaryBytes ?? DELEGATION_LIMITS.resultSummaryBytes),
+          outputRefs: [],
+          evidenceRefs: [],
+          data: { linkedSessionId: pooled.session.linkedSessionId },
+        };
+      } catch (error) {
+        if (delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+          return Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...new Set(delegatedTaskIds)]) });
+        }
+        return {
+          status: signal?.aborted || this.closed ? "cancelled" : "failed",
+          summary: utf8Prefix(String(error instanceof Error ? error.message : error), this.options.resultSummaryBytes ?? DELEGATION_LIMITS.resultSummaryBytes),
+          outputRefs: [],
+          evidenceRefs: [],
+          data: {},
+        };
+      }
+    })();
+    this.activeExecutions.add(execution);
+    void execution.then(
+      () => { this.activeExecutions.delete(execution); },
+      () => { this.activeExecutions.delete(execution); },
+    );
+    return execution;
+  }
+
+  rebuildBoundaries(tasks: readonly PersistedDelegationTask[]): void {
+    const base = workerDirectory(this.options.projectRoot, this.options.sessionId, this.options.runId);
+    const ordered = [...tasks]
+      .filter((task) => task.runId === this.options.runId)
+      .sort((a, b) => a.creationSequence - b.creationSequence || (a.taskId < b.taskId ? -1 : a.taskId > b.taskId ? 1 : 0));
+    for (const task of ordered) {
+      if (task.attempts.length) {
+        writeBoundary(base, task, "start", {
+          objective: task.objective,
+          contextRefs: task.contextRefs,
+          deliverables: task.deliverables,
+          provenance: task.provenance,
+        });
+      }
+      if (task.result) writeBoundary(base, task, "result", task.result);
+    }
+  }
+
+  async closeSessions(): Promise<void> {
+    if (this.closing) return this.closing;
+    if (this.closed && !this.sessions.size) return;
+    this.closed = true;
+    const sessions = [...this.sessions.values()];
+    this.sessions.clear();
+    const closing = Promise.allSettled(sessions.map(async ({ session }) => {
+      try { await session.abort?.(); } finally { await session.dispose(); }
+    })).then(() => undefined);
+    this.closing = closing;
+    try {
+      await closing;
+    } finally {
+      if (this.closing === closing) this.closing = undefined;
+    }
+  }
+
+  async waitForSettlement(timeoutMs: number): Promise<boolean> {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 0) throw new Error("Worker settlement timeout is invalid");
+    const pending = [...this.activeExecutions, ...this.opening.values()];
+    if (!pending.length) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        Promise.allSettled(pending).then(() => true),
+        new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/tests/workflows/workflow-delegation.test.ts
+++ b/tests/workflows/workflow-delegation.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import {
+  DELEGATION_LIMITS,
+  DelegationRuntime,
+  createDelegationState,
+  reduceDelegationState,
+  type DelegationContextReference,
+} from "../../src/workflows/delegation.ts";
+import { createWorkflowEvent, sealWorkflowEvent } from "../../src/workflows/events.ts";
+import { authorizeReferences, type ReferenceAuthorizationDecision } from "../../src/workflows/references.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { replayWorkflowJournal } from "../../src/workflows/replay.ts";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  return {
+    snapshotHash: "a".repeat(64),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    payload: {
+      project: { projectId: "project-1", rootRef: "." },
+      workflow: {
+        id: "delivery",
+        team: {
+          rootId: "root",
+          nodes: [
+            { id: "root", agentId: "lead", memberIds: ["api", "web"], depth: 1, responsibilities: [], skills: {}, knowledge: {}, budgets: {} },
+            { id: "api", agentId: "builder", parentId: "root", memberIds: ["db"], depth: 2, responsibilities: [], skills: {}, knowledge: {}, budgets: {} },
+            { id: "web", agentId: "builder", parentId: "root", memberIds: [], depth: 2, responsibilities: [], skills: {}, knowledge: {}, budgets: {} },
+            { id: "db", agentId: "database", parentId: "api", memberIds: [], depth: 3, responsibilities: [], skills: {}, knowledge: {}, budgets: {} },
+          ],
+        },
+      },
+      authority: { capabilityContractVersion: 1, nodes: [] },
+      agents: [], skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+    },
+  } as ActivationSnapshotFileV1;
+}
+
+function fixture(authorize?: (ref: DelegationContextReference, nodeId: string) => ReferenceAuthorizationDecision, runId = "run-1") {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-delegation-"));
+  let id = 0;
+  const runtime = new DelegationRuntime({
+    projectRoot,
+    projectId: "project-1",
+    sessionId: "session-1",
+    runId,
+    snapshot: snapshot(),
+    createTaskId: () => `task-${++id}`,
+    now: () => "2026-01-01T00:00:00.000Z",
+    referenceAuthorizer: authorize ? { authorize } : undefined,
+  });
+  return { projectRoot, runtime, root: runtime.rootExecutionContext() };
+}
+
+function startWorker(runtime: DelegationRuntime, taskId: string, attemptId = `attempt-${taskId}`) {
+  runtime.start(taskId, attemptId);
+  return runtime.workerExecutionContext(taskId, attemptId);
+}
+
+test("delegation derives caller identity and allows only direct members", () => {
+  const { runtime, root } = fixture();
+  const parent = runtime.accept(root, { targetNodeId: "api", objective: "Build API", deliverables: ["patch"] });
+  const api = startWorker(runtime, parent.taskId);
+  assert.throws(() => runtime.accept(api, { targetNodeId: "web", objective: "Cross team", deliverables: [] }), /direct member/i);
+  assert.throws(() => runtime.accept(root, { targetNodeId: "db", objective: "Skip lead", deliverables: [] }), /direct member/i);
+  assert.throws(() => runtime.accept(root, { targetNodeId: "missing", objective: "Unknown", deliverables: [] }), /unknown|direct member/i);
+  assert.equal(runtime.accept(api, { targetNodeId: "db", objective: "Schema", deliverables: [] }).taskId, "task-2");
+
+  const fake = { nodeId: "root", taskId: undefined } as never;
+  assert.throws(() => runtime.accept(fake, { targetNodeId: "web", objective: "spoof", deliverables: [] }), /trusted execution context/i);
+  runtime.suspend(parent.taskId, ["task-2"]);
+  assert.throws(() => runtime.accept(api, { targetNodeId: "db", objective: "late recursive work", deliverables: [] }), /active worker task|current|active matching/i);
+  assert.throws(() => runtime.status(api), /active|current|trusted/i);
+  assert.throws(() => runtime.preparedResultDelivery(api), /active|current|trusted/i);
+});
+
+test("trusted worker contexts are revoked after terminal result publication", () => {
+  const { runtime, root } = fixture();
+  const accepted = runtime.accept(root, { targetNodeId: "api", objective: "terminal context", deliverables: [] });
+  const api = startWorker(runtime, accepted.taskId);
+  runtime.recordResult(accepted.taskId, { status: "completed", summary: "done" });
+  assert.throws(() => runtime.status(api), /active matching|current/i);
+  assert.throws(() => runtime.prepareResultDelivery(api, "stale-delivery"), /active matching|current/i);
+});
+
+test("delegation provenance and parent task identity are derived from trusted context", () => {
+  const { runtime, root } = fixture();
+  assert.throws(() => runtime.accept(root, {
+    targetNodeId: "api", objective: "forged runtime", deliverables: [],
+    provenance: { source: "runtime", parentTaskId: "forged" } as never,
+  }), /provenance|unsupported|forg/i);
+  const parent = runtime.accept(root, { targetNodeId: "api", objective: "parent", deliverables: [] });
+  const api = startWorker(runtime, parent.taskId);
+  const child = runtime.accept(api, {
+    targetNodeId: "db", objective: "child", deliverables: [], provenance: { correlationId: "tool-call-1" },
+  });
+  assert.deepEqual(runtime.restore().tasks[child.taskId].provenance, {
+    source: "delegate_agent", correlationId: "tool-call-1", parentTaskId: parent.taskId,
+  });
+});
+
+test("acceptance and authorized context are durable, bounded, opaque on denial, and non-blocking", () => {
+  const calls: string[] = [];
+  const { projectRoot, runtime, root } = fixture((ref, nodeId) => {
+    calls.push(`${nodeId}:${ref.kind}:${ref.id}`);
+    if (ref.id === "secret") return { authorized: false, diagnostic: "recipient lacks attachment" };
+    return { authorized: true, resolved: { excerpt: "bounded content" } };
+  });
+  const accepted = runtime.accept(root, {
+    targetNodeId: "api",
+    objective: "Inspect references without copying the parent transcript",
+    contextRefs: [{ kind: "artifact", id: "change-1" }, { kind: "knowledge", id: "secret" }],
+    deliverables: ["findings"],
+    provenance: { correlationId: "call-1" },
+  });
+  assert.deepEqual(accepted, { accepted: true, queued: true, taskId: "task-1" });
+  assert.deepEqual(calls, ["api:artifact:change-1", "api:knowledge:secret"]);
+  const task = runtime.restore().tasks[accepted.taskId];
+  assert.equal(task.creationSequence, 1);
+  assert.equal(task.queueState, "queued");
+  assert.deepEqual(task.contextRefs.map((entry) => entry.authorization), ["authorized", "denied"]);
+  const denied = task.contextRefs[1];
+  assert.equal(denied.authorization, "denied");
+  if (denied.authorization === "denied") assert.equal(denied.diagnostic, "recipient lacks attachment");
+  assert.equal("parentTranscript" in task, false);
+  assert.equal(readWorkflowJournal(projectRoot, "session-1").at(-1)?.type, "task.accepted");
+
+  const replayed = replayWorkflowJournal(
+    readWorkflowJournal(projectRoot, "session-1"),
+    createDelegationState("session-1", "run-1", snapshot()),
+    reduceDelegationState,
+  ).state;
+  assert.deepEqual(replayed.tasks, runtime.restore().tasks);
+  assert.throws(() => runtime.accept(root, {
+    targetNodeId: "api", objective: "x".repeat(DELEGATION_LIMITS.objectiveBytes + 1), deliverables: [],
+  }), /objective.*limit|objective.*large/i);
+});
+
+test("results are reauthorized for the parent and use durable prepared/accepted delivery", () => {
+  const calls: string[] = [];
+  const { projectRoot, runtime, root } = fixture((ref, nodeId) => {
+    calls.push(`${nodeId}:${ref.id}`);
+    return ref.id === "secret-output"
+      ? { authorized: false, diagnostic: "sensitive backend detail" }
+      : { authorized: true, resolved: { safe: ref.id } };
+  });
+  const parent = runtime.accept(root, { targetNodeId: "api", objective: "Coordinate schema", deliverables: ["result"] });
+  const api = startWorker(runtime, parent.taskId, "attempt-parent");
+  const child = runtime.accept(api, { targetNodeId: "db", objective: "Inspect DB", deliverables: ["report"] });
+  runtime.suspend(parent.taskId, [child.taskId]);
+  startWorker(runtime, child.taskId, "attempt-child");
+  runtime.recordResult(child.taskId, {
+    status: "completed",
+    summary: "Schema inspected",
+    outputRefs: [{ kind: "file", id: "schema.sql" }, { kind: "file", id: "secret-output" }],
+    evidenceRefs: [{ kind: "tool-result", id: "verify-1" }],
+    data: { rows: 4 },
+  });
+
+  let restored = runtime.restore();
+  assert.equal(restored.tasks[child.taskId].queueState, "terminal");
+  assert.equal(restored.tasks[parent.taskId].queueState, "suspended", "parent must not resume before durable delivery acceptance");
+  assert.deepEqual(restored.tasks[child.taskId].result?.outputRefs.map((ref) => ref.authorization), ["authorized", "denied"]);
+  assert.deepEqual(calls.slice(-3), ["api:schema.sql", "api:secret-output", "api:verify-1"]);
+
+  const prepared = runtime.prepareResultDeliveryForSuspendedTask(parent.taskId, "delivery-child-1", { limit: 10 });
+  assert.equal(prepared.items[0].taskId, child.taskId);
+  assert.equal(readWorkflowJournal(projectRoot, "session-1").at(-1)?.type, "task.result.delivery.prepared");
+
+  const restarted = new DelegationRuntime(runtime.options);
+  assert.equal(restarted.restore().deliveries["delivery-child-1"].acceptedSequence, undefined, "a crash before provider acceptance must redeliver the prepared result");
+  assert.equal(restarted.restore().tasks[parent.taskId].queueState, "suspended");
+  restarted.deliverPendingResultsToSuspendedTask(parent.taskId, "delivery-child-1");
+  restored = restarted.restore();
+  assert.equal(restored.tasks[child.taskId].resultAcceptedSequence! > restored.tasks[child.taskId].result!.recordedSequence, true);
+  assert.equal(restored.tasks[parent.taskId].queueState, "active", "parent resumes the same attempt only after durable result acceptance");
+  assert.equal(readWorkflowJournal(projectRoot, "session-1").at(-1)?.type, "task.result.delivery.accepted");
+});
+
+test("delegation replay ignores other runs in the same session", () => {
+  const { projectRoot, runtime, root } = fixture(undefined, "run-1");
+  runtime.accept(root, { targetNodeId: "api", objective: "first run", deliverables: [] });
+  const second = new DelegationRuntime({ ...runtime.options, runId: "run-2", createTaskId: () => "run-2-task" });
+  const secondRoot = second.rootExecutionContext();
+  second.accept(secondRoot, { targetNodeId: "web", objective: "second run", deliverables: [] });
+  assert.deepEqual(Object.keys(second.restore().tasks), ["run-2-task"]);
+  assert.deepEqual(Object.keys(runtime.restore().tasks), ["task-1"]);
+  assert.deepEqual(readWorkflowJournal(projectRoot, "session-1").filter((event) => event.type === "task.accepted").map((event) => event.runId), ["run-1", "run-2"]);
+});
+
+test("delegation reducer validates exact versioned payloads", () => {
+  const zero = createDelegationState("session-1", "run-1", snapshot());
+  const malformed = sealWorkflowEvent(createWorkflowEvent({
+    eventId: "event-1", projectId: "project-1", sessionId: "session-1", runId: "run-1",
+    type: "task.accepted", producer: "runtime", timestamp: "2026-01-01T00:00:00.000Z",
+    payload: { formatVersion: 2, taskId: "task-1", parentNodeId: "root", targetNodeId: "api", objective: "x", contextRefs: [], deliverables: [], provenance: { source: "runtime" }, extra: true },
+  }), 1, null);
+  assert.throws(() => reduceDelegationState(zero, malformed), /format version|unsupported field/i);
+});
+
+test("result events must match the journal-active attempt", () => {
+  const { runtime, root } = fixture();
+  const accepted = runtime.accept(root, { targetNodeId: "api", objective: "attempt bound", deliverables: [] });
+  runtime.start(accepted.taskId, "actual-attempt");
+  const mismatched = sealWorkflowEvent(createWorkflowEvent({
+    eventId: "event-result", projectId: "project-1", sessionId: "session-1", runId: "run-1",
+    type: "task.result.recorded", producer: "harness", timestamp: "2026-01-01T00:00:01.000Z",
+    payload: { formatVersion: 1, taskId: accepted.taskId, result: { status: "completed", summary: "wrong", outputRefs: [], evidenceRefs: [], data: {}, attemptId: "forged-attempt" } },
+  }), 999, null);
+  assert.throws(() => reduceDelegationState(runtime.restore(), mismatched), /attempt/i);
+});
+
+test("delegation replay reapplies resolved reference item and aggregate JSON bounds", () => {
+  const zero = createDelegationState("session-1", "run-1", snapshot());
+  const acceptedEvent = (contextRefs: unknown[]) => sealWorkflowEvent(createWorkflowEvent({
+    eventId: `event-${contextRefs.length}-${JSON.stringify(contextRefs).length}`,
+    projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "task.accepted", producer: "runtime",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    payload: { formatVersion: 1, taskId: "task-replay", parentNodeId: "root", targetNodeId: "api", objective: "replay", contextRefs: contextRefs as never, deliverables: [], provenance: { source: "delegate_agent" } },
+  }), 1, null);
+  const ref = (id: string, resolved: unknown) => ({ ref: { kind: "artifact", id }, authorization: "authorized", resolved });
+  let deep: unknown = "value";
+  for (let index = 0; index < 18; index++) deep = { child: deep };
+  assert.throws(() => reduceDelegationState(zero, acceptedEvent([ref("deep", deep)])), /structural|limit|bound/i);
+  assert.throws(() => reduceDelegationState(zero, acceptedEvent([ref("wide", Array.from({ length: 4_100 }, () => 1))])), /structural|limit|bound/i);
+  assert.throws(() => reduceDelegationState(zero, acceptedEvent([ref("large", "x".repeat(65_537))])), /byte|limit|bound/i);
+  assert.throws(() => reduceDelegationState(zero, acceptedEvent([
+    ref("one", "x".repeat(45_000)), ref("two", "x".repeat(45_000)), ref("three", "x".repeat(45_000)),
+  ])), /aggregate|limit|bound/i);
+});
+
+test("reference authorization applies iterative node/depth and UTF-8 diagnostic bounds", () => {
+  const tooWide = Array.from({ length: 5_000 }, (_, index) => index);
+  assert.deepEqual(authorizeReferences([{ kind: "artifact", id: "wide" }], "api", {
+    authorize: () => ({ authorized: true, resolved: tooWide }),
+  }).map((entry) => entry.authorization), ["denied"]);
+
+  const denied = authorizeReferences([{ kind: "artifact", id: "secret" }], "api", {
+    authorize: () => { throw new Error("🙂".repeat(2_000)); },
+  })[0];
+  assert.equal(denied.authorization, "denied");
+  if (denied.authorization === "denied") {
+    assert.ok(Buffer.byteLength(denied.diagnostic, "utf8") <= 2_048);
+    assert.equal(denied.diagnostic.includes("�"), false);
+  }
+});
+
+test("reference authorization fails closed for unavailable, malformed, and aggregate-bound edge cases", () => {
+  const reference = { kind: "artifact", id: "change-1" };
+  assert.deepEqual(authorizeReferences([reference], "api"), [{
+    ref: reference,
+    authorization: "denied",
+    diagnostic: "No reference authorization service is available",
+  }]);
+
+  const thrown = authorizeReferences([reference], "api", {
+    authorize: () => { throw "provider offline"; },
+  })[0];
+  assert.equal(thrown.authorization, "denied");
+  if (thrown.authorization === "denied") assert.match(thrown.diagnostic, /provider offline/);
+
+  const defaultDenial = authorizeReferences([reference], "api", {
+    authorize: () => ({ authorized: false, diagnostic: "   " }),
+  })[0];
+  assert.equal(defaultDenial.authorization, "denied");
+  if (defaultDenial.authorization === "denied") assert.equal(defaultDenial.diagnostic, "Recipient is not authorized for this reference");
+
+  const unresolved = authorizeReferences([reference], "api", {
+    authorize: () => ({ authorized: true }),
+  })[0];
+  assert.deepEqual(unresolved, { ref: reference, authorization: "authorized" });
+
+  assert.throws(() => authorizeReferences({} as never, "api"), /reference limit/i);
+  assert.throws(() => authorizeReferences(Array.from({ length: 129 }, () => reference), "api"), /reference limit/i);
+  assert.throws(() => authorizeReferences([{ ...reference, extra: true }] as never, "api"), /closed shape/i);
+
+  const aggregate = authorizeReferences([
+    { kind: "artifact", id: "one" },
+    { kind: "artifact", id: "two" },
+    { kind: "artifact", id: "three" },
+  ], "api", {
+    authorize: () => ({ authorized: true, resolved: "x".repeat(45_000) }),
+  });
+  assert.deepEqual(aggregate.map((entry) => entry.authorization), ["authorized", "authorized", "denied"]);
+});
+
+test("status is identity-scoped, summarized, and cursor paginated", () => {
+  const { runtime, root } = fixture();
+  for (let index = 0; index < 4; index++) runtime.accept(root, { targetNodeId: index % 2 ? "web" : "api", objective: `task ${index}`, deliverables: [] });
+  const first = runtime.status(root, { limit: 2 });
+  assert.equal(first.items.length, 2);
+  assert.equal(first.summary.queued, 4);
+  assert.ok(first.nextCursor);
+  const second = runtime.status(root, { limit: 2, cursor: first.nextCursor });
+  assert.deepEqual([...first.items, ...second.items].map((task) => task.taskId), ["task-1", "task-2", "task-3", "task-4"]);
+  assert.throws(() => runtime.status({ nodeId: "root" } as never, { limit: 1 }), /trusted execution context/i);
+});

--- a/tests/workflows/workflow-orchestration.test.ts
+++ b/tests/workflows/workflow-orchestration.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { DelegationRuntime } from "../../src/workflows/delegation.ts";
+import { RunOrchestrationService, type RunOrchestrationServiceOptions } from "../../src/workflows/orchestration.ts";
+import { acquireRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import type { WorkerSessionFactory } from "../../src/workflows/workers.ts";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  return { snapshotHash: "e".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." },
+    workflow: { id: "delivery", team: { rootId: "root", nodes: [
+      { id: "root", agentId: "lead", memberIds: ["worker"], depth: 1, responsibilities: [] },
+      { id: "worker", agentId: "builder", parentId: "root", memberIds: ["leaf"], depth: 2, role: "API builder", responsibilities: ["implementation"] },
+      { id: "leaf", agentId: "database", parentId: "worker", memberIds: [], depth: 3, role: "Database reviewer", responsibilities: ["schema review"] },
+    ] } },
+    authority: { capabilityContractVersion: 1, nodes: [
+      { nodeId: "root", capabilities: { effective: { shell: [] } }, tools: ["delegate_agent", "route_agent", "workflow_finish"], model: "root-model", thinking: "medium" },
+      { nodeId: "worker", capabilities: { effective: { shell: ["inspect"] } }, tools: ["delegate_agent", "route_agent", "read"], model: "worker-model", thinking: "low" },
+      { nodeId: "leaf", capabilities: { effective: { shell: ["inspect"] } }, tools: ["read"], model: "leaf-model", thinking: "low" },
+    ] },
+    agents: [
+      { id: "lead", name: "Lead", tags: [], prompt: "lead" },
+      { id: "builder", name: "Builder", tags: ["implementation"], prompt: "build" },
+      { id: "database", name: "Database", tags: ["schema"], prompt: "review schema" },
+    ],
+    skills: [], knowledge: [], models: [
+      { nodeId: "root", modelId: "root-model", thinking: "medium", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+      { nodeId: "worker", modelId: "worker-model", thinking: "low", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+      { nodeId: "leaf", modelId: "leaf-model", thinking: "low", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+    ], sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function fixture(factoryOverride?: WorkerSessionFactory, overrides: Partial<RunOrchestrationServiceOptions> = {}) {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-orchestration-"));
+  const ownerNonce = "owner-1";
+  const ownership = acquireRuntimeOwnership(projectRoot, "session-1", { nonce: ownerNonce });
+  assert.equal(ownership.ok, true);
+  let run = 0;
+  let task = 0;
+  let attempt = 0;
+  const factory: WorkerSessionFactory = async (input) => ({
+    linkedSessionId: `linked-${input.runId}-${input.nodeId}`,
+    async prompt(text) { return `durable result:${text.includes("Objective")}`; },
+    async abort() {},
+    dispose() {},
+  });
+  const options: RunOrchestrationServiceOptions = {
+    projectRoot, projectId: "project-1", sessionId: "session-1", snapshot: snapshot(), runtimeOwnerNonce: ownerNonce,
+    maxParallel: 1, workerFactory: factoryOverride ?? factory,
+    createRunId: () => `run-${++run}`, createTaskId: () => `task-${++task}`, createAttemptId: () => `attempt-${++attempt}`,
+    pauseAuthority: { captureState: () => ({ digest: "pause" }), releaseLeases: () => {}, releaseOwnership: () => {} },
+    resumeAuthority: { acquireOwnership: () => {}, acquireLeases: () => {}, revalidateHashes: () => true, rollbackAuthority: () => {} },
+    cancellationAuthority: { terminateProcessTrees: () => {}, capturePartialState: () => ({}), releaseLeases: () => {} },
+    ...overrides,
+  };
+  const service = new RunOrchestrationService(options);
+  return { projectRoot, service, options };
+}
+
+function deliverInitial(service: RunOrchestrationService, inputId: string) {
+  const recorded = service.lifecycle.recordUserInput({ inputId, text: inputId, source: "interactive" });
+  const delivery = service.lifecycle.prepareInputDelivery(`input-delivery-${inputId}`);
+  service.lifecycle.confirmInputDelivery(delivery.requestId);
+  return recorded.runId;
+}
+
+test("run orchestration integrates descendants, route/delegate, durable delivery, and sequential runs", async () => {
+  const { service } = fixture();
+  const run1 = deliverInitial(service, "first");
+  assert.equal(run1, "run-1");
+  const root = service.rootServices();
+  assert.equal(root.route({ objective: "API implementation", includeUnmatched: true })[0].nodeId, "worker");
+  const delegated = root.delegate({ targetNodeId: "worker", objective: "Implement API", deliverables: ["patch"] });
+
+  const blocked = await service.lifecycle.finish({ status: "completed", summary: "too early" }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(blocked.ok, false);
+  if (!blocked.ok) assert.match(blocked.issues.join(" "), /descendants/i);
+
+  await service.runWorkers();
+  const stillBlocked = await service.lifecycle.finish({ status: "completed", summary: "not delivered" }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(stillBlocked.ok, false);
+  const prepared = root.prepareResultDelivery("root-result-delivery");
+  assert.equal(prepared.items[0].taskId, delegated.taskId);
+  root.acceptResultDelivery(prepared.deliveryId);
+  const finished = await service.lifecycle.finish({ status: "completed", summary: "run one complete" }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(finished.ok, true);
+  assert.equal(service.hasLiveHandles(), false, "terminal finish must dispose worker sessions immediately");
+  assert.equal(service.delegationState().schedulerStatus, "closed");
+  assert.throws(() => root.route({ objective: "post-terminal routing", includeUnmatched: true }), /terminal|closed|stale|current run/i);
+  assert.throws(() => root.delegate({ targetNodeId: "worker", objective: "post-terminal", deliverables: [] }), /terminal|closed|stale|current run/i);
+  assert.throws(() => root.status(), /terminal|closed|stale|current run/i);
+
+  const run2 = deliverInitial(service, "second");
+  assert.equal(run2, "run-2");
+  const secondRoot = service.rootServices();
+  assert.throws(() => root.delegate({ targetNodeId: "worker", objective: "stale run spoof", deliverables: [] }), /current run|stale/i);
+  secondRoot.delegate({ targetNodeId: "worker", objective: "Second run task", deliverables: [] });
+  await service.runWorkers();
+  const secondPrepared = secondRoot.prepareResultDelivery("run-2-results");
+  secondRoot.acceptResultDelivery(secondPrepared.deliveryId);
+  assert.equal(service.delegationState().runId, "run-2");
+  assert.deepEqual(Object.values(service.delegationState().tasks).map((task) => task.runId), ["run-2"]);
+  await service.shutdown("session shutdown");
+  assert.equal(service.hasLiveHandles(), false);
+});
+
+test("maxParallel one recursively delegates through worker tool context and resumes the same attempt after durable delivery", async () => {
+  const executionOrder: string[] = [];
+  let parentPrompts = 0;
+  let deliveredChildResult = false;
+  const factory: WorkerSessionFactory = async (input) => ({
+    linkedSessionId: `linked-${input.nodeId}`,
+    async prompt(text, _signal, invocation) {
+      executionOrder.push(input.nodeId);
+      assert.ok(invocation, "worker prompt invocation context is required");
+      if (input.nodeId === "leaf") return "leaf durable result";
+      if (parentPrompts++ === 0) {
+        const delegation = invocation.delegation;
+        assert.ok(delegation, "worker delegation context is required");
+        const recommendation = delegation.route({ objective: "schema review", includeUnmatched: true });
+        assert.equal(recommendation[0].nodeId, "leaf");
+        delegation.delegate({ targetNodeId: "leaf", objective: "Review schema", deliverables: ["findings"] });
+        return "yield after recursive delegation";
+      }
+      deliveredChildResult = text.includes("leaf durable result");
+      return "parent synthesis";
+    },
+    dispose() {},
+  });
+  const { service } = fixture(factory);
+  deliverInitial(service, "nested");
+  const parentId = service.rootServices().delegate({ targetNodeId: "worker", objective: "Coordinate review", deliverables: ["synthesis"] }).taskId;
+
+  await service.runWorkers();
+
+  const state = service.delegationState();
+  const parent = state.tasks[parentId];
+  const child = Object.values(state.tasks).find((task) => task.provenance.parentTaskId === parentId);
+  assert.ok(child);
+  assert.deepEqual(executionOrder, ["worker", "leaf", "worker"]);
+  assert.equal(deliveredChildResult, true);
+  assert.equal(parent.attempts.length, 1, "recursive continuation must preserve the parent attempt");
+  assert.equal(parent.result?.status, "completed");
+  assert.equal(child.resultAcceptedSequence !== undefined, true);
+});
+
+test("terminal preparation crash restores fail-closed admission and cancels a raced queued descendant before commit", async () => {
+  let injected = false;
+  const { service, options } = fixture(undefined, {
+    journalFault: (eventType, stage) => {
+      if (!injected && eventType === "run.terminal.prepared" && stage === "afterRename") {
+        injected = true;
+        throw new Error("simulated crash after terminal preparation publication");
+      }
+    },
+  });
+  const runId = deliverInitial(service, "terminal-crash");
+  const root = service.rootServices();
+
+  const interrupted = await service.lifecycle.finish(
+    { status: "completed", summary: "terminal crash replay" },
+    { callerNodeId: "root", toolBatch: ["workflow_finish"] },
+  );
+  assert.equal(interrupted.ok, false);
+  assert.equal(service.lifecycle.restore().latestRun?.pendingTerminal !== undefined, true);
+
+  const racer = new DelegationRuntime({
+    projectRoot: options.projectRoot,
+    projectId: options.projectId,
+    sessionId: options.sessionId,
+    runId,
+    snapshot: options.snapshot,
+    createTaskId: () => "raced-task",
+  });
+  racer.accept(racer.rootExecutionContext(), { targetNodeId: "worker", objective: "raced after terminal preparation", deliverables: [] });
+  assert.equal(racer.restore().tasks["raced-task"].queueState, "queued");
+  assert.throws(() => root.delegate({ targetNodeId: "worker", objective: "rejected after terminal preparation", deliverables: [] }), /terminal|finalizing|closed/i);
+  assert.equal(racer.restore().admissionOpen, false, "cached root services must immediately close durable admission");
+  assert.equal(racer.restore().tasks["raced-task"].result?.status, "cancelled");
+
+  const restarted = new RunOrchestrationService({ ...options, journalFault: undefined });
+  const restored = restarted.delegationState();
+  assert.equal(restored.admissionOpen, false, "pending terminal restore must durably fail closed");
+  assert.equal(restored.schedulerStatus, "closed");
+  assert.equal(restored.tasks["raced-task"].result?.status, "cancelled", "raced queued work must settle before terminal commit");
+  assert.throws(() => restarted.rootServices(), /terminal|finalizing|closed|current open/i);
+
+  const replayed = await restarted.lifecycle.finish(
+    { status: "completed", summary: "terminal crash replay" },
+    { callerNodeId: "root", toolBatch: ["workflow_finish"] },
+  );
+  assert.equal(replayed.ok, true, replayed.ok ? "" : replayed.issues.join(" "));
+  assert.equal(Object.values(restarted.delegationState().tasks).every((task) => task.queueState === "terminal"), true);
+  assert.equal(restarted.hasLiveHandles(), false);
+});
+
+test("integrated pause, resume, and shutdown settle and rebuild run-scoped resources", async () => {
+  const { service } = fixture();
+  deliverInitial(service, "pause-me");
+  service.rootServices().delegate({ targetNodeId: "worker", objective: "resume task", deliverables: [] });
+  assert.equal(await service.pause("native navigation"), true);
+  assert.equal(service.delegationState().schedulerStatus, "paused");
+  assert.equal(service.hasLiveHandles(), false);
+  assert.equal(await service.resume(), true);
+  assert.equal(service.delegationState().schedulerStatus, "running");
+  await service.runWorkers();
+  const root = service.rootServices();
+  const prepared = root.prepareResultDelivery("pause-result-delivery");
+  root.acceptResultDelivery(prepared.deliveryId);
+  await service.shutdown();
+  assert.equal(service.hasLiveHandles(), false);
+});
+
+test("integrated cancellation settles scheduler and worker sessions through W11 semantics", async () => {
+  const { service } = fixture();
+  deliverInitial(service, "cancel-me");
+  service.rootServices().delegate({ targetNodeId: "worker", objective: "cancel task", deliverables: [] });
+  const result = await service.cancel("user cancelled");
+  assert.equal(result.envelope.status, "cancelled");
+  assert.equal(Object.values(service.delegationState().tasks).every((task) => task.result?.status === "cancelled"), true);
+  assert.equal(service.hasLiveHandles(), false);
+});

--- a/tests/workflows/workflow-routing.test.ts
+++ b/tests/workflows/workflow-routing.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { routeDirectMembers } from "../../src/workflows/routing.ts";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  const caps = (shell: string[] = [], git = false) => ({
+    effective: { filesystem: [], shell, git, "external-network": false, "human-input": false, artifact: [], knowledge: [] },
+    provenance: {}, budgets: {}, attachments: { skills: [], knowledge: [] }, directMemberIds: [],
+  });
+  return {
+    snapshotHash: "b".repeat(64), createdAt: "2026-01-01T00:00:00.000Z",
+    payload: {
+      project: { projectId: "project-1", rootRef: "." },
+      workflow: { id: "delivery", team: { rootId: "root", nodes: [
+        { id: "root", agentId: "lead", memberIds: ["alpha", "beta", "gamma"], depth: 1, responsibilities: [] },
+        { id: "alpha", agentId: "shared", parentId: "root", memberIds: [], depth: 2, role: "API builder", responsibilities: ["database migrations"], consultWhen: "service schema failures" },
+        { id: "beta", agentId: "shared", parentId: "root", memberIds: [], depth: 2, role: "UI builder", responsibilities: ["React components"], consultWhen: "browser layout failures" },
+        { id: "gamma", agentId: "reviewer", parentId: "root", memberIds: [], depth: 2, role: "Review", responsibilities: ["inspect API security"], consultWhen: "permission failures" },
+      ] } },
+      agents: [
+        { id: "lead", name: "Lead", tags: [], frontmatter: {}, prompt: "", sourceHash: "", canonicalSourceHash: "", promptHash: "" },
+        { id: "shared", name: "Reusable Builder", description: "implementation specialist", tags: ["implementation", "typescript"], frontmatter: {}, prompt: "", sourceHash: "", canonicalSourceHash: "", promptHash: "" },
+        { id: "reviewer", name: "Reviewer", description: "security analysis", tags: ["security", "audit"], frontmatter: {}, prompt: "", sourceHash: "", canonicalSourceHash: "", promptHash: "" },
+      ],
+      authority: { capabilityContractVersion: 1, nodes: [
+        { nodeId: "root", capabilities: caps(), tools: [] },
+        { nodeId: "alpha", capabilities: caps(["inspect", "execute-code"], true), tools: [] },
+        { nodeId: "beta", capabilities: caps(["inspect", "execute-code"]), tools: [] },
+        { nodeId: "gamma", capabilities: caps(["inspect"]), tools: [] },
+      ] },
+      skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+    },
+  } as unknown as ActivationSnapshotFileV1;
+}
+
+test("routing is direct-member-only, capability filtered, deterministic, and explains token matches", () => {
+  const input = snapshot();
+  const first = routeDirectMembers(input, "root", {
+    objective: "Inspect API service schema database migrations and implementation",
+    requiredCapabilities: { shell: ["inspect"] },
+    limit: 10,
+  });
+  const second = routeDirectMembers(input, "root", {
+    objective: "Inspect API service schema database migrations and implementation",
+    requiredCapabilities: { shell: ["inspect"] },
+    limit: 10,
+  });
+  assert.deepEqual(first, second);
+  assert.equal(first[0].nodeId, "alpha");
+  assert.ok(first[0].reasons.some((reason) => reason.startsWith("role:")));
+  assert.ok(first[0].reasons.some((reason) => reason.startsWith("responsibility:")));
+  assert.equal(first.every((result) => ["alpha", "beta", "gamma"].includes(result.nodeId)), true);
+
+  const gitOnly = routeDirectMembers(input, "root", { objective: "implementation", requiredCapabilities: { git: true } });
+  assert.deepEqual(gitOnly.map((entry) => entry.nodeId), ["alpha"]);
+  assert.throws(() => routeDirectMembers(input, "alpha", { objective: "anything" }), /no direct members|direct member/i);
+  assert.throws(() => routeDirectMembers(input, "missing", { objective: "anything" }), /unknown node/i);
+  assert.throws(() => routeDirectMembers(input, "root", { objective: "anything", requiredCapabilities: { shell: ["unknown-power"] } as any }), /capability.*invalid|unknown.*capability/i);
+  assert.throws(() => routeDirectMembers(input, "root", { objective: "anything", requiredCapabilities: { hiddenAuthority: true } as any }), /capability.*invalid|unknown.*capability/i);
+});
+
+test("routing has stable node-ID tie breaks and no semantic name/type bonus", () => {
+  const input = snapshot();
+  const tied = routeDirectMembers(input, "root", { objective: "unmatched tokens", includeUnmatched: true });
+  assert.deepEqual(tied.map((entry) => entry.nodeId), ["alpha", "beta", "gamma"]);
+  assert.deepEqual(tied.map((entry) => entry.score), [0, 0, 0]);
+
+  const security = routeDirectMembers(input, "root", { objective: "security audit" });
+  assert.equal(security[0].nodeId, "gamma");
+  assert.equal(security[0].reasons.some((reason) => /type|planner|coder/i.test(reason)), false);
+});

--- a/tests/workflows/workflow-scheduler.test.ts
+++ b/tests/workflows/workflow-scheduler.test.ts
@@ -1,0 +1,327 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { DelegationRuntime, type WorkerResultInput } from "../../src/workflows/delegation.ts";
+import { DurableDelegationScheduler } from "../../src/workflows/scheduler.ts";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  return { snapshotHash: "c".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." }, workflow: { id: "delivery", team: { rootId: "root", nodes: [
+      { id: "root", agentId: "lead", memberIds: ["a", "b"], depth: 1 },
+      { id: "a", agentId: "shared", parentId: "root", memberIds: ["a1"], depth: 2 },
+      { id: "b", agentId: "shared", parentId: "root", memberIds: [], depth: 2 },
+      { id: "a1", agentId: "leaf", parentId: "a", memberIds: [], depth: 3 },
+    ] } }, authority: { capabilityContractVersion: 1, nodes: [] }, agents: [], skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function fixture() {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-"));
+  let task = 0;
+  let attempt = 0;
+  const runtime = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot(), createTaskId: () => `task-${++task}` });
+  const root = runtime.rootExecutionContext();
+  const ids = {
+    a1: runtime.accept(root, { targetNodeId: "a", objective: "a-one", deliverables: [] }).taskId,
+    a2: runtime.accept(root, { targetNodeId: "a", objective: "a-two", deliverables: [] }).taskId,
+    b1: runtime.accept(root, { targetNodeId: "b", objective: "b-one", deliverables: [] }).taskId,
+    b2: runtime.accept(root, { targetNodeId: "b", objective: "b-two", deliverables: [] }).taskId,
+  };
+  return { projectRoot, runtime, ids, createAttemptId: () => `attempt-${++attempt}` };
+}
+
+const completed = (summary: string): WorkerResultInput => ({ status: "completed", summary, outputRefs: [], evidenceRefs: [] });
+
+test("scheduler preserves per-node FIFO and durable least-recently-dispatched fairness", async () => {
+  const f = fixture();
+  const order: string[] = [];
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime,
+    maxParallel: 1,
+    createAttemptId: f.createAttemptId,
+    execute: async (task) => { order.push(task.taskId); return completed(task.objective); },
+  });
+  await scheduler.runUntilSettled();
+  assert.deepEqual(order, [f.ids.a1, f.ids.b1, f.ids.a2, f.ids.b2]);
+  assert.equal(scheduler.activeCount, 0);
+  assert.equal(scheduler.hasLiveHandles(), false);
+  assert.equal(f.runtime.status(f.runtime.rootExecutionContext(), { limit: 10 }).summary.completed, 4);
+
+  const restartedOrder: string[] = [];
+  const restarted = new DurableDelegationScheduler({
+    runtime: new DelegationRuntime(f.runtime.options), maxParallel: 1, createAttemptId: f.createAttemptId,
+    verifiedTakeover: () => true,
+    execute: async (task) => { restartedOrder.push(task.taskId); return completed("unexpected"); },
+  });
+  await restarted.runUntilSettled();
+  assert.deepEqual(restartedOrder, [], "terminal work must not restart after journal replay");
+});
+
+test("different node IDs sharing one agent identity run independently", async () => {
+  const f = fixture();
+  let active = 0;
+  let maximum = 0;
+  const seenNodes = new Set<string>();
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 2, createAttemptId: f.createAttemptId,
+    execute: async (task) => {
+      seenNodes.add(task.targetNodeId);
+      active++;
+      maximum = Math.max(maximum, active);
+      await new Promise((resolve) => setImmediate(resolve));
+      active--;
+      return completed(task.taskId);
+    },
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(maximum, 2);
+  assert.deepEqual(seenNodes, new Set(["a", "b"]));
+});
+
+test("max-parallel one nested delegation yields and resumes only after accepted delivery", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-nested-"));
+  let taskNumber = 0;
+  let attempt = 0;
+  const options = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot(), createTaskId: () => `task-${++taskNumber}` };
+  const runtime = new DelegationRuntime(options);
+  const parent = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "parent", deliverables: [] }).taskId;
+  let childId = "";
+  let parentExecutions = 0;
+  const executionOrder: string[] = [];
+  const scheduler = new DurableDelegationScheduler({
+    runtime, maxParallel: 1, createAttemptId: () => `attempt-${++attempt}`,
+    execute: async (task, control) => {
+      executionOrder.push(task.targetNodeId);
+      if (task.taskId === parent && parentExecutions++ === 0) {
+        childId = runtime.accept(control.executionContext, { targetNodeId: "a1", objective: "child", deliverables: [] }).taskId;
+        return { status: "suspended", dependencyTaskIds: [childId] };
+      }
+      return completed(task.objective);
+    },
+    onResultDurable: (task) => {
+      if (task.parentNodeId !== "root") {
+        const deliveryId = `delivery-${task.taskId}`;
+        runtime.deliverPendingResultsToSuspendedTask(parent, deliveryId);
+      }
+    },
+  });
+  await scheduler.runUntilSettled();
+  assert.deepEqual(executionOrder, ["a", "a1", "a"]);
+  assert.equal(runtime.restore().tasks[parent].result?.status, "completed");
+  assert.equal(runtime.restore().tasks[parent].attempts.length, 1);
+  assert.equal(runtime.restore().tasks[childId].result?.status, "completed");
+});
+
+test("task acceptance fault atomically preserves parent dependency linkage for takeover replay and child delivery", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-accept-fault-"));
+  let taskNumber = 0;
+  let injectAcceptanceFault = false;
+  const options = {
+    projectRoot,
+    projectId: "project-1",
+    sessionId: "session-1",
+    runId: "run-1",
+    snapshot: snapshot(),
+    createTaskId: () => `task-${++taskNumber}`,
+    journalFault: (eventType: string, stage: string) => {
+      if (injectAcceptanceFault && eventType === "task.accepted" && stage === "afterRename") {
+        injectAcceptanceFault = false;
+        throw new Error("simulated crash after child acceptance publication");
+      }
+    },
+  };
+  const runtime = new DelegationRuntime(options);
+  const parentId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "parent", deliverables: [] }).taskId;
+  runtime.start(parentId, "attempt-parent");
+  injectAcceptanceFault = true;
+  assert.throws(() => runtime.accept(runtime.workerExecutionContext(parentId, "attempt-parent"), {
+    targetNodeId: "a1", objective: "child accepted at crash", deliverables: [],
+  }), /simulated crash/i);
+
+  const replayed = new DelegationRuntime(options);
+  assert.deepEqual(replayed.restore().tasks[parentId].suspendedOn, ["task-2"], "child acceptance must atomically persist the parent linkage");
+  assert.equal(replayed.restore().tasks[parentId].queueState, "active");
+
+  const executionOrder: string[] = [];
+  const deliveredToParent: string[] = [];
+  const scheduler = new DurableDelegationScheduler({
+    runtime: replayed,
+    maxParallel: 1,
+    verifiedTakeover: () => true,
+    createAttemptId: () => "unexpected-new-attempt",
+    execute: async (task) => {
+      executionOrder.push(task.targetNodeId);
+      if (task.taskId === parentId) {
+        const child = replayed.restore().tasks["task-2"];
+        if (child.resultAcceptedSequence !== undefined) deliveredToParent.push(child.result?.summary ?? "");
+      }
+      return completed(task.objective);
+    },
+    onResultDurable: (task) => {
+      if (task.taskId === "task-2") replayed.deliverPendingResultsToSuspendedTask(parentId, "delivery-task-2");
+    },
+  });
+  await scheduler.runUntilSettled();
+
+  const parent = replayed.restore().tasks[parentId];
+  assert.deepEqual(executionOrder, ["a1", "a"]);
+  assert.deepEqual(deliveredToParent, ["child accepted at crash"]);
+  assert.deepEqual(parent.attempts.map((attempt) => attempt.attemptId), ["attempt-parent"]);
+  assert.equal(parent.attempts[0].interruptedSequence, undefined, "linked parent takeover must suspend rather than restart the attempt");
+  assert.equal(parent.result?.status, "completed");
+});
+
+test("a durable resume-ready task continues the same attempt after scheduler restart", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-resume-replay-"));
+  let taskNumber = 0;
+  const runtime = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot(), createTaskId: () => `task-${++taskNumber}` });
+  const parentId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "parent", deliverables: [] }).taskId;
+  runtime.start(parentId, "attempt-parent");
+  const parentContext = runtime.workerExecutionContext(parentId, "attempt-parent");
+  const childId = runtime.accept(parentContext, { targetNodeId: "a1", objective: "child", deliverables: [] }).taskId;
+  runtime.suspend(parentId, [childId]);
+  runtime.start(childId, "attempt-child");
+  runtime.recordResult(childId, completed("child"));
+  runtime.deliverPendingResultsToSuspendedTask(parentId, "delivery-replay-child");
+
+  const replayed = new DelegationRuntime(runtime.options);
+  const scheduler = new DurableDelegationScheduler({
+    runtime: replayed, maxParallel: 1,
+    execute: async (task) => completed(task.objective),
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(replayed.restore().tasks[parentId].result?.status, "completed");
+  assert.deepEqual(replayed.restore().tasks[parentId].attempts.map((attempt) => attempt.attemptId), ["attempt-parent"]);
+});
+
+test("verified takeover interrupts and requeues journal-active tasks", async () => {
+  const f = fixture();
+  f.runtime.start(f.ids.a1, "crashed-attempt");
+  const replayed = new DelegationRuntime(f.runtime.options);
+  const seen: string[] = [];
+  const scheduler = new DurableDelegationScheduler({
+    runtime: replayed,
+    maxParallel: 1,
+    verifiedTakeover: () => true,
+    createAttemptId: f.createAttemptId,
+    execute: async (task) => { seen.push(task.taskId); return completed(task.taskId); },
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(replayed.restore().tasks[f.ids.a1].attempts[0].interruptedSequence !== undefined, true);
+  assert.equal(replayed.restore().tasks[f.ids.a1].attempts.length, 2);
+  assert.equal(seen.includes(f.ids.a1), true);
+
+  const unsafe = fixture();
+  unsafe.runtime.start(unsafe.ids.a1, "still-owned-attempt");
+  const denied = new DurableDelegationScheduler({ runtime: new DelegationRuntime(unsafe.runtime.options), maxParallel: 1, verifiedTakeover: () => false, execute: async () => completed("no") });
+  await assert.rejects(denied.runUntilSettled(), /verified takeover/i);
+});
+
+test("worker failure becomes a bounded task result and does not terminate the run", async () => {
+  const f = fixture();
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 1, createAttemptId: f.createAttemptId,
+    execute: async (task) => { if (task.taskId === f.ids.a1) throw new Error("provider unavailable"); return completed(task.taskId); },
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(f.runtime.restore().tasks[f.ids.a1].result?.status, "failed");
+  assert.match(f.runtime.restore().tasks[f.ids.a1].result?.summary ?? "", /provider unavailable/);
+  assert.equal(f.runtime.restore().tasks[f.ids.b2].result?.status, "completed");
+});
+
+test("invalid worker executor outcomes fail their tasks without stopping later work", async () => {
+  const f = fixture();
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 1, createAttemptId: f.createAttemptId,
+    execute: async (task) => {
+      if (task.taskId === f.ids.a1) return undefined as never;
+      if (task.taskId === f.ids.b1) return { status: "suspended", dependencyTaskIds: [] };
+      if (task.taskId === f.ids.a2) return { status: "unknown" } as never;
+      return completed("valid result");
+    },
+  });
+
+  await scheduler.runUntilSettled();
+  const tasks = f.runtime.restore().tasks;
+  assert.match(tasks[f.ids.a1].result?.summary ?? "", /no result/i);
+  assert.match(tasks[f.ids.b1].result?.summary ?? "", /no dependency/i);
+  assert.match(tasks[f.ids.a2].result?.summary ?? "", /invalid terminal status/i);
+  assert.equal(tasks[f.ids.b2].result?.status, "completed");
+});
+
+test("pause aborts cooperative work and restart resumes queued tasks", async () => {
+  const f = fixture();
+  let releases = 0;
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 1, createAttemptId: f.createAttemptId,
+    execute: async (task, control) => {
+      if (!control.signal.aborted) await new Promise<void>((resolve) => control.signal.addEventListener("abort", () => resolve(), { once: true }));
+      releases++;
+      return completed(task.taskId);
+    },
+  });
+  const running = scheduler.runUntilSettled();
+  await new Promise((resolve) => setImmediate(resolve));
+  scheduler.pauseAdmission("process shutdown");
+  scheduler.abortOwnedWork("process shutdown");
+  assert.equal(await scheduler.waitForSettlement(100), true);
+  await running;
+  assert.equal(releases, 1);
+  assert.equal(Object.values(f.runtime.restore().tasks).every((task) => task.queueState === "queued"), true);
+  scheduler.resume();
+});
+
+test("cancellation settles interrupted queued work without claiming its stale attempt", async () => {
+  const f = fixture();
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 1, createAttemptId: f.createAttemptId,
+    execute: async (task, control) => {
+      if (!control.signal.aborted) await new Promise<void>((resolve) => control.signal.addEventListener("abort", () => resolve(), { once: true }));
+      return completed(task.taskId);
+    },
+  });
+  const running = scheduler.runUntilSettled();
+  await new Promise((resolve) => setImmediate(resolve));
+  scheduler.pauseAdmission("process shutdown");
+  scheduler.abortOwnedWork("process shutdown");
+  assert.equal(await scheduler.waitForSettlement(100), true);
+  await running;
+
+  const interrupted = f.runtime.restore().tasks[f.ids.a1];
+  assert.equal(interrupted.queueState, "queued");
+  assert.equal(interrupted.attempts[0]?.interruptedSequence !== undefined, true);
+
+  scheduler.closeAdmission("cancelled");
+  scheduler.cancelPending("cancelled");
+  const settled = f.runtime.restore();
+  assert.equal(settled.tasks[f.ids.a1].result?.attemptId, undefined);
+  assert.equal(settled.tasks[f.ids.a1].attempts[0]?.resultSequence, undefined);
+  assert.equal(Object.values(settled.tasks).every((task) => task.queueState === "terminal"), true);
+  assert.equal(Object.values(settled.tasks).every((task) => task.result?.status === "cancelled"), true);
+});
+
+test("hung abort is bounded and remains unsettled until the execution actually exits", async () => {
+  const f = fixture();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const scheduler = new DurableDelegationScheduler({
+    runtime: f.runtime, maxParallel: 1, createAttemptId: f.createAttemptId,
+    execute: async () => { await gate; return completed("late"); },
+  });
+  const running = scheduler.runUntilSettled();
+  await new Promise((resolve) => setImmediate(resolve));
+  scheduler.closeAdmission("cancelled");
+  scheduler.cancelPending("cancelled");
+  scheduler.abortOwnedWork("cancelled");
+  const started = Date.now();
+  assert.equal(await scheduler.waitForSettlement(20), false);
+  assert.ok(Date.now() - started < 500, "settlement wait must be bounded");
+  assert.equal(scheduler.hasLiveHandles(), true);
+  release();
+  assert.equal(await scheduler.waitForSettlement(500), true);
+  await running;
+  assert.equal(scheduler.hasLiveHandles(), false);
+});

--- a/tests/workflows/workflow-workers.test.ts
+++ b/tests/workflows/workflow-workers.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import type { PersistedDelegationTask } from "../../src/workflows/delegation.ts";
+import {
+  WorkerSessionPool,
+  workerTranscriptPath,
+  type WorkerSessionFactory,
+} from "../../src/workflows/workers.ts";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  return { snapshotHash: "d".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." },
+    workflow: { id: "delivery", instructions: { shared: "shared workflow rules", root: "root-only transcript policy" }, artifact: { adapter: "openspec", profile: "delivery", contractVersion: "v1", checkpoints: ["verified"] }, team: { rootId: "root", nodes: [
+      { id: "root", agentId: "lead", memberIds: ["alpha", "beta"], depth: 1 },
+      { id: "alpha", agentId: "shared-agent", parentId: "root", memberIds: [], depth: 2, role: "Implementer", responsibilities: ["ship patches"], skills: { resolved: ["coding"] }, knowledge: { resolved: ["architecture"] } },
+      { id: "beta", agentId: "shared-agent", parentId: "root", memberIds: [], depth: 2, skills: { resolved: [] }, knowledge: { resolved: [] } },
+    ] } },
+    authority: { capabilityContractVersion: 1, nodes: [
+      { nodeId: "root", capabilities: {}, tools: ["workflow_finish"] },
+      { nodeId: "alpha", capabilities: { effective: { shell: ["inspect"] }, provenance: { shell: ["agent-ceiling", "workflow-node"] } }, tools: ["delegate_agent", "read"], model: "model-alpha", thinking: "medium" },
+      { nodeId: "beta", capabilities: {}, tools: ["read"], model: "model-beta", thinking: "low" },
+    ] },
+    agents: [
+      { id: "lead", name: "Lead", prompt: "root" },
+      { id: "shared-agent", name: "Shared", prompt: "worker" },
+    ],
+    skills: [{ id: "coding", treeHash: "skill-hash", files: [{ relativePath: "SKILL.md", content: "coding skill content", hash: "file-hash" }] }],
+    knowledge: [{ id: "architecture", provider: "okf", path: ".pi/hive/knowledge/architecture", attachedNodeIds: ["alpha"] }],
+    models: [
+      { nodeId: "root", modelId: "root-model", thinking: "medium", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+      { nodeId: "alpha", modelId: "model-alpha", thinking: "medium", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+      { nodeId: "beta", modelId: "model-beta", thinking: "low", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 },
+    ],
+    sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function task(taskId: string, targetNodeId: string, objective: string): PersistedDelegationTask {
+  return {
+    taskId, runId: "run-1", parentNodeId: "root", targetNodeId, objective,
+    contextRefs: [], deliverables: ["bounded result"], provenance: { source: "delegate_agent" },
+    creationSequence: Number(taskId.split("-")[1]), createdAt: "2026-01-01T00:00:00.000Z",
+    queueState: "active", attempts: [{ attemptId: `attempt-${taskId}`, startedSequence: 2 }],
+    lastStartedSequence: 2,
+  };
+}
+
+function completedTask(input: PersistedDelegationTask, summary: string): PersistedDelegationTask {
+  return {
+    ...input,
+    queueState: "terminal",
+    result: {
+      status: "completed", summary, outputRefs: [], evidenceRefs: [], data: {},
+      attemptId: input.attempts.at(-1)?.attemptId,
+      recordedAt: "2026-01-01T00:00:01.000Z", recordedSequence: input.creationSequence + 10,
+    },
+  };
+}
+
+test("worker transcripts and immutable snapshot execution config are scoped by run and node", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-"));
+  const created: Array<{ nodeId: string; agentId: string; modelId: string; thinking: string; transcriptPath: string; tools: readonly string[] }> = [];
+  const prompts = new Map<string, string[]>();
+  const factory: WorkerSessionFactory = async (input) => {
+    created.push({ nodeId: input.nodeId, agentId: input.agentId, modelId: input.modelId, thinking: input.thinking, transcriptPath: input.transcriptPath, tools: input.tools });
+    const nodePrompts = prompts.get(input.nodeId) ?? [];
+    prompts.set(input.nodeId, nodePrompts);
+    return {
+      linkedSessionId: `linked-${input.runId}-${input.nodeId}`,
+      async prompt(text) { nodePrompts.push(text); return `result from ${input.nodeId}`; },
+      async abort() {},
+      dispose() {},
+    };
+  };
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), factory });
+  await pool.execute(task("task-1", "alpha", "alpha objective"));
+  await pool.execute(task("task-2", "beta", "beta objective"));
+
+  assert.deepEqual(created.map(({ nodeId, agentId, modelId, thinking, tools }) => ({ nodeId, agentId, modelId, thinking, tools })), [
+    { nodeId: "alpha", agentId: "shared-agent", modelId: "model-alpha", thinking: "medium", tools: ["delegate_agent", "read"] },
+    { nodeId: "beta", agentId: "shared-agent", modelId: "model-beta", thinking: "low", tools: ["read"] },
+  ]);
+  assert.notEqual(created[0].transcriptPath, created[1].transcriptPath);
+  assert.equal(created.every((entry) => entry.tools.includes("workflow_finish") === false), true);
+  assert.equal(prompts.get("alpha")?.[0].includes("beta objective"), false);
+  assert.equal(prompts.get("alpha")?.[0].includes("alpha objective"), true);
+  assert.match(workerTranscriptPath(projectRoot, "session-1", "run-1", "alpha"), /runs[/\\]run-1[/\\]workers[/\\]alpha\.jsonl$/);
+});
+
+test("worker prompt invocation exposes full immutable snapshot and task context without root transcript", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-prompt-context-"));
+  let invocation: unknown;
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), factory: async () => ({
+    linkedSessionId: "linked-alpha",
+    async prompt(_text, _signal, value) { invocation = value; return "ok"; },
+    dispose() {},
+  }) });
+  await pool.execute(task("task-1", "alpha", "immutable objective"));
+  const context = invocation as { promptContext: Record<string, unknown> };
+  const promptContext = context.promptContext as Record<string, unknown>;
+  assert.equal(promptContext.agentPrompt, "worker");
+  assert.equal(promptContext.sharedInstructions, "shared workflow rules");
+  assert.equal("rootInstructions" in promptContext, false);
+  assert.equal(promptContext.role, "Implementer");
+  assert.deepEqual(promptContext.responsibilities, ["ship patches"]);
+  assert.deepEqual((promptContext.skills as Array<{ id: string }>).map((entry) => entry.id), ["coding"]);
+  assert.deepEqual((promptContext.knowledge as Array<{ id: string }>).map((entry) => entry.id), ["architecture"]);
+  assert.deepEqual(promptContext.adapterContract, { adapter: "openspec", profile: "delivery", contractVersion: "v1", checkpoints: ["verified"] });
+  assert.deepEqual(promptContext.effectivePolicy, { effective: { shell: ["inspect"] }, provenance: { shell: ["agent-ceiling", "workflow-node"] } });
+  assert.equal((promptContext.taskContract as { objective: string }).objective, "immutable objective");
+  assert.equal(Object.isFrozen(promptContext), true);
+  assert.equal(JSON.stringify(promptContext).includes("root-only transcript policy"), false);
+});
+
+test("sequential tasks reuse one node/run session and boundaries project only committed journal state", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-reuse-"));
+  let creations = 0;
+  const factory: WorkerSessionFactory = async (input) => {
+    creations++;
+    return { linkedSessionId: `linked-${input.nodeId}`, async prompt(text) { return text.includes("second") ? "second result" : "first result"; }, dispose() {} };
+  };
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), factory });
+  const firstTask = task("task-1", "alpha", "first");
+  const secondTask = task("task-2", "alpha", "second");
+  const first = await pool.execute(firstTask);
+  const second = await pool.execute(secondTask);
+  assert.equal(creations, 1);
+  assert.equal(first.status, "completed");
+  assert.equal(second.status, "completed");
+  const boundaryDir = join(projectRoot, ".pi", "hive", "sessions", "session-1", "runs", "run-1", "workers", "alpha.boundaries");
+  assert.equal(existsSync(boundaryDir), false, "executor output must not outrun authoritative result publication");
+
+  pool.rebuildBoundaries([completedTask(firstTask, first.summary), completedTask(secondTask, second.summary)]);
+  const files = readdirSync(boundaryDir).sort();
+  assert.equal(files.length, 4);
+  const records = files.map((file) => JSON.parse(readFileSync(join(boundaryDir, file), "utf8")));
+  assert.deepEqual(records.map((record) => `${record.taskId}:${record.kind}`), ["task-1:start", "task-1:result", "task-2:start", "task-2:result"]);
+  pool.rebuildBoundaries([completedTask(firstTask, first.summary), completedTask(secondTask, second.summary)]);
+  assert.equal(readdirSync(boundaryDir).length, 4, "journal projection rebuild is idempotent after a crash");
+});
+
+test("boundary rebuild remains stable when a takeover appends a retry attempt", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-retry-boundary-"));
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), factory: async () => ({
+    linkedSessionId: "unused", prompt: async () => "unused", dispose() {},
+  }) });
+  const active = task("task-1", "alpha", "retry after crash");
+  pool.rebuildBoundaries([active]);
+  const retried = {
+    ...active,
+    attempts: [
+      { ...active.attempts[0], interruptedSequence: 5 },
+      { attemptId: "attempt-retry", startedSequence: 6, startedAt: "2026-01-01T00:00:01.000Z" },
+    ],
+    lastStartedSequence: 6,
+  };
+  assert.doesNotThrow(() => pool.rebuildBoundaries([retried]));
+});
+
+test("structured authorized refs are the only resolved context and prose carries an explicit no-DLP limitation", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-context-"));
+  let prompt = "";
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), factory: async () => ({
+    linkedSessionId: "linked", async prompt(text) { prompt = text; return "ok"; }, dispose() {},
+  }) });
+  const withRefs = { ...task("task-1", "alpha", "inspect"), contextRefs: [
+    { ref: { kind: "artifact", id: "allowed" }, authorization: "authorized" as const, resolved: { excerpt: "visible" } },
+    { ref: { kind: "knowledge", id: "secret" }, authorization: "denied" as const, diagnostic: "not attached" },
+  ] };
+  await pool.execute(withRefs);
+  assert.match(prompt, /visible/);
+  assert.match(prompt, /secret.*denied|denied.*secret/i);
+  assert.match(prompt, /prose.*not.*DLP|not information-flow control/i);
+});
+
+test("worker result output is bounded and active execution settlement is observable", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-cleanup-"));
+  let aborts = 0;
+  let disposals = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: snapshot(), resultSummaryBytes: 64, factory: async () => ({
+    linkedSessionId: "linked",
+    async prompt() { await gate; return "x".repeat(1_000); },
+    async abort() { aborts++; },
+    dispose() { disposals++; },
+  }) });
+  const pending = pool.execute(task("task-1", "alpha", "long"));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(pool.activeExecutionCount, 1);
+  await pool.closeSessions();
+  assert.equal(await pool.waitForSettlement(20), false, "a provider ignoring abort remains explicitly unsettled");
+  assert.equal(pool.hasLiveHandles(), true);
+  release();
+  const result = await pending;
+  if (result.status === "suspended") assert.fail("non-delegating worker must return a terminal result");
+  assert.ok(Buffer.byteLength(result.summary, "utf8") <= 64);
+  assert.equal(await pool.waitForSettlement(100), true);
+  assert.equal(aborts, 1);
+  assert.equal(disposals, 1);
+  assert.equal(pool.activeSessionCount, 0);
+  assert.equal(pool.hasLiveHandles(), false);
+});


### PR DESCRIPTION
## Summary
- persist direct-member delegation tasks, attempts, dependencies, and two-phase result delivery
- add deterministic routing, fair restartable scheduling, and node/run worker sessions
- integrate delegation settlement with workflow finish, pause, cancellation, and recovery

## Validation
- focused delegation, routing, scheduler, worker, and orchestration tests
- `just typecheck-core`
- `just test`
- `just verify`