### PR TITLE
feat(workflows): add handoff and orphan recovery

### DIFF
--- a/src/integration/commands.ts
+++ b/src/integration/commands.ts
@@ -8,6 +8,8 @@ import { renderHiveDoctor } from "../engine/doctor";
 import { dashboardUrl, ensureDashboard, readDaemonToken, stopDashboard } from "../engine/dashboard";
 import * as openspec from "../engine/openspec";
 import { truncateMiddle } from "../core/utils";
+export { createWorkflowLifecycleServiceHandlers } from "./workflow-lifecycle-handlers";
+export type { WorkflowLifecycleServiceHandlers, WorkflowLifecycleServiceHandlerOptions } from "./workflow-lifecycle-handlers";
 
 function listChangeIds(cwd: string, api: typeof openspec): string[] {
   return api.listChanges(cwd).map((c) => c.name);

--- a/src/integration/session-links.ts
+++ b/src/integration/session-links.ts
@@ -12,24 +12,40 @@ export function createPiSessionNavigationAdapter(commandContext: ExtensionComman
   return {
     async create(input) {
       let created: { piSessionId: string; piSessionFile: string } | undefined;
-      const result = await commandContext.newSession({
-        parentSession: input.parentSession,
-        setup: async (manager) => {
-          manager.appendSessionInfo(input.name);
-          manager.appendCustomEntry(WORKFLOW_SESSION_MARKER_TYPE, {
-            formatVersion: 1,
-            workflowId: input.workflowId,
-            activationHash: input.activationHash,
-          });
-        },
-        withSession: async (fresh) => {
-          const file = fresh.sessionManager.getSessionFile();
-          if (!file) throw new Error("Workflow Pi session is not persisted");
-          created = { piSessionId: fresh.sessionManager.getSessionId(), piSessionFile: file };
-        },
-      });
-      if (result.cancelled || !created) throw new Error("Workflow Pi session creation cancelled");
-      return created;
+      let enteredReplacement = false;
+      const restore = async (): Promise<void> => {
+        if (!input.restoreSession) throw new Error("Pi replacement session has no restoration target");
+        const restored = await commandContext.switchSession(input.restoreSession, { withSession: async () => {} });
+        if (restored.cancelled) throw new Error("Pi replacement session restoration was cancelled");
+      };
+      try {
+        const result = await commandContext.newSession({
+          parentSession: input.parentSession,
+          setup: async (manager) => {
+            manager.appendSessionInfo(input.name);
+            manager.appendCustomEntry(WORKFLOW_SESSION_MARKER_TYPE, {
+              formatVersion: 1,
+              workflowId: input.workflowId,
+              activationHash: input.activationHash,
+              ...(input.recovery ? { recovery: input.recovery } : {}),
+            });
+          },
+          withSession: async (fresh) => {
+            enteredReplacement = true;
+            const file = fresh.sessionManager.getSessionFile();
+            if (!file) throw new Error("Workflow Pi session is not persisted");
+            created = { piSessionId: fresh.sessionManager.getSessionId(), piSessionFile: file };
+          },
+        });
+        if (result.cancelled || !created) throw new Error("Workflow Pi session creation cancelled");
+      } catch (error) {
+        if (enteredReplacement && input.restoreSession) {
+          try { await restore(); }
+          catch (restoreError) { throw new AggregateError([error, restoreError], "Workflow Pi session creation failed and restoration was unsuccessful"); }
+        }
+        throw error;
+      }
+      return { ...created, ...(input.restoreSession ? { compensate: restore } : {}) };
     },
     async switch(input) {
       return commandContext.switchSession(input.piSessionFile, {

--- a/src/integration/workflow-lifecycle-handlers.ts
+++ b/src/integration/workflow-lifecycle-handlers.ts
@@ -1,0 +1,78 @@
+import type { SnapshotCompatibilityRuntime } from "../config/snapshot-compat";
+import type { AcquireOwnershipOptions } from "../workflows/ownership";
+import {
+  reloadWorkflowSession,
+  resolveHandoffSource,
+  selectWorkflowSession,
+  type PreparedReloadActivation,
+  type SelectableWorkflow,
+  type SelectionResult,
+  type SessionNavigationAdapter,
+} from "../workflows/navigation";
+import { clearStagedHandoff, type HandoffPacket } from "../workflows/handoff";
+import {
+  detectOrphanedWorkflowSessions,
+  recoverOrphanedWorkflowSession,
+  type RecoverOrphanedWorkflowSessionInput,
+} from "../workflows/recovery";
+
+export interface WorkflowLifecycleRecoveryDependencies {
+  readonly runtime: () => SnapshotCompatibilityRuntime;
+  readonly currentPiSessionFile: () => string;
+}
+export interface WorkflowLifecycleServiceHandlerOptions {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly currentPiSessionId: () => string;
+  readonly adapter: SessionNavigationAdapter;
+  readonly owner: () => AcquireOwnershipOptions & { nonce: string };
+  /** Recovery remains unavailable unless every mandatory compatibility/navigation dependency is bound. */
+  readonly recovery?: WorkflowLifecycleRecoveryDependencies;
+}
+export interface WorkflowLifecycleSelectRequest {
+  readonly workflow: SelectableWorkflow;
+  readonly fresh?: boolean;
+  readonly from?: string | "last";
+  /** Packet-shaped input is always re-derived from its same-project source journal before use. */
+  readonly packet?: HandoffPacket;
+}
+export interface WorkflowLifecycleServiceHandlers {
+  select(input: WorkflowLifecycleSelectRequest): Promise<SelectionResult>;
+  clearHandoff(targetSessionId: string, expectedPacketHash?: string): ReturnType<typeof clearStagedHandoff>;
+  reload(prepareActivation: () => PreparedReloadActivation | Promise<PreparedReloadActivation>): Promise<SelectionResult>;
+  detectOrphans(): ReturnType<typeof detectOrphanedWorkflowSessions>;
+  recover(workflowSessionId: string, options?: Pick<RecoverOrphanedWorkflowSessionInput, "validateActivation">): ReturnType<typeof recoverOrphanedWorkflowSession>;
+}
+
+/**
+ * Typed schema-v1 command services. W26 owns argument parsing, registration, and
+ * TUI/headless presentation; constructing these handlers has no side effects.
+ */
+export function createWorkflowLifecycleServiceHandlers(options: WorkflowLifecycleServiceHandlerOptions): WorkflowLifecycleServiceHandlers {
+  return Object.freeze({
+    async select(input: WorkflowLifecycleSelectRequest): Promise<SelectionResult> {
+      if (input.from !== undefined && input.packet !== undefined) throw new Error("Select accepts either a source selector or a verified packet, not both");
+      const stagedHandoff = input.packet ?? (input.from === undefined ? undefined : resolveHandoffSource({
+        projectRoot: options.projectRoot, projectId: options.projectId, runId: input.from, currentPiSessionId: options.currentPiSessionId(),
+      }));
+      return selectWorkflowSession({
+        projectRoot: options.projectRoot, projectId: options.projectId, currentPiSessionId: options.currentPiSessionId(), workflow: input.workflow,
+        ...(input.fresh ? { fresh: true } : {}), ...(stagedHandoff ? { stagedHandoff } : {}), adapter: options.adapter, owner: options.owner(),
+      });
+    },
+    clearHandoff(targetSessionId: string, expectedPacketHash?: string) {
+      return clearStagedHandoff({ projectRoot: options.projectRoot, projectId: options.projectId, targetSessionId, ...(expectedPacketHash ? { expectedPacketHash } : {}) });
+    },
+    reload(prepareActivation: () => PreparedReloadActivation | Promise<PreparedReloadActivation>) {
+      return reloadWorkflowSession({ projectRoot: options.projectRoot, projectId: options.projectId, currentPiSessionId: options.currentPiSessionId(), adapter: options.adapter, owner: options.owner(), prepareActivation });
+    },
+    detectOrphans() { return detectOrphanedWorkflowSessions({ projectRoot: options.projectRoot, projectId: options.projectId }); },
+    recover(workflowSessionId: string, recoveryOptions: Pick<RecoverOrphanedWorkflowSessionInput, "validateActivation"> = {}) {
+      if (!options.recovery) throw new Error("Workflow recovery is blocked because mandatory runtime and Pi navigation dependencies are unavailable");
+      const runtime = options.recovery.runtime();
+      const restorePiSessionFile = options.recovery.currentPiSessionFile();
+      if (!runtime || !restorePiSessionFile) throw new Error("Workflow recovery is blocked because mandatory runtime and Pi navigation dependencies are incomplete");
+      return recoverOrphanedWorkflowSession({ projectRoot: options.projectRoot, projectId: options.projectId, workflowSessionId, adapter: options.adapter, owner: options.owner(), runtime, restorePiSessionFile, ...recoveryOptions });
+    },
+  });
+}

--- a/src/workflows/events.ts
+++ b/src/workflows/events.ts
@@ -10,6 +10,9 @@ export type WorkflowEventType =
   | "session.linked"
   | "session.selected"
   | "session.orphaned"
+  | "session.recovery.blocked"
+  | "session.recovery.prepared"
+  | "session.recovered"
   | "control.requested"
   | "run.started"
   | "run.input.recorded"
@@ -55,7 +58,7 @@ export type WorkflowEventType =
   | "knowledge.transition"
   | "terminal.recorded";
 const EVENT_TYPES = new Set<WorkflowEventType>([
-  "session.created", "session.linked", "session.selected", "session.orphaned", "control.requested",
+  "session.created", "session.linked", "session.selected", "session.orphaned", "session.recovery.blocked", "session.recovery.prepared", "session.recovered", "control.requested",
   "run.started", "run.input.recorded", "run.input.delivery.prepared", "run.input.delivered",
   "run.transition", "run.cancel.requested", "run.cancel.settlement.failed", "run.pause.release.confirmed", "run.terminal.prepared",
   "task.accepted", "task.started", "task.suspended", "task.interrupted", "task.result.recorded",

--- a/src/workflows/handoff.ts
+++ b/src/workflows/handoff.ts
@@ -1,0 +1,370 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+import type { DynamicPromptInput } from "./prompts";
+import {
+  createEmptyRunLifecycleState,
+  reduceRunLifecycle,
+  terminalEnvelopeFromEvent,
+  type ArtifactReference,
+  type EvidenceReference,
+  type FileChangeRecord,
+  type PersistedTerminalEnvelope,
+  type TerminalRunStatus,
+} from "./runs";
+import { createWorkflowEvent, type WorkflowEventEnvelope } from "./events";
+import { appendWorkflowEventChecked, readWorkflowJournal, type JournalFaultOptions } from "./journal";
+import { replayWorkflowJournal } from "./replay";
+import { listSessionLinks, type WorkflowSessionLink } from "./sessions";
+
+export const HANDOFF_FORMAT_VERSION = 1 as const;
+export const HANDOFF_LIMITS = Object.freeze({
+  packetBytes: 131_072,
+  dataBytes: 65_536,
+  dataDepth: 16,
+  dataNodes: 4_096,
+  summaryBytes: 8_192,
+  idBytes: 256,
+  referenceItems: 128,
+  referenceFieldBytes: 2_048,
+  fileChanges: 4_096,
+  consumedRecords: 4_096,
+});
+
+export interface HandoffPacketSource {
+  readonly projectId: string;
+  readonly workflowId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly snapshotId: string;
+  readonly terminalEventHash: string;
+}
+export interface HandoffPacket {
+  readonly formatVersion: 1;
+  readonly packetHash: string;
+  readonly createdAt: string;
+  readonly source: HandoffPacketSource;
+  readonly terminal: Readonly<{ status: TerminalRunStatus; summary: string; finishedAt: string }>;
+  readonly fileChanges: readonly FileChangeRecord[];
+  readonly changeCoverage: string;
+  /** W17 must revalidate these refs before adapter binding or mutation. */
+  readonly artifactRefsAreCandidates: true;
+  readonly artifactRefs: readonly ArtifactReference[];
+  readonly evidenceRefs: readonly EvidenceReference[];
+  readonly data: Readonly<Record<string, JsonValue>>;
+}
+export interface ConsumedHandoff {
+  readonly packet: HandoffPacket;
+  readonly runId: string;
+  readonly inputId: string;
+  readonly consumedAt: string;
+  readonly sequence: number;
+}
+export interface HandoffState {
+  readonly staged?: HandoffPacket;
+  readonly consumed: readonly ConsumedHandoff[];
+}
+
+function handoffInvariant(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(message); }
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown) throw new Error(`${label} contains unsupported field: ${unknown}`);
+  const missing = allowed.find((key) => !(key in value));
+  if (missing) throw new Error(`${label} is missing field: ${missing}`);
+}
+function bounded(value: unknown, label: string, maxBytes: number = HANDOFF_LIMITS.referenceFieldBytes): string {
+  if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > maxBytes || value.includes("\0")) throw new Error(`${label} is invalid or exceeds its limit`);
+  return value;
+}
+function identifier(value: unknown, label: string): string { return bounded(value, label, HANDOFF_LIMITS.idBytes); }
+function digest(value: unknown, label: string, prefixed = true): string {
+  const result = bounded(value, label, 80);
+  const expression = prefixed ? /^sha256:[0-9a-f]{64}$/u : /^[0-9a-f]{64}$/u;
+  if (!expression.test(result)) throw new Error(`${label} is not a SHA-256 digest`);
+  return result;
+}
+function freeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const child of Object.values(value as Record<string, unknown>)) freeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+function jsonData(value: unknown): Readonly<Record<string, JsonValue>> {
+  if (!plainRecord(value)) throw new Error("Handoff data must be a plain JSON object");
+  let nodes = 0;
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  while (stack.length) {
+    const current = stack.pop()!;
+    nodes += 1;
+    if (nodes > HANDOFF_LIMITS.dataNodes || current.depth > HANDOFF_LIMITS.dataDepth) throw new Error("Handoff data exceeds its structural limit");
+    if (current.value === null || typeof current.value === "string" || typeof current.value === "boolean") continue;
+    if (typeof current.value === "number") { if (!Number.isFinite(current.value)) throw new Error("Handoff data is not JSON"); continue; }
+    if (Array.isArray(current.value)) { for (const child of current.value) stack.push({ value: child, depth: current.depth + 1 }); continue; }
+    if (!plainRecord(current.value)) throw new Error("Handoff data is not JSON");
+    for (const [key, child] of Object.entries(current.value)) {
+      bounded(key, "Handoff data key");
+      stack.push({ value: child, depth: current.depth + 1 });
+    }
+  }
+  const cloned = structuredClone(value) as Record<string, JsonValue>;
+  if (Buffer.byteLength(canonicalJson(cloned), "utf8") > HANDOFF_LIMITS.dataBytes) throw new Error("Handoff data exceeds its byte limit");
+  return freeze(cloned);
+}
+function projectPath(value: unknown, label: string): string {
+  const result = bounded(value, label, 4_096);
+  if (result.startsWith("/") || result.includes("\\") || result.split("/").some((part) => !part || part === "." || part === "..")) throw new Error(`${label} is not a normalized project-relative path`);
+  return result;
+}
+function parseFileChanges(value: unknown): readonly FileChangeRecord[] {
+  if (!Array.isArray(value) || value.length > HANDOFF_LIMITS.fileChanges) throw new Error("Handoff file changes exceed their limit");
+  return freeze(value.map((entry, index): FileChangeRecord => {
+    if (!plainRecord(entry)) throw new Error(`Handoff fileChanges[${index}] is invalid`);
+    const allowed = ["path", "previousPath", "operation", "beforeHash", "afterHash", "attribution"];
+    const unknown = Object.keys(entry).find((key) => !allowed.includes(key));
+    if (unknown) throw new Error(`Handoff fileChanges[${index}] contains unsupported field: ${unknown}`);
+    if (entry.operation !== "create" && entry.operation !== "update" && entry.operation !== "delete" && entry.operation !== "rename") throw new Error(`Handoff fileChanges[${index}] operation is invalid`);
+    if (!new Set(["recorded", "reconciled", "unknown", "git-reconciled", "scoped-reconciled", "conflicted", "unattributed"]).has(String(entry.attribution))) throw new Error(`Handoff fileChanges[${index}] attribution is invalid`);
+    const path = projectPath(entry.path, `Handoff fileChanges[${index}].path`);
+    const previousPath = entry.previousPath === undefined ? undefined : projectPath(entry.previousPath, `Handoff fileChanges[${index}].previousPath`);
+    const beforeHash = entry.beforeHash === undefined ? undefined : digest(entry.beforeHash, `Handoff fileChanges[${index}].beforeHash`);
+    const afterHash = entry.afterHash === undefined ? undefined : digest(entry.afterHash, `Handoff fileChanges[${index}].afterHash`);
+    if (entry.operation === "create" && (beforeHash || previousPath || !afterHash)) throw new Error("Handoff create change hash shape is invalid");
+    if (entry.operation === "update" && (!beforeHash || !afterHash || previousPath)) throw new Error("Handoff update change hash shape is invalid");
+    if (entry.operation === "delete" && (!beforeHash || afterHash || previousPath)) throw new Error("Handoff delete change hash shape is invalid");
+    if (entry.operation === "rename" && (!beforeHash || !afterHash || !previousPath || previousPath === path)) throw new Error("Handoff rename change hash shape is invalid");
+    return freeze({ path, ...(previousPath ? { previousPath } : {}), operation: entry.operation, ...(beforeHash ? { beforeHash } : {}), ...(afterHash ? { afterHash } : {}), attribution: entry.attribution as FileChangeRecord["attribution"] });
+  }));
+}
+function parseArtifactRefs(value: unknown): readonly ArtifactReference[] {
+  if (!Array.isArray(value) || value.length > HANDOFF_LIMITS.referenceItems) throw new Error("Handoff artifact refs exceed their limit");
+  return freeze(value.map((entry, index) => {
+    if (!plainRecord(entry)) throw new Error(`Handoff artifactRefs[${index}] is invalid`);
+    exactKeys(entry, ["workspaceId", "checkpoint", "digest"], `Handoff artifactRefs[${index}]`);
+    return freeze({ workspaceId: bounded(entry.workspaceId, "Handoff artifact workspace"), checkpoint: bounded(entry.checkpoint, "Handoff artifact checkpoint"), digest: digest(entry.digest, "Handoff artifact digest") });
+  }));
+}
+function parseEvidenceRefs(value: unknown): readonly EvidenceReference[] {
+  if (!Array.isArray(value) || value.length > HANDOFF_LIMITS.referenceItems) throw new Error("Handoff evidence refs exceed their limit");
+  return freeze(value.map((entry, index) => {
+    if (!plainRecord(entry)) throw new Error(`Handoff evidenceRefs[${index}] is invalid`);
+    const allowed = entry.toolCallId === undefined ? ["kind", "claim"] : ["kind", "toolCallId", "claim"];
+    exactKeys(entry, allowed, `Handoff evidenceRefs[${index}]`);
+    return freeze({ kind: bounded(entry.kind, "Handoff evidence kind"), ...(entry.toolCallId === undefined ? {} : { toolCallId: identifier(entry.toolCallId, "Handoff evidence tool call") }), claim: bounded(entry.claim, "Handoff evidence claim") });
+  }));
+}
+function packetIdentity(packet: Omit<HandoffPacket, "packetHash">): Omit<HandoffPacket, "packetHash"> { return packet; }
+function packetHash(packet: Omit<HandoffPacket, "packetHash">): string {
+  return createHash("sha256").update("pi-hive-handoff-packet-v1\0").update(canonicalJson(packet)).digest("hex");
+}
+
+export interface CreateHandoffPacketInput {
+  readonly projectId: string;
+  readonly workflowId: string;
+  readonly sessionId: string;
+  readonly terminal: PersistedTerminalEnvelope;
+  readonly createdAt?: string;
+}
+export function createHandoffPacket(input: CreateHandoffPacketInput): HandoffPacket {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const identity: Omit<HandoffPacket, "packetHash"> = {
+    formatVersion: HANDOFF_FORMAT_VERSION,
+    createdAt,
+    source: {
+      projectId: input.projectId,
+      workflowId: input.workflowId,
+      sessionId: input.sessionId,
+      runId: input.terminal.runId,
+      snapshotId: input.terminal.snapshotId,
+      terminalEventHash: input.terminal.terminalEventHash,
+    },
+    terminal: { status: input.terminal.status, summary: input.terminal.summary, finishedAt: input.terminal.finishedAt },
+    fileChanges: input.terminal.fileChanges,
+    changeCoverage: input.terminal.changeCoverage,
+    artifactRefsAreCandidates: true,
+    artifactRefs: input.terminal.artifactRefs,
+    evidenceRefs: input.terminal.evidenceRefs,
+    data: input.terminal.data,
+  };
+  return verifyHandoffPacket({ ...identity, packetHash: packetHash(packetIdentity(identity)) }, input.projectId);
+}
+
+export function verifyHandoffPacket(value: unknown, expectedProjectId?: string): HandoffPacket {
+  if (!plainRecord(value)) throw new Error("Handoff packet is invalid");
+  exactKeys(value, ["formatVersion", "packetHash", "createdAt", "source", "terminal", "fileChanges", "changeCoverage", "artifactRefsAreCandidates", "artifactRefs", "evidenceRefs", "data"], "Handoff packet");
+  if (value.formatVersion !== HANDOFF_FORMAT_VERSION) throw new Error("Handoff packet format is unsupported");
+  const hash = digest(value.packetHash, "Handoff packet hash", false);
+  const createdAt = bounded(value.createdAt, "Handoff createdAt");
+  if (!Number.isFinite(Date.parse(createdAt))) throw new Error("Handoff createdAt is invalid");
+  if (!plainRecord(value.source)) throw new Error("Handoff packet source is invalid");
+  exactKeys(value.source, ["projectId", "workflowId", "sessionId", "runId", "snapshotId", "terminalEventHash"], "Handoff source");
+  const source = freeze({
+    projectId: identifier(value.source.projectId, "Handoff source project"),
+    workflowId: identifier(value.source.workflowId, "Handoff source workflow"),
+    sessionId: identifier(value.source.sessionId, "Handoff source session"),
+    runId: identifier(value.source.runId, "Handoff source run"),
+    snapshotId: digest(value.source.snapshotId, "Handoff source snapshot", false),
+    terminalEventHash: digest(value.source.terminalEventHash, "Handoff source terminal event", false),
+  });
+  if (expectedProjectId !== undefined && source.projectId !== expectedProjectId) throw new Error("Handoff packet belongs to a different canonical project");
+  if (!plainRecord(value.terminal)) throw new Error("Handoff terminal is invalid");
+  exactKeys(value.terminal, ["status", "summary", "finishedAt"], "Handoff terminal");
+  if (!new Set(["completed", "blocked", "failed", "cancelled"]).has(String(value.terminal.status))) throw new Error("Handoff terminal status is invalid");
+  const finishedAt = bounded(value.terminal.finishedAt, "Handoff terminal finishedAt");
+  if (!Number.isFinite(Date.parse(finishedAt))) throw new Error("Handoff terminal finishedAt is invalid");
+  const terminal = freeze({ status: value.terminal.status as TerminalRunStatus, summary: bounded(value.terminal.summary, "Handoff terminal summary", HANDOFF_LIMITS.summaryBytes), finishedAt });
+  if (value.artifactRefsAreCandidates !== true) throw new Error("Handoff artifact references must remain non-authoritative candidates");
+  const result: HandoffPacket = {
+    formatVersion: HANDOFF_FORMAT_VERSION,
+    packetHash: hash,
+    createdAt,
+    source,
+    terminal,
+    fileChanges: parseFileChanges(value.fileChanges),
+    changeCoverage: bounded(value.changeCoverage, "Handoff change coverage", 128),
+    artifactRefsAreCandidates: true,
+    artifactRefs: parseArtifactRefs(value.artifactRefs),
+    evidenceRefs: parseEvidenceRefs(value.evidenceRefs),
+    data: jsonData(value.data),
+  };
+  const { packetHash: _packetHash, ...identity } = result;
+  if (packetHash(identity) !== hash) throw new Error("Handoff packet hash mismatch");
+  if (Buffer.byteLength(canonicalJson(result), "utf8") > HANDOFF_LIMITS.packetBytes) throw new Error("Handoff packet exceeds its byte limit");
+  return freeze(result);
+}
+
+/** Verify packet identity against the authoritative linked source journal, not caller-supplied hashes. */
+export function verifyHandoffPacketSource(projectRoot: string, projectId: string, value: unknown): HandoffPacket {
+  const packet = verifyHandoffPacket(value, projectId);
+  const link = listSessionLinks(projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === packet.source.sessionId);
+  if (!link || link.workflowId !== packet.source.workflowId) throw new Error("Handoff source is not linked to the claimed workflow in this project");
+  if (link.activationHash !== packet.source.snapshotId) throw new Error("Handoff source snapshot does not match its linked activation");
+  const events = readWorkflowJournal(projectRoot, link.workflowSessionId);
+  if (!events.length || events.some((event) => event.projectId !== projectId)) throw new Error("Handoff source journal belongs to a different or missing canonical project");
+  replayWorkflowJournal(events, createEmptyRunLifecycleState(link.workflowSessionId), reduceRunLifecycle);
+  const terminalEvents = events.filter((event) => event.type === "terminal.recorded" && event.runId === packet.source.runId);
+  if (terminalEvents.length !== 1) throw new Error("Handoff source run does not have one authoritative terminal event");
+  const terminalEvent = terminalEvents[0];
+  if (terminalEvent.producer !== "harness" || terminalEvent.eventHash !== packet.source.terminalEventHash) throw new Error("Handoff source terminal event hash or authority does not match");
+  const terminal = terminalEnvelopeFromEvent(terminalEvent);
+  const derived = createHandoffPacket({ projectId, workflowId: link.workflowId, sessionId: link.workflowSessionId, terminal, createdAt: terminal.finishedAt });
+  if (canonicalJson(derived) !== canonicalJson(packet)) throw new Error("Handoff packet does not match its authoritative source terminal envelope");
+  return derived;
+}
+
+export function createEmptyHandoffState(): HandoffState { return freeze({ consumed: [] }); }
+function eventPayload(event: WorkflowEventEnvelope): Record<string, unknown> {
+  if (!plainRecord(event.payload) || event.payload.formatVersion !== HANDOFF_FORMAT_VERSION) throw new Error("Handoff event payload is invalid");
+  return event.payload;
+}
+function runStartHandoff(event: WorkflowEventEnvelope): Readonly<{ packetHash: string; inputId: string }> | undefined {
+  if (event.type !== "run.started") return undefined;
+  if (!plainRecord(event.payload) || event.payload.handoffPacketHash === undefined) return undefined;
+  const hash = digest(event.payload.handoffPacketHash, "Run handoff packet hash", false);
+  const input = event.payload.input;
+  if (!plainRecord(input)) throw new Error("Run handoff input is invalid");
+  return freeze({ packetHash: hash, inputId: identifier(input.inputId, "Run handoff input ID") });
+}
+export function reduceHandoffState(state: HandoffState, event: WorkflowEventEnvelope): HandoffState {
+  if (event.type === "handoff.recorded") {
+    if (event.producer !== "harness") throw new Error("Handoff state event lacks harness authority");
+    const payload = eventPayload(event);
+    if (payload.operation === "stage") {
+      const packet = verifyHandoffPacket(payload.packet, event.projectId);
+      if (state.staged) throw new Error("A staged handoff already exists");
+      return freeze({ ...state, staged: packet });
+    }
+    if (payload.operation === "clear") {
+      const expected = digest(payload.packetHash, "Cleared handoff hash", false);
+      if (!state.staged || state.staged.packetHash !== expected) throw new Error("Staged handoff changed before clear");
+      return freeze({ ...state, staged: undefined });
+    }
+    throw new Error("Handoff state operation is unsupported");
+  }
+  const consumed = runStartHandoff(event);
+  if (!consumed) return state;
+  if (event.producer !== "runtime" || !event.runId) throw new Error("Handoff consumption lacks runtime authority");
+  if (!state.staged || state.staged.packetHash !== consumed.packetHash) throw new Error("Run cannot consume a missing or different staged handoff");
+  if (state.consumed.length >= HANDOFF_LIMITS.consumedRecords) throw new Error("Handoff consumption history exceeds its bound");
+  return freeze({ staged: undefined, consumed: [...state.consumed, { packet: state.staged, runId: event.runId, inputId: consumed.inputId, consumedAt: event.timestamp, sequence: event.sequence }] });
+}
+export function restoreHandoffState(events: readonly WorkflowEventEnvelope[]): HandoffState {
+  return events.reduce(reduceHandoffState, createEmptyHandoffState());
+}
+export function readHandoffState(projectRoot: string, targetSessionId: string): HandoffState {
+  return restoreHandoffState(readWorkflowJournal(projectRoot, targetSessionId));
+}
+export function handoffForRun(events: readonly WorkflowEventEnvelope[], runId: string): HandoffPacket | undefined {
+  return restoreHandoffState(events).consumed.find((entry) => entry.runId === runId)?.packet;
+}
+export function readHandoffPacket(projectRoot: string, sessionId: string, packetHashValue: string): HandoffPacket | undefined {
+  digest(packetHashValue, "Handoff packet reference", false);
+  const state = readHandoffState(projectRoot, sessionId);
+  if (state.staged?.packetHash === packetHashValue) return state.staged;
+  return state.consumed.find((entry) => entry.packet.packetHash === packetHashValue)?.packet;
+}
+export function hasOpenRun(events: readonly WorkflowEventEnvelope[]): boolean {
+  let openRunId: string | undefined;
+  for (const event of events) {
+    if (event.type === "run.started") openRunId = event.runId;
+    else if (event.type === "terminal.recorded" && event.runId === openRunId) openRunId = undefined;
+  }
+  return openRunId !== undefined;
+}
+export interface StageHandoffInput extends JournalFaultOptions {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly targetSessionId: string;
+  readonly targetWorkflowId: string;
+  readonly packet: HandoffPacket;
+  readonly now?: () => string;
+}
+export function stageHandoff(input: StageHandoffInput): Readonly<{ staged: boolean; duplicate: boolean; packet: HandoffPacket }> {
+  const packet = verifyHandoffPacketSource(input.projectRoot, input.projectId, input.packet);
+  if (packet.source.workflowId === input.targetWorkflowId) throw new Error("Handoff target must be a different workflow");
+  const initial = readWorkflowJournal(input.projectRoot, input.targetSessionId);
+  if (hasOpenRun(initial)) throw new Error("Target workflow session must be idle before handoff staging");
+  const existing = restoreHandoffState(initial).staged;
+  if (existing?.packetHash === packet.packetHash) return freeze({ staged: false, duplicate: true, packet: existing });
+  if (existing) throw new Error("Target workflow session has a conflicting staged handoff");
+  appendWorkflowEventChecked(input.projectRoot, createWorkflowEvent({
+    projectId: input.projectId, sessionId: input.targetSessionId, type: "handoff.recorded",
+    payload: { formatVersion: HANDOFF_FORMAT_VERSION, operation: "stage", targetWorkflowId: input.targetWorkflowId, packet: packet as unknown as JsonValue },
+    producer: "harness", timestamp: input.now?.() ?? new Date().toISOString(),
+  }), (events) => {
+    handoffInvariant(!hasOpenRun(events), "Target workflow session opened a run before handoff staging");
+    const locked = restoreHandoffState(events).staged;
+    handoffInvariant(!locked, locked?.packetHash === packet.packetHash ? "Handoff packet was staged concurrently" : "Target workflow session has a conflicting staged handoff");
+  }, { fault: input.fault });
+  return freeze({ staged: true, duplicate: false, packet });
+}
+export function clearStagedHandoff(input: { projectRoot: string; projectId: string; targetSessionId: string; expectedPacketHash?: string; now?: () => string } & JournalFaultOptions): Readonly<{ cleared: boolean; packetHash?: string }> {
+  const initial = readWorkflowJournal(input.projectRoot, input.targetSessionId);
+  if (hasOpenRun(initial)) throw new Error("Target workflow session must be idle before clearing a staged handoff");
+  const staged = restoreHandoffState(initial).staged;
+  if (!staged) return freeze({ cleared: false });
+  if (input.expectedPacketHash !== undefined && staged.packetHash !== input.expectedPacketHash) throw new Error("Staged handoff changed before clear");
+  appendWorkflowEventChecked(input.projectRoot, createWorkflowEvent({
+    projectId: input.projectId, sessionId: input.targetSessionId, type: "handoff.recorded",
+    payload: { formatVersion: HANDOFF_FORMAT_VERSION, operation: "clear", packetHash: staged.packetHash },
+    producer: "harness", timestamp: input.now?.() ?? new Date().toISOString(),
+  }), (events) => {
+    handoffInvariant(!hasOpenRun(events), "Target workflow session opened a run before handoff clear");
+    handoffInvariant(restoreHandoffState(events).staged?.packetHash === staged.packetHash, "Staged handoff changed before clear");
+  }, { fault: input.fault });
+  return freeze({ cleared: true, packetHash: staged.packetHash });
+}
+export function handoffPromptInput(packet: HandoffPacket): DynamicPromptInput {
+  const verified = verifyHandoffPacket(packet);
+  return freeze({
+    source: "handoff",
+    provenance: `handoff:${verified.packetHash}:${verified.source.workflowId}:${verified.source.runId}`,
+    content: verified,
+    ref: `workflow_status:handoff?packetHash=${verified.packetHash}`,
+  });
+}

--- a/src/workflows/journal.ts
+++ b/src/workflows/journal.ts
@@ -38,22 +38,27 @@ export function readWorkflowJournal(projectRoot: string, sessionId: string): rea
   for (let index = 0; index < events.length; index += 1) { const event = events[index]; if (event.sequence !== index + 1) throw new Error("Workflow journal sequence gap or duplicate"); if (event.previousHash !== previous) throw new Error("Workflow journal previous hash mismatch"); if (event.sessionId !== sessionId || (projectId !== undefined && event.projectId !== projectId)) throw new Error("Workflow journal identity mismatch"); const expectedName = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; if (names[index] !== expectedName) throw new Error("Workflow journal filename/hash mismatch"); projectId = event.projectId; previous = event.eventHash; }
   return Object.freeze(events);
 }
+export function withWorkflowJournalTransaction<T>(projectRoot: string, sessionId: string, transact: (events: readonly WorkflowEventEnvelope[]) => T): T {
+  const dir = journalDirectory(projectRoot, sessionId);
+  ensureDirectory(dir);
+  return withCrossProcessFileLock(join(dir, "append"), () => transact(readWorkflowJournal(projectRoot, sessionId)), { timeoutMs: 5_000, staleMs: 30_000 });
+}
 export function appendWorkflowEventChecked(
   projectRoot: string,
   draft: WorkflowEventDraft,
   check: (events: readonly WorkflowEventEnvelope[]) => void,
   options: JournalFaultOptions = {},
 ): WorkflowEventEnvelope {
-  const dir = journalDirectory(projectRoot, draft.sessionId); ensureDirectory(dir); const lockResource = join(dir, "append");
-  return withCrossProcessFileLock(lockResource, () => {
-    const existing = readWorkflowJournal(projectRoot, draft.sessionId); if (existing.some((event) => event.eventId === draft.eventId)) throw new Error("Workflow journal duplicate event ID"); if (existing.length && existing[0].projectId !== draft.projectId) throw new Error("Workflow journal project identity mismatch");
+  const dir = journalDirectory(projectRoot, draft.sessionId);
+  return withWorkflowJournalTransaction(projectRoot, draft.sessionId, (existing) => {
+    if (existing.some((event) => event.eventId === draft.eventId)) throw new Error("Workflow journal duplicate event ID"); if (existing.length && existing[0].projectId !== draft.projectId) throw new Error("Workflow journal project identity mismatch");
     check(existing);
     const last = existing.at(-1); const event = sealWorkflowEvent(draft, existing.length + 1, last?.eventHash ?? null); const content = `${canonicalJson(event)}\n`;
     const name = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; const target = join(dir, name); const temp = join(dir, `.${name}.${process.pid}.${randomUUID()}.tmp`); let fd: number | undefined;
     try {
       options.fault?.("beforeWrite"); fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; options.fault?.("afterFileFsync"); options.fault?.("beforeRename"); renameSync(temp, target); options.fault?.("afterRename"); options.fault?.("beforeDirFsync"); fsyncDirectory(dir); return event;
     } finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } }
-  }, { timeoutMs: 5_000, staleMs: 30_000 });
+  });
 }
 export function appendWorkflowEvent(projectRoot: string, draft: WorkflowEventDraft, options: JournalFaultOptions = {}): WorkflowEventEnvelope {
   return appendWorkflowEventChecked(projectRoot, draft, () => {}, options);

--- a/src/workflows/navigation.ts
+++ b/src/workflows/navigation.ts
@@ -1,14 +1,20 @@
 import { randomUUID } from "node:crypto";
 import { acquireRuntimeOwnership, heartbeatRuntimeOwnership, releaseRuntimeOwnership, type AcquireOwnershipOptions } from "./ownership";
-import { appendWorkflowEvent } from "./journal";
-import { createWorkflowEvent } from "./events";
+import { appendWorkflowEvent, readWorkflowJournal, withWorkflowJournalTransaction } from "./journal";
+import { createWorkflowEvent, type WorkflowEventEnvelope } from "./events";
 import { commitWorkflowSelection, listSessionLinks, type NormalSessionLink, type WorkflowSessionLink } from "./sessions";
+import { createEmptyRunLifecycleState, reduceRunLifecycle, terminalEnvelopeFromEvent } from "./runs";
+import { replayWorkflowJournal } from "./replay";
+import { clearStagedHandoff, createHandoffPacket, hasOpenRun, readHandoffState, restoreHandoffState, stageHandoff, verifyHandoffPacketSource, type HandoffPacket } from "./handoff";
 
 export interface SelectableWorkflow { readonly workflowId: string; readonly activationHash: string; readonly source: "current" | "stale" | "missing" | "invalid"; readonly resumable: boolean; readonly freshEnabled: boolean; readonly model: string; readonly thinking: string; readonly tools: readonly string[] }
-export interface SessionNavigationAdapter { create(input: { parentSession: string; name: string; workflowId: string; activationHash: string }): Promise<{ piSessionId: string; piSessionFile: string }>; switch(input: { piSessionFile: string; withSession: (ctx: unknown) => Promise<void> | void }): Promise<{ cancelled: boolean }> }
-export interface SelectionInput { projectRoot: string; projectId: string; currentPiSessionId: string; workflow: SelectableWorkflow; fresh?: boolean; adapter: SessionNavigationAdapter; owner: AcquireOwnershipOptions & { nonce: string } }
+export interface CreatedNavigationSession { readonly piSessionId: string; readonly piSessionFile: string; /** Restore the Pi session active before creation if the durable CAS does not commit. */ readonly compensate?: () => void | Promise<void> }
+export interface SessionNavigationAdapter { create(input: { parentSession: string; restoreSession?: string; name: string; workflowId: string; activationHash: string; recovery?: Readonly<{ workflowSessionId: string; previousPiSessionId: string; previousPiSessionFile: string }> }): Promise<CreatedNavigationSession>; switch(input: { piSessionFile: string; withSession: (ctx: unknown) => Promise<void> | void }): Promise<{ cancelled: boolean }> }
+interface ReloadSourceGuard { readonly workflowSessionId: string; readonly workflowId: string; readonly piSessionId: string; readonly activationHash: string; readonly eventCount: number; readonly lastEventHash: string | null; readonly stagedPacketHash?: string }
+export interface SelectionInput { projectRoot: string; projectId: string; currentPiSessionId: string; workflow: SelectableWorkflow; fresh?: boolean; stagedHandoff?: HandoffPacket; adapter: SessionNavigationAdapter; owner: AcquireOwnershipOptions & { nonce: string }; /** Reload's second source-validation phase, run after Pi-session creation and immediately before the link CAS. */ beforeCommit?: () => void | Promise<void>; /** Internal reload CAS guard captured before asynchronous activation preparation. */ reloadGuard?: ReloadSourceGuard }
 export type SelectionResult = Readonly<{ kind: "created" | "resumed"; link: WorkflowSessionLink }>;
-function normalLink(root: string): NormalSessionLink { const normal = listSessionLinks(root).find((entry): entry is NormalSessionLink => entry.kind === "normal"); if (!normal) throw new Error("Canonical normal parent is missing"); return normal; }
+function navigationInvariant(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(message); }
+function normalLink(root: string): NormalSessionLink { const normal = listSessionLinks(root).find((entry): entry is NormalSessionLink => entry.kind === "normal"); navigationInvariant(normal, "Canonical normal parent is missing"); return normal; }
 function own(root: string, id: string, owner: SelectionInput["owner"]): "existing" | "acquired" {
   try { if (heartbeatRuntimeOwnership(root, id, owner.nonce)) return "existing"; }
   catch (error: unknown) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
@@ -17,31 +23,169 @@ function own(root: string, id: string, owner: SelectionInput["owner"]): "existin
   return "acquired";
 }
 function event(root: string, projectId: string, sessionId: string, type: "session.created" | "session.linked" | "session.selected", payload: Record<string, string | boolean>): void { appendWorkflowEvent(root, createWorkflowEvent({ projectId, sessionId, type, payload, producer: "runtime" })); }
+function reloadGuardFor(link: WorkflowSessionLink, events: readonly WorkflowEventEnvelope[], stagedPacketHash?: string): ReloadSourceGuard {
+  return Object.freeze({ workflowSessionId: link.workflowSessionId, workflowId: link.workflowId, piSessionId: link.piSessionId, activationHash: link.activationHash, eventCount: events.length, lastEventHash: events.at(-1)?.eventHash ?? null, ...(stagedPacketHash ? { stagedPacketHash } : {}) });
+}
+function assertReloadGuard(projectRoot: string, guard: ReloadSourceGuard, events?: readonly WorkflowEventEnvelope[]): WorkflowSessionLink {
+  const current = listSessionLinks(projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowId === guard.workflowId && entry.status === "current");
+  navigationInvariant(current && current.workflowSessionId === guard.workflowSessionId && current.piSessionId === guard.piSessionId && current.activationHash === guard.activationHash, "Reload source session changed before compare-and-swap commit");
+  const journal = events ?? readWorkflowJournal(projectRoot, guard.workflowSessionId);
+  navigationInvariant(journal.length === guard.eventCount && (journal.at(-1)?.eventHash ?? null) === guard.lastEventHash && !hasOpenRun(journal), "Reload source run or journal changed before compare-and-swap commit");
+  navigationInvariant(restoreHandoffState(journal).staged?.packetHash === guard.stagedPacketHash, "Reload source staged handoff changed before compare-and-swap commit");
+  return current;
+}
 export async function selectWorkflowSession(input: SelectionInput): Promise<SelectionResult> {
-  const normal = normalLink(input.projectRoot); const links = listSessionLinks(input.projectRoot); const current = links.find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowId === input.workflow.workflowId && entry.status === "current");
+  const normal = normalLink(input.projectRoot);
+  navigationInvariant(normal.projectId === input.projectId, "Selection project identity does not match the canonical normal parent");
+  const links = listSessionLinks(input.projectRoot); const current = links.find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowId === input.workflow.workflowId && entry.status === "current");
+  const packet = input.stagedHandoff ? verifyHandoffPacketSource(input.projectRoot, input.projectId, input.stagedHandoff) : undefined;
+  if (input.reloadGuard) assertReloadGuard(input.projectRoot, input.reloadGuard);
+  navigationInvariant(packet?.source.workflowId !== input.workflow.workflowId, "Handoff target must be a different workflow");
+  if (packet && current) {
+    const currentEvents = readWorkflowJournal(input.projectRoot, current.workflowSessionId);
+    navigationInvariant(!hasOpenRun(currentEvents), "Existing target workflow session has an open run");
+    const staged = readHandoffState(input.projectRoot, current.workflowSessionId).staged;
+    if (staged && staged.packetHash !== packet.packetHash) throw new Error("Target workflow session has a conflicting staged handoff");
+  }
   if (!input.fresh && current) {
     if (!input.workflow.resumable || current.activationHash !== input.workflow.activationHash) throw new Error("Workflow activation is not resumable or compatible");
     const ownership = own(input.projectRoot, current.workflowSessionId, input.owner);
-    const result = await input.adapter.switch({ piSessionFile: current.piSessionFile, withSession: async () => {} });
-    if (result.cancelled) { if (ownership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce); throw new Error("Session switch cancelled"); }
+    let staged: ReturnType<typeof stageHandoff> | undefined;
+    try {
+      staged = packet ? stageHandoff({ projectRoot: input.projectRoot, projectId: input.projectId, targetSessionId: current.workflowSessionId, targetWorkflowId: current.workflowId, packet }) : undefined;
+      const result = await input.adapter.switch({ piSessionFile: current.piSessionFile, withSession: async () => {} });
+      if (result.cancelled) throw new Error("Session switch cancelled");
+    } catch (error) {
+      if (ownership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce);
+      if (staged?.staged) clearStagedHandoff({ projectRoot: input.projectRoot, projectId: input.projectId, targetSessionId: current.workflowSessionId, expectedPacketHash: packet!.packetHash });
+      throw error;
+    }
     event(input.projectRoot, input.projectId, current.workflowSessionId, "session.selected", { resumed: true }); return Object.freeze({ kind: "resumed", link: current });
   }
   if (input.workflow.source !== "current" || !input.workflow.freshEnabled) throw new Error("Fresh selection blocked by invalid or stale source");
   const previousOwnership = current ? own(input.projectRoot, current.workflowSessionId, input.owner) : undefined;
-  const workflowSessionId = `workflow-${randomUUID()}`; own(input.projectRoot, workflowSessionId, input.owner); let created: { piSessionId: string; piSessionFile: string };
-  try { created = await input.adapter.create({ parentSession: normal.piSessionFile, name: `hive:${input.workflow.workflowId}:${input.workflow.activationHash.slice(0, 8)}`, workflowId: input.workflow.workflowId, activationHash: input.workflow.activationHash }); }
-  catch (error) { releaseRuntimeOwnership(input.projectRoot, workflowSessionId, input.owner.nonce); if (current && previousOwnership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce); throw error; }
+  const workflowSessionId = `workflow-${randomUUID()}`;
+  own(input.projectRoot, workflowSessionId, input.owner);
+  let created: CreatedNavigationSession;
+  const restoreSession = links.find((entry) => entry.piSessionId === input.currentPiSessionId)?.piSessionFile;
+  try {
+    created = await input.adapter.create({ parentSession: normal.piSessionFile, ...(restoreSession ? { restoreSession } : {}), name: `hive:${input.workflow.workflowId}:${input.workflow.activationHash.slice(0, 8)}`, workflowId: input.workflow.workflowId, activationHash: input.workflow.activationHash });
+  } catch (error) {
+    releaseRuntimeOwnership(input.projectRoot, workflowSessionId, input.owner.nonce);
+    if (current && previousOwnership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce);
+    throw error;
+  }
   const now = new Date().toISOString(); const link: WorkflowSessionLink = Object.freeze({ kind: "workflow", formatVersion: 1, workflowSessionId, workflowId: input.workflow.workflowId, activationHash: input.workflow.activationHash, piSessionId: created.piSessionId, piSessionFile: created.piSessionFile, normalParentId: normal.piSessionId, normalParentFile: normal.piSessionFile, status: "current", stale: false, model: input.workflow.model, thinking: input.workflow.thinking, tools: [...new Set(input.workflow.tools)].sort(), createdAt: now, updatedAt: now, name: `hive:${input.workflow.workflowId}:${input.workflow.activationHash.slice(0, 8)}` });
   const archived = current ? Object.freeze({ ...current, status: "archived" as const, name: `${current.name}:archived:${current.activationHash.slice(0, 8)}`, updatedAt: now }) : undefined;
-  try { commitWorkflowSelection(input.projectRoot, input.workflow.workflowId, current?.workflowSessionId, archived, link); }
-  catch (error) { releaseRuntimeOwnership(input.projectRoot, workflowSessionId, input.owner.nonce); if (current && previousOwnership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce); throw error; }
-  if (current && !releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce)) throw new Error("Previous runtime ownership could not be released");
+  let staged: ReturnType<typeof stageHandoff> | undefined;
+  try {
+    await input.beforeCommit?.();
+    const commit = (): void => {
+      if (packet) staged = stageHandoff({ projectRoot: input.projectRoot, projectId: input.projectId, targetSessionId: workflowSessionId, targetWorkflowId: input.workflow.workflowId, packet });
+      commitWorkflowSelection(input.projectRoot, input.workflow.workflowId, current?.workflowSessionId, archived, link);
+    };
+    if (input.reloadGuard) {
+      withWorkflowJournalTransaction(input.projectRoot, input.reloadGuard.workflowSessionId, (events) => {
+        assertReloadGuard(input.projectRoot, input.reloadGuard!, events);
+        commit();
+      });
+    } else commit();
+  } catch (error) {
+    const cleanupErrors: unknown[] = [];
+    if (staged?.staged) {
+      try { clearStagedHandoff({ projectRoot: input.projectRoot, projectId: input.projectId, targetSessionId: workflowSessionId, expectedPacketHash: packet!.packetHash }); }
+      catch (cleanupError) { cleanupErrors.push(new Error(`staged handoff compensation failed: ${String(cleanupError instanceof Error ? cleanupError.message : cleanupError)}`)); }
+    }
+    releaseRuntimeOwnership(input.projectRoot, workflowSessionId, input.owner.nonce);
+    if (current && previousOwnership === "acquired") releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce);
+    if (created.compensate) {
+      try { await created.compensate(); }
+      catch (cleanupError) { cleanupErrors.push(new Error(`Pi session compensation failed: ${String(cleanupError instanceof Error ? cleanupError.message : cleanupError)}`)); }
+    }
+    if (cleanupErrors.length) throw new AggregateError([error, ...cleanupErrors], "Workflow selection failed and compensation was incomplete");
+    throw error;
+  }
+  navigationInvariant(!current || releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.owner.nonce), "Previous runtime ownership could not be released");
   event(input.projectRoot, input.projectId, workflowSessionId, "session.created", { workflowId: input.workflow.workflowId }); event(input.projectRoot, input.projectId, workflowSessionId, "session.linked", { normalParentId: normal.piSessionId }); return Object.freeze({ kind: "created", link });
 }
+export interface ResolveHandoffSourceInput {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly runId: string | "last";
+  readonly currentPiSessionId: string;
+}
+export function resolveHandoffSource(input: ResolveHandoffSourceInput): HandoffPacket {
+  const normal = normalLink(input.projectRoot);
+  navigationInvariant(normal.projectId === input.projectId, "Handoff source belongs to a different canonical project");
+  const workflowLinks = listSessionLinks(input.projectRoot).filter((entry): entry is WorkflowSessionLink => entry.kind === "workflow");
+  const candidates = input.runId === "last"
+    ? (() => {
+        const selected = workflowLinks.find((entry) => entry.piSessionId === input.currentPiSessionId);
+        if (!selected) throw new Error("Handoff 'last' requires a currently selected source workflow; normal chat must use an explicit run ID");
+        return [selected];
+      })()
+    : workflowLinks;
+  const matches: Array<{ link: WorkflowSessionLink; terminal: ReturnType<typeof terminalEnvelopeFromEvent>; sequence: number }> = [];
+  let sawNonterminal = false;
+  for (const link of candidates) {
+    const events = readWorkflowJournal(input.projectRoot, link.workflowSessionId);
+    navigationInvariant(!events.some((event) => event.projectId !== input.projectId), "Handoff source journal belongs to a different canonical project");
+    replayWorkflowJournal(events, createEmptyRunLifecycleState(link.workflowSessionId), reduceRunLifecycle);
+    const terminals = events.filter((event) => event.type === "terminal.recorded" && event.runId);
+    if (input.runId === "last") {
+      const latest = terminals.at(-1);
+      if (latest) matches.push({ link, terminal: terminalEnvelopeFromEvent(latest), sequence: latest.sequence });
+      else sawNonterminal = events.some((event) => event.type === "run.started");
+      continue;
+    }
+    const terminal = terminals.find((event) => event.runId === input.runId);
+    if (terminal) matches.push({ link, terminal: terminalEnvelopeFromEvent(terminal), sequence: terminal.sequence });
+    else if (events.some((event) => event.type === "run.started" && event.runId === input.runId)) sawNonterminal = true;
+  }
+  navigationInvariant(matches.length, sawNonterminal ? "Handoff source run is not terminal" : "Handoff source run is missing");
+  navigationInvariant(matches.length === 1, "Handoff source run ID is ambiguous within the project");
+  const match = matches.sort((left, right) => right.sequence - left.sequence)[0];
+  navigationInvariant(match.terminal.snapshotId === match.link.activationHash, "Handoff source terminal snapshot does not match its linked activation");
+  return createHandoffPacket({ projectId: input.projectId, workflowId: match.link.workflowId, sessionId: match.link.workflowSessionId, terminal: match.terminal, createdAt: match.terminal.finishedAt });
+}
+
+export interface PreparedReloadActivation {
+  readonly workflow: SelectableWorkflow;
+  /** Re-probe the prepared source identity after Pi session creation and before the link CAS. */
+  readonly validateBeforeCommit?: () => void | Promise<void>;
+}
+export interface ReloadWorkflowSessionInput {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly currentPiSessionId: string;
+  readonly adapter: SessionNavigationAdapter;
+  readonly owner: AcquireOwnershipOptions & { nonce: string };
+  readonly prepareActivation: () => PreparedReloadActivation | Promise<PreparedReloadActivation>;
+}
+export async function reloadWorkflowSession(input: ReloadWorkflowSessionInput): Promise<SelectionResult> {
+  const current = listSessionLinks(input.projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.status === "current" && entry.piSessionId === input.currentPiSessionId);
+  if (!current) throw new Error("Reload requires the currently selected workflow session");
+  const events = readWorkflowJournal(input.projectRoot, current.workflowSessionId);
+  if (hasOpenRun(events)) throw new Error("Reload requires an idle workflow session");
+  const staged = restoreStagedForReload(input.projectRoot, current.workflowSessionId);
+  const guard = reloadGuardFor(current, events, staged?.packetHash);
+  const prepared = await input.prepareActivation();
+  if (prepared.workflow.workflowId !== current.workflowId || prepared.workflow.source !== "current" || !prepared.workflow.freshEnabled) throw new Error("Reload activation validation did not produce a current fresh-compatible workflow");
+  assertReloadGuard(input.projectRoot, guard);
+  return selectWorkflowSession({
+    projectRoot: input.projectRoot, projectId: input.projectId, currentPiSessionId: input.currentPiSessionId,
+    workflow: prepared.workflow, fresh: true, ...(staged ? { stagedHandoff: staged } : {}), adapter: input.adapter, owner: input.owner, reloadGuard: guard,
+    ...(prepared.validateBeforeCommit ? { beforeCommit: prepared.validateBeforeCommit } : {}),
+  });
+}
+function restoreStagedForReload(projectRoot: string, sessionId: string): HandoffPacket | undefined {
+  return readHandoffState(projectRoot, sessionId).staged;
+}
+
 export async function exitWorkflowSession(input: { projectRoot: string; currentPiSessionId: string; ownerNonce: string; adapter: SessionNavigationAdapter }): Promise<{ piSessionId: string; activeTools: readonly string[] }> {
   const links = listSessionLinks(input.projectRoot); const current = links.find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.piSessionId === input.currentPiSessionId); const normal = normalLink(input.projectRoot);
   if (current && !heartbeatRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.ownerNonce)) throw new Error("Runtime ownership does not match exit request");
   const result = await input.adapter.switch({ piSessionFile: normal.piSessionFile, withSession: async () => {} }); if (result.cancelled) throw new Error("Session switch cancelled");
-  if (current && !releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.ownerNonce)) throw new Error("Runtime ownership release failed");
+  navigationInvariant(!current || releaseRuntimeOwnership(input.projectRoot, current.workflowSessionId, input.ownerNonce), "Runtime ownership release failed");
   return Object.freeze({ piSessionId: normal.piSessionId, activeTools: normal.normalTools });
 }

--- a/src/workflows/orchestration.ts
+++ b/src/workflows/orchestration.ts
@@ -56,6 +56,8 @@ import {
   buildCompactionPreservationBlock,
   type WorkflowPromptAssembly,
 } from "./prompts";
+import { readWorkflowJournal } from "./journal";
+import { handoffForRun, handoffPromptInput } from "./handoff";
 import {
   buildWorkflowStatusPage,
   issueWorkflowToolRuntimeBinding,
@@ -241,11 +243,14 @@ export class RunOrchestrationService {
   private rootPromptAssembly(runId?: string): WorkflowPromptAssembly {
     const run = this.lifecycle.restore().latestRun;
     if (!run || (runId !== undefined && run.runId !== runId)) throw new Error("Root prompt requires the current workflow run");
+    const handoff = run.handoffPacketHash ? handoffForRun(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), run.runId) : undefined;
+    if (run.handoffPacketHash && handoff?.packetHash !== run.handoffPacketHash) throw new Error("Consumed handoff packet is missing or does not match the run marker");
     return assembleRootWorkflowPrompt({
       snapshot: this.options.snapshot,
       nodeId: rootNodeId(this.options.snapshot),
       sessionId: this.options.sessionId,
       runId: run.runId,
+      ...(handoff ? { handoff: handoffPromptInput(handoff) } : {}),
       runInputs: run.inputs.map((entry) => ({
         source: "user" as const,
         provenance: `run-input:${entry.sequence}:${entry.source}`,
@@ -658,11 +663,16 @@ export class RunOrchestrationService {
           team: bound,
           workflowStatus: (input) => {
             assertCurrent();
+            const lifecycle = this.lifecycle.restore();
+            const run = lifecycle.latestRun;
+            const handoff = run?.handoffPacketHash ? handoffForRun(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), run.runId) : undefined;
+            if (run?.handoffPacketHash && handoff?.packetHash !== run.handoffPacketHash) throw new Error("Consumed handoff packet is missing or does not match the run marker");
             return buildWorkflowStatusPage({
               snapshot: this.options.snapshot,
-              lifecycle: this.lifecycle.restore(),
+              lifecycle,
               budget: resources.budgets.restore(),
               delegation: resources.runtime.restore(),
+              ...(handoff ? { handoff } : {}),
             }, input);
           },
           finish: (input, batch) => this.lifecycle.finish(input, { callerNodeId: context.nodeId, toolBatch: batch }),

--- a/src/workflows/recovery.ts
+++ b/src/workflows/recovery.ts
@@ -1,6 +1,17 @@
+import { lstatSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { withCrossProcessFileLock } from "../core/file-lock";
 import type { JsonValue } from "../config/types";
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import { validateSnapshotResumeCompatibility, type SnapshotCompatibilityRuntime } from "../config/snapshot-compat";
+import { readActivationSnapshot } from "../config/snapshot-store";
 import { type AttemptEffect, type AttemptResult, type AttemptRuntime, type PersistedAttempt } from "./attempts";
 import { deepFreeze, utf8Prefix } from "./values";
+import { createWorkflowEvent, type WorkflowEventEnvelope } from "./events";
+import { appendWorkflowEventChecked, readWorkflowJournal, workflowSessionDirectory, type JournalFaultStage } from "./journal";
+import type { SessionNavigationAdapter } from "./navigation";
+import { acquireRuntimeOwnership, releaseRuntimeOwnership, type AcquireOwnershipOptions } from "./ownership";
+import { commitWorkflowRecovery, listSessionLinks, markMissingPiSession, prepareWorkflowRecoveryLink, recordWorkflowRecoveryBlocked, rollbackWorkflowRecovery, sameWorkflowLinkGeneration, workflowLinkGenerationHash, type WorkflowSessionLink } from "./sessions";
 
 export type SideEffectReconciliation =
   | Readonly<{ state: "applied" | "not-applied"; result: AttemptResult }>
@@ -23,6 +34,9 @@ export interface UnknownSideEffectRecoveryReport {
 function boundedDiagnostic(value: unknown): string {
   const text = String(value instanceof Error ? value.message : value) || "reconciliation returned no diagnostic";
   return Buffer.byteLength(text, "utf8") <= 8_192 ? text : Buffer.from(text).subarray(0, 8_192).toString("utf8");
+}
+function recoveryInvariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
 }
 
 /**
@@ -83,4 +97,314 @@ export function reconcileExpectedHashes(input: HashReconciliationInput): SideEff
     return Object.freeze({ state: "not-applied", result: Object.freeze({ ok: false, error: "effect was proven not applied" }) });
   }
   return Object.freeze({ state: "unknown", diagnostic: "current state matches neither the recorded before nor expected after hash" });
+}
+
+export interface OrphanDetectionResult {
+  readonly workflowSessionId: string;
+  readonly workflowId: string;
+  readonly piSessionId: string;
+  readonly piSessionFile: string;
+  readonly orphaned: true;
+}
+function missingOrUnsupportedPiSession(path: string): boolean {
+  try { const stat = lstatSync(path); return !stat.isFile() || stat.isSymbolicLink(); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return true; throw error; }
+}
+export function detectOrphanedWorkflowSessions(input: { projectRoot: string; projectId: string }): readonly OrphanDetectionResult[] {
+  reconcilePreparedWorkflowRecoveries(input);
+  const results: OrphanDetectionResult[] = [];
+  for (const link of listSessionLinks(input.projectRoot)) {
+    if (link.kind !== "workflow") continue;
+    if (link.orphaned === true || missingOrUnsupportedPiSession(link.piSessionFile)) {
+      if (link.orphaned !== true) markMissingPiSession(input.projectRoot, input.projectId, link.workflowSessionId);
+      results.push(Object.freeze({ workflowSessionId: link.workflowSessionId, workflowId: link.workflowId, piSessionId: link.piSessionId, piSessionFile: link.piSessionFile, orphaned: true }));
+    }
+  }
+  return Object.freeze(results);
+}
+
+export interface RecoveryActivationValidation { readonly ok: boolean; readonly codes: readonly string[] }
+function validateRecoverySnapshot(snapshot: ActivationSnapshotFileV1, input: RecoverOrphanedWorkflowSessionInput, link: WorkflowSessionLink): RecoveryActivationValidation {
+  const compatibility = validateSnapshotResumeCompatibility(snapshot, input.runtime);
+  const codes = [
+    ...compatibility.codes,
+    ...(snapshot.snapshotHash === link.activationHash ? [] : ["SNAPSHOT_ACTIVATION_IDENTITY_MISMATCH"]),
+    ...(snapshot.payload.project.projectId === input.projectId ? [] : ["SNAPSHOT_PROJECT_IDENTITY_MISMATCH"]),
+    ...(snapshot.payload.workflow.id === link.workflowId ? [] : ["SNAPSHOT_WORKFLOW_IDENTITY_MISMATCH"]),
+  ];
+  return Object.freeze({ ok: codes.length === 0, codes: Object.freeze([...new Set(codes)].sort()) });
+}
+export interface RecoverOrphanedWorkflowSessionInput {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly workflowSessionId: string;
+  readonly adapter: SessionNavigationAdapter;
+  readonly owner: AcquireOwnershipOptions & { nonce: string };
+  /** Runtime/model/knowledge/artifact/workspace probes are mandatory recovery authority. */
+  readonly runtime: SnapshotCompatibilityRuntime;
+  /** Pi session that was active before recovery and must be restored on failure. */
+  readonly restorePiSessionFile: string;
+  /** Additional policy may only narrow the mandatory compatibility decision. */
+  readonly validateActivation?: (snapshot: ActivationSnapshotFileV1) => RecoveryActivationValidation;
+  /** Fault-injection seam for transactional recovery tests. */
+  readonly journalFault?: (stage: JournalFaultStage) => void;
+  /** Process-crash seam. Tests may terminate the process at a durable protocol boundary. */
+  readonly recoveryFault?: (stage: RecoveryFaultStage) => void;
+}
+export type RecoveryFaultStage = "afterPrepared" | "afterLinkPrepared" | "afterCommitted";
+function withRecoverySettlementLock<T>(projectRoot: string, workflowSessionId: string, settle: () => T): T {
+  const directory = workflowSessionDirectory(projectRoot, workflowSessionId);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  return withCrossProcessFileLock(join(directory, "recovery-settlement"), settle, { timeoutMs: 35_000, staleMs: 30_000 });
+}
+function orphanLink(input: RecoverOrphanedWorkflowSessionInput): WorkflowSessionLink {
+  const link = listSessionLinks(input.projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === input.workflowSessionId);
+  recoveryInvariant(link, "Orphan workflow session link is missing");
+  recoveryInvariant(link.formatVersion === 1, "Workflow runtime contract is unsupported; recovery is blocked");
+  recoveryInvariant(link.orphaned === true, "Workflow session is not marked orphaned");
+  return link;
+}
+function eventPayload(event: { payload: unknown }): Record<string, unknown> | undefined {
+  return event.payload && typeof event.payload === "object" && !Array.isArray(event.payload) ? event.payload as Record<string, unknown> : undefined;
+}
+function preparedReference(event: { type: string; payload: unknown }): string | undefined {
+  if (event.type !== "session.recovered" && event.type !== "session.orphaned") return undefined;
+  const payload = eventPayload(event);
+  return typeof payload?.preparedEventHash === "string" ? payload.preparedEventHash : undefined;
+}
+function isPublishedRecoveryRollback(event: { type: string; payload: unknown }, preparedEventHash: string): boolean {
+  return event.type === "session.orphaned" && preparedReference(event) === preparedEventHash && eventPayload(event)?.rolledBack === true;
+}
+function committedFor(events: readonly WorkflowEventEnvelope[], preparedEventHash: string): WorkflowEventEnvelope | undefined {
+  return events.find((event) => event.type === "session.recovered" && preparedReference(event) === preparedEventHash);
+}
+function preparedPayload(event: WorkflowEventEnvelope): { expected: WorkflowSessionLink; piSessionId: string; piSessionFile: string; preparedAt: string } | undefined {
+  // Every caller obtains this envelope from a session.recovery.prepared-only path.
+  const payload = eventPayload(event);
+  const expected = payload?.expectedLink as WorkflowSessionLink | undefined;
+  if (!expected || expected.kind !== "workflow" || expected.formatVersion !== 1 || expected.workflowSessionId !== event.sessionId) return undefined;
+  if (payload?.expectedLinkHash !== workflowLinkGenerationHash(expected)) return undefined;
+  if (typeof payload.piSessionId !== "string" || typeof payload.piSessionFile !== "string" || typeof payload.preparedAt !== "string" || !Number.isFinite(Date.parse(payload.preparedAt))) return undefined;
+  if (payload.previousPiSessionId !== expected.piSessionId || payload.previousPiSessionFile !== expected.piSessionFile || payload.activationHash !== expected.activationHash) return undefined;
+  return { expected, piSessionId: payload.piSessionId, piSessionFile: payload.piSessionFile, preparedAt: payload.preparedAt };
+}
+function preparedLinkGeneration(prepared: WorkflowEventEnvelope, parsed: NonNullable<ReturnType<typeof preparedPayload>>): WorkflowSessionLink {
+  return {
+    ...parsed.expected, piSessionId: parsed.piSessionId, piSessionFile: parsed.piSessionFile, orphaned: true,
+    recovery: {
+      state: "prepared", previousPiSessionId: parsed.expected.piSessionId, previousPiSessionFile: parsed.expected.piSessionFile,
+      preparedAt: parsed.preparedAt, preparedEventHash: prepared.eventHash, expectedLinkHash: workflowLinkGenerationHash(parsed.expected),
+    },
+    updatedAt: parsed.preparedAt,
+  };
+}
+function preparedLinkMatches(link: WorkflowSessionLink, prepared: WorkflowEventEnvelope, parsed: NonNullable<ReturnType<typeof preparedPayload>>): boolean {
+  return sameWorkflowLinkGeneration(link, preparedLinkGeneration(prepared, parsed));
+}
+function recoveredLinkMatches(link: WorkflowSessionLink, prepared: WorkflowEventEnvelope, committed: WorkflowEventEnvelope | undefined): boolean {
+  return Boolean(committed) && link.orphaned === false && link.recovery?.state === "recovered"
+    && link.recovery.preparedEventHash === prepared.eventHash && link.recovery.eventHash === committed?.eventHash;
+}
+function appendRecoveryRollback(input: { projectRoot: string; projectId: string; sessionId: string; prepared: WorkflowEventEnvelope; candidate: { piSessionId: string; piSessionFile: string }; reason: string }): void {
+  const existing = readWorkflowJournal(input.projectRoot, input.sessionId);
+  if (committedFor(existing, input.prepared.eventHash)) throw new Error("Committed workflow recovery cannot be rolled back");
+  if (existing.some((event) => isPublishedRecoveryRollback(event, input.prepared.eventHash))) return;
+  appendWorkflowEventChecked(input.projectRoot, createWorkflowEvent({
+    projectId: input.projectId, sessionId: input.sessionId, type: "session.orphaned", producer: "recovery",
+    payload: {
+      reason: input.reason.slice(0, 2_048), piSessionId: input.candidate.piSessionId, piSessionFile: input.candidate.piSessionFile,
+      preparedEventHash: input.prepared.eventHash, rolledBack: true,
+    },
+  }), (locked) => {
+    if (committedFor(locked, input.prepared.eventHash)) throw new Error("Committed workflow recovery cannot be rolled back");
+    if (locked.some((event) => isPublishedRecoveryRollback(event, input.prepared.eventHash))) throw new Error("Workflow recovery was already rolled back concurrently");
+  });
+}
+function appendRecoveryCommit(input: { projectRoot: string; projectId: string; prepared: WorkflowEventEnvelope; preparedLink: WorkflowSessionLink; recoveredAt: string; fault?: (stage: JournalFaultStage) => void }): WorkflowEventEnvelope {
+  recoveryInvariant(input.preparedLink.recovery?.state === "prepared" && input.preparedLink.recovery.preparedEventHash === input.prepared.eventHash, "Workflow recovery link is not durably prepared");
+  return appendWorkflowEventChecked(input.projectRoot, createWorkflowEvent({
+    projectId: input.projectId, sessionId: input.preparedLink.workflowSessionId, type: "session.recovered", producer: "recovery", timestamp: input.recoveredAt,
+    payload: {
+      preparedEventHash: input.prepared.eventHash,
+      previousPiSessionId: input.preparedLink.recovery.previousPiSessionId, previousPiSessionFile: input.preparedLink.recovery.previousPiSessionFile,
+      piSessionId: input.preparedLink.piSessionId, piSessionFile: input.preparedLink.piSessionFile,
+      activationHash: input.preparedLink.activationHash, recoveredAt: input.recoveredAt,
+    },
+  }), (events) => {
+    recoveryInvariant(events.some((event) => event.eventHash === input.prepared.eventHash && event.type === "session.recovery.prepared"), "Workflow recovery preparation is missing");
+    recoveryInvariant(!events.some((event) => isPublishedRecoveryRollback(event, input.prepared.eventHash)), "Workflow recovery preparation was rolled back");
+    recoveryInvariant(!committedFor(events, input.prepared.eventHash), "Workflow recovery was committed concurrently");
+  }, { fault: input.fault });
+}
+function currentWorkflowLink(projectRoot: string, workflowSessionId: string): WorkflowSessionLink {
+  const current = listSessionLinks(projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === workflowSessionId);
+  recoveryInvariant(current, "Prepared workflow session link is missing");
+  return current;
+}
+function committedTimestamp(committed: WorkflowEventEnvelope): string {
+  const recoveredAt = eventPayload(committed)?.recoveredAt;
+  recoveryInvariant(typeof recoveredAt === "string" && Number.isFinite(Date.parse(recoveredAt)), "Workflow recovery commit timestamp is invalid");
+  return recoveredAt;
+}
+/** Must be called while holding the per-session recovery settlement lock. */
+function commitRecoverySettlement(input: { projectRoot: string; projectId: string; prepared: WorkflowEventEnvelope; recoveredAt: string; fault?: (stage: JournalFaultStage) => void; afterCommitPublished?: () => void }): WorkflowSessionLink {
+  const parsed = preparedPayload(input.prepared);
+  recoveryInvariant(parsed, "Workflow recovery preparation is invalid");
+  let events = readWorkflowJournal(input.projectRoot, input.prepared.sessionId);
+  recoveryInvariant(!events.some((event) => isPublishedRecoveryRollback(event, input.prepared.eventHash)), "Workflow recovery preparation was rolled back");
+  let committed = committedFor(events, input.prepared.eventHash);
+  let current = currentWorkflowLink(input.projectRoot, input.prepared.sessionId);
+  if (recoveredLinkMatches(current, input.prepared, committed)) return current;
+  recoveryInvariant(preparedLinkMatches(current, input.prepared, parsed), "Prepared workflow link changed before recovery commit");
+  if (!committed) {
+    committed = appendRecoveryCommit({ ...input, preparedLink: current });
+    events = readWorkflowJournal(input.projectRoot, input.prepared.sessionId);
+    committed = committedFor(events, input.prepared.eventHash) ?? committed;
+    input.afterCommitPublished?.();
+  }
+  current = currentWorkflowLink(input.projectRoot, input.prepared.sessionId);
+  if (recoveredLinkMatches(current, input.prepared, committed)) return current;
+  return commitWorkflowRecovery(input.projectRoot, current, { recoveredAt: committedTimestamp(committed), preparedEventHash: input.prepared.eventHash, eventHash: committed.eventHash });
+}
+/** Must be called while holding the per-session recovery settlement lock. A published commit always wins. */
+function rollbackRecoverySettlement(input: { projectRoot: string; projectId: string; prepared: WorkflowEventEnvelope; reason: string }): WorkflowSessionLink | undefined {
+  const parsed = preparedPayload(input.prepared);
+  recoveryInvariant(parsed, "Workflow recovery preparation is invalid");
+  const events = readWorkflowJournal(input.projectRoot, input.prepared.sessionId);
+  const committed = committedFor(events, input.prepared.eventHash);
+  let current = currentWorkflowLink(input.projectRoot, input.prepared.sessionId);
+  if (committed) {
+    if (recoveredLinkMatches(current, input.prepared, committed)) return current;
+    recoveryInvariant(preparedLinkMatches(current, input.prepared, parsed), "Committed workflow recovery link changed before reconciliation");
+    return commitWorkflowRecovery(input.projectRoot, current, { recoveredAt: committedTimestamp(committed), preparedEventHash: input.prepared.eventHash, eventHash: committed.eventHash });
+  }
+  if (events.some((event) => isPublishedRecoveryRollback(event, input.prepared.eventHash))) return undefined;
+  if (!sameWorkflowLinkGeneration(current, parsed.expected)) {
+    recoveryInvariant(preparedLinkMatches(current, input.prepared, parsed), "Workflow recovery rollback refused a changed link generation");
+    rollbackWorkflowRecovery(input.projectRoot, current, parsed.expected, input.prepared.eventHash);
+    current = currentWorkflowLink(input.projectRoot, input.prepared.sessionId);
+    recoveryInvariant(sameWorkflowLinkGeneration(current, parsed.expected), "Workflow recovery rollback did not restore the exact prior generation");
+  }
+  appendRecoveryRollback({ projectRoot: input.projectRoot, projectId: input.projectId, sessionId: input.prepared.sessionId, prepared: input.prepared, candidate: parsed, reason: input.reason });
+  return undefined;
+}
+async function restorePriorPiSession(input: RecoverOrphanedWorkflowSessionInput, created: { readonly compensate?: () => void | Promise<void> }): Promise<void> {
+  if (created.compensate) return created.compensate();
+  const restored = await input.adapter.switch({ piSessionFile: input.restorePiSessionFile, withSession: async () => {} });
+  if (restored.cancelled) throw new Error("Pi recovery compensation was cancelled");
+}
+
+/** Resolve durable recovery preparations left by a terminated process before orphan status is reported. */
+export function reconcilePreparedWorkflowRecoveries(input: { projectRoot: string; projectId: string }): void {
+  for (const initial of listSessionLinks(input.projectRoot)) {
+    if (initial.kind !== "workflow") continue;
+    const preparedEvents = readWorkflowJournal(input.projectRoot, initial.workflowSessionId).filter((event) => event.type === "session.recovery.prepared");
+    for (const prepared of preparedEvents) {
+      withRecoverySettlementLock(input.projectRoot, initial.workflowSessionId, () => {
+        const parsed = preparedPayload(prepared);
+        recoveryInvariant(parsed, "Workflow recovery preparation is invalid");
+        const events = readWorkflowJournal(input.projectRoot, initial.workflowSessionId);
+        const committed = committedFor(events, prepared.eventHash);
+        if (events.some((event) => isPublishedRecoveryRollback(event, prepared.eventHash))) return;
+        let current = currentWorkflowLink(input.projectRoot, initial.workflowSessionId);
+        if (recoveredLinkMatches(current, prepared, committed)) return;
+        try {
+          if (!preparedLinkMatches(current, prepared, parsed)) {
+            recoveryInvariant(sameWorkflowLinkGeneration(current, parsed.expected), "prepared recovery lost its exact link generation");
+            if (missingOrUnsupportedPiSession(parsed.piSessionFile)) {
+              rollbackRecoverySettlement({ ...input, prepared, reason: "recovery restart reconciliation rolled back a missing Pi session" });
+              return;
+            }
+            current = prepareWorkflowRecoveryLink(input.projectRoot, parsed.expected, { ...parsed, preparedEventHash: prepared.eventHash });
+          }
+          if (missingOrUnsupportedPiSession(current.piSessionFile)) {
+            rollbackRecoverySettlement({ ...input, prepared, reason: "recovery restart reconciliation rolled back a missing Pi session" });
+            return;
+          }
+          commitRecoverySettlement({ ...input, prepared, recoveredAt: new Date().toISOString() });
+        } catch (error) {
+          const recovered = rollbackRecoverySettlement({ ...input, prepared, reason: `recovery restart reconciliation blocked: ${boundedDiagnostic(error)}` });
+          if (recovered) return;
+        }
+      });
+    }
+  }
+}
+
+export async function recoverOrphanedWorkflowSession(input: RecoverOrphanedWorkflowSessionInput): Promise<WorkflowSessionLink> {
+  const link = orphanLink(input);
+  recoveryInvariant(link.recovery?.state !== "prepared", "Workflow recovery has a durable preparation that must be reconciled first");
+  recoveryInvariant(!missingOrUnsupportedPiSession(input.restorePiSessionFile), "Recovery requires a persisted prior Pi session restoration target");
+  let snapshot: ActivationSnapshotFileV1;
+  let validation: RecoveryActivationValidation;
+  try {
+    snapshot = readActivationSnapshot(input.projectRoot, link.activationHash);
+    const base = validateRecoverySnapshot(snapshot, input, link);
+    let narrowing: RecoveryActivationValidation = Object.freeze({ ok: true, codes: Object.freeze([]) });
+    if (input.validateActivation) {
+      try { narrowing = input.validateActivation(snapshot); }
+      catch { narrowing = Object.freeze({ ok: false, codes: Object.freeze(["RECOVERY_VALIDATION_FAILED"]) }); }
+    }
+    validation = Object.freeze({ ok: base.ok && narrowing.ok, codes: Object.freeze([...new Set([...base.codes, ...narrowing.codes])].sort()) });
+  } catch (error) {
+    validation = Object.freeze({ ok: false, codes: Object.freeze(["SNAPSHOT_INVALID"]) });
+    recordWorkflowRecoveryBlocked(input.projectRoot, input.projectId, link, validation.codes, `Snapshot invalid or missing: ${String(error instanceof Error ? error.message : error)}`);
+    throw new Error(`Snapshot invalid or missing; recovery blocked: ${validation.codes.join(",")}`);
+  }
+  if (!validation.ok) {
+    recordWorkflowRecoveryBlocked(input.projectRoot, input.projectId, link, validation.codes, "Stored activation/runtime contract is unsupported");
+    throw new Error(`Recovery blocked by unsupported activation/runtime contract: ${validation.codes.join(",")}`);
+  }
+  const ownership = acquireRuntimeOwnership(input.projectRoot, link.workflowSessionId, input.owner);
+  recoveryInvariant(ownership.ok, `Recovery refuses a live owner: ${ownership.reason}`);
+  let created: Awaited<ReturnType<SessionNavigationAdapter["create"]>>;
+  try {
+    created = await input.adapter.create({
+      parentSession: link.normalParentFile, restoreSession: input.restorePiSessionFile, name: `${link.name}:recovered`, workflowId: link.workflowId, activationHash: link.activationHash,
+      recovery: { workflowSessionId: link.workflowSessionId, previousPiSessionId: link.piSessionId, previousPiSessionFile: link.piSessionFile },
+    });
+  } catch (error) {
+    releaseRuntimeOwnership(input.projectRoot, link.workflowSessionId, input.owner.nonce);
+    throw error;
+  }
+  const preparedAt = new Date().toISOString();
+  const preparedDraft = createWorkflowEvent({
+    projectId: input.projectId, sessionId: link.workflowSessionId, type: "session.recovery.prepared", producer: "recovery", timestamp: preparedAt,
+    payload: {
+      expectedLinkHash: workflowLinkGenerationHash(link), expectedLink: link as unknown as JsonValue,
+      previousPiSessionId: link.piSessionId, previousPiSessionFile: link.piSessionFile,
+      piSessionId: created.piSessionId, piSessionFile: created.piSessionFile, activationHash: link.activationHash, preparedAt,
+    },
+  });
+  let prepared: WorkflowEventEnvelope | undefined;
+  try {
+    prepared = appendWorkflowEventChecked(input.projectRoot, preparedDraft, (events) => {
+      const unresolved = events.filter((event) => event.type === "session.recovery.prepared").some((event) => !committedFor(events, event.eventHash) && !events.some((candidate) => isPublishedRecoveryRollback(candidate, event.eventHash)));
+      recoveryInvariant(!unresolved, "Another workflow recovery preparation is unresolved");
+    });
+    input.recoveryFault?.("afterPrepared");
+    prepareWorkflowRecoveryLink(input.projectRoot, link, { ...created, preparedAt, preparedEventHash: prepared.eventHash });
+    input.recoveryFault?.("afterLinkPrepared");
+    return withRecoverySettlementLock(input.projectRoot, link.workflowSessionId, () => commitRecoverySettlement({
+      projectRoot: input.projectRoot, projectId: input.projectId, prepared: prepared!, recoveredAt: new Date().toISOString(), fault: input.journalFault,
+      afterCommitPublished: () => input.recoveryFault?.("afterCommitted"),
+    }));
+  } catch (error) {
+    const cleanupErrors: unknown[] = [];
+    try {
+      const events = readWorkflowJournal(input.projectRoot, link.workflowSessionId);
+      prepared = prepared ?? events.find((event) => event.eventId === preparedDraft.eventId && event.type === "session.recovery.prepared");
+      if (prepared) {
+        const recovered = withRecoverySettlementLock(input.projectRoot, link.workflowSessionId, () => rollbackRecoverySettlement({
+          projectRoot: input.projectRoot, projectId: input.projectId, prepared: prepared!, reason: "recovery transaction rolled back",
+        }));
+        if (recovered) return recovered;
+      }
+    } catch (cleanupError) { cleanupErrors.push(new Error(`Recovery protocol rollback failed: ${boundedDiagnostic(cleanupError)}`)); }
+    try { await restorePriorPiSession(input, created); }
+    catch (cleanupError) { cleanupErrors.push(new Error(`Pi session compensation failed: ${boundedDiagnostic(cleanupError)}`)); }
+    if (!releaseRuntimeOwnership(input.projectRoot, link.workflowSessionId, input.owner.nonce)) cleanupErrors.push(new Error("Recovery ownership release failed"));
+    if (cleanupErrors.length) throw new AggregateError([error, ...cleanupErrors], "Workflow recovery failed and compensation was incomplete");
+    throw error;
+  }
 }

--- a/src/workflows/registry.ts
+++ b/src/workflows/registry.ts
@@ -1,6 +1,71 @@
 export const WORKFLOW_SELECTOR_LIMITS = Object.freeze({ items: 4_096, diagnosticBytes: 2_048, aggregateBytes: 262_144 });
-export interface WorkflowSelectorInput { readonly workflowId: string; readonly name?: string; readonly source: "current" | "stale" | "missing" | "invalid"; readonly resumable: boolean; readonly freshEnabled: boolean; readonly diagnostics: readonly string[]; readonly prompt?: string }
-export interface WorkflowSelectorRow { readonly id: string; readonly name?: string; readonly source: WorkflowSelectorInput["source"]; readonly status: "available" | "invalid" | "resumable-stale"; readonly resumable: boolean; readonly freshEnabled: boolean; readonly diagnostics: readonly string[]; readonly truncated: boolean }
+export interface WorkflowSelectorHandoffStatus { readonly packetHash: string; readonly sourceWorkflowId: string; readonly sourceRunId: string }
+export type WorkflowSelectorSessionState = "none" | "idle" | "open" | "orphaned" | "archived";
+export type WorkflowSelectorRecoveryState = "none" | "available" | "blocked" | "recovered";
+export interface WorkflowSelectorInput {
+  readonly workflowId: string;
+  readonly name?: string;
+  readonly source: "current" | "stale" | "missing" | "invalid";
+  readonly resumable: boolean;
+  readonly freshEnabled: boolean;
+  readonly diagnostics: readonly string[];
+  readonly prompt?: string;
+  readonly stagedHandoff?: WorkflowSelectorHandoffStatus;
+  readonly currentSessionState?: WorkflowSelectorSessionState;
+  readonly archiveCount?: number;
+  readonly recoveryState?: WorkflowSelectorRecoveryState;
+  /** Presentation hint only. Deliberately not copied to the selector status DTO. */
+  readonly suggestedNext?: readonly string[];
+}
+export interface WorkflowSelectorRow {
+  readonly id: string;
+  readonly name?: string;
+  readonly source: WorkflowSelectorInput["source"];
+  readonly sourceStale: boolean;
+  readonly status: "available" | "invalid" | "resumable-stale";
+  readonly resumable: boolean;
+  readonly freshEnabled: boolean;
+  readonly stagedHandoff?: WorkflowSelectorHandoffStatus;
+  readonly currentSessionState: WorkflowSelectorSessionState;
+  readonly archiveCount: number;
+  readonly recoveryState: WorkflowSelectorRecoveryState;
+  readonly diagnostics: readonly string[];
+  readonly truncated: boolean;
+}
 function compare(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }
 function truncateUtf8(value: string, bytes: number): string { if (Buffer.byteLength(value) <= bytes) return value; let out = ""; for (const char of value) { if (Buffer.byteLength(out + char + "…") > bytes) break; out += char; } return `${out}…`; }
-export function buildWorkflowSelector(inputs: readonly WorkflowSelectorInput[]): readonly WorkflowSelectorRow[] { const rows: WorkflowSelectorRow[] = []; let bytes = 2; for (const input of [...inputs].sort((a, b) => compare(a.workflowId, b.workflowId)).slice(0, WORKFLOW_SELECTOR_LIMITS.items)) { const diagnostics = input.diagnostics.slice(0, 16).map((value) => truncateUtf8(value, WORKFLOW_SELECTOR_LIMITS.diagnosticBytes)); const row: WorkflowSelectorRow = Object.freeze({ id: truncateUtf8(input.workflowId, 256), ...(input.name ? { name: truncateUtf8(input.name, 512) } : {}), source: input.source, status: input.resumable && input.source !== "current" ? "resumable-stale" : input.source === "current" ? "available" : "invalid", resumable: input.resumable, freshEnabled: input.freshEnabled, diagnostics: Object.freeze(diagnostics), truncated: diagnostics.length < input.diagnostics.length }); const size = Buffer.byteLength(JSON.stringify(row)) + 1; if (bytes + size > WORKFLOW_SELECTOR_LIMITS.aggregateBytes) break; rows.push(row); bytes += size; } return Object.freeze(rows); }
+function handoffStatus(input: WorkflowSelectorHandoffStatus | undefined): WorkflowSelectorHandoffStatus | undefined {
+  if (!input) return undefined;
+  return Object.freeze({ packetHash: truncateUtf8(String(input.packetHash), 64), sourceWorkflowId: truncateUtf8(String(input.sourceWorkflowId), 256), sourceRunId: truncateUtf8(String(input.sourceRunId), 256) });
+}
+export function buildWorkflowSelector(inputs: readonly WorkflowSelectorInput[]): readonly WorkflowSelectorRow[] {
+  const rows: WorkflowSelectorRow[] = [];
+  let bytes = 2;
+  for (const input of [...inputs].sort((a, b) => compare(a.workflowId, b.workflowId)).slice(0, WORKFLOW_SELECTOR_LIMITS.items)) {
+    const diagnostics = input.diagnostics.slice(0, 16).map((value) => truncateUtf8(value, WORKFLOW_SELECTOR_LIMITS.diagnosticBytes));
+    const archiveCount = Number.isSafeInteger(input.archiveCount) && Number(input.archiveCount) >= 0 ? Math.min(Number(input.archiveCount), 4_096) : 0;
+    const currentSessionState = input.currentSessionState ?? "none";
+    const recoveryState = input.recoveryState ?? (currentSessionState === "orphaned" ? "available" : "none");
+    const stagedHandoff = handoffStatus(input.stagedHandoff);
+    const row: WorkflowSelectorRow = Object.freeze({
+      id: truncateUtf8(input.workflowId, 256),
+      ...(input.name ? { name: truncateUtf8(input.name, 512) } : {}),
+      source: input.source,
+      sourceStale: input.source === "stale",
+      status: input.resumable && input.source !== "current" ? "resumable-stale" : input.source === "current" ? "available" : "invalid",
+      resumable: input.resumable,
+      freshEnabled: input.freshEnabled,
+      ...(stagedHandoff ? { stagedHandoff } : {}),
+      currentSessionState,
+      archiveCount,
+      recoveryState,
+      diagnostics: Object.freeze(diagnostics),
+      truncated: diagnostics.length < input.diagnostics.length,
+    });
+    const size = Buffer.byteLength(JSON.stringify(row)) + 1;
+    if (bytes + size > WORKFLOW_SELECTOR_LIMITS.aggregateBytes) break;
+    rows.push(row);
+    bytes += size;
+  }
+  return Object.freeze(rows);
+}

--- a/src/workflows/runs.ts
+++ b/src/workflows/runs.ts
@@ -6,6 +6,7 @@ import { createWorkflowEvent, type WorkflowEventEnvelope, type WorkflowEventType
 import { appendWorkflowEventChecked, readWorkflowJournal, workflowJournalIdentity, type JournalFaultStage } from "./journal";
 import { heartbeatCurrentRuntimeOwnership } from "./ownership";
 import { replayWorkflowJournal } from "./replay";
+import { restoreHandoffState } from "./handoff";
 
 export const RUN_LIFECYCLE_FORMAT_VERSION = 1 as const;
 export const CANCELLATION_TIMING = Object.freeze({ settleGraceMs: 2_000, killSettleMs: 1_000, coordinatorStepMs: 2_000 });
@@ -92,6 +93,8 @@ export interface WorkflowRunRecord {
   readonly runId: string;
   readonly status: RunStatus;
   readonly startedAt: string;
+  /** Content-addressed, authority-free context consumed atomically by run.started. */
+  readonly handoffPacketHash?: string;
   readonly inputs: readonly RunInputRecord[];
   readonly deliveredThrough: number;
   readonly pendingDelivery?: PendingInputDelivery;
@@ -302,10 +305,13 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
     if (state.latestRun && isOpenRunStatus(state.latestRun.status)) throw new Error("Workflow session already has an open run");
     const input = parseInput(payload.input, "initial");
     if (input.sequence !== 1 || state.inputAssignments?.[input.inputId]) throw new Error("Run initial input is invalid or duplicated");
+    const handoffPacketHash = payload.handoffPacketHash;
+    if (handoffPacketHash !== undefined && (typeof handoffPacketHash !== "string" || !/^[0-9a-f]{64}$/u.test(handoffPacketHash))) throw new Error("Run handoff packet hash is invalid");
     const run: WorkflowRunRecord = {
       runId: event.runId,
       status: "running",
       startedAt: event.timestamp,
+      ...(handoffPacketHash === undefined ? {} : { handoffPacketHash }),
       inputs: [input],
       deliveredThrough: 0,
       cancellationRequested: false,
@@ -698,7 +704,8 @@ export class WorkflowRunLifecycle {
 
   recordUserInput(input: RecordRunInput): RecordRunInputResult {
     validateInput(input);
-    const state = this.restore();
+    const eventsAtInput = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+    const state = replayWorkflowJournal(eventsAtInput, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state;
     const assigned = state.inputAssignments?.[input.inputId];
     if (assigned) return duplicateInputResult(input, assigned);
     const now = this.options.now?.() ?? new Date().toISOString();
@@ -706,19 +713,22 @@ export class WorkflowRunLifecycle {
     if (!current || !isOpenRunStatus(current.status)) {
       const runId = this.options.createRunId?.() ?? `run-${randomUUID()}`;
       const record = freezeInput({ ...input, sequence: 1, kind: "initial", receivedAt: now });
+      const stagedHandoff = restoreHandoffState(eventsAtInput).staged;
       try {
         appendWorkflowEventChecked(this.options.projectRoot, createWorkflowEvent({
           projectId: this.options.projectId,
           sessionId: this.options.sessionId,
           runId,
           type: "run.started",
-          payload: asJson({ formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, input: record }),
+          payload: asJson({ formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, input: record, ...(stagedHandoff ? { handoffPacketHash: stagedHandoff.packetHash } : {}) }),
           producer: "runtime",
           timestamp: now,
         }), (existing) => {
           const locked = replayWorkflowJournal(existing, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state;
           if (locked.inputAssignments?.[input.inputId]) throw new Error("Run input callback was recorded concurrently");
           if (locked.latestRun && isOpenRunStatus(locked.latestRun.status)) throw new Error("Workflow session already has an open run");
+          const lockedHandoff = restoreHandoffState(existing).staged;
+          if (lockedHandoff?.packetHash !== stagedHandoff?.packetHash) throw new Error("Staged handoff changed before atomic run creation");
         });
       } catch (error) {
         const concurrent = this.restore().inputAssignments?.[input.inputId];

--- a/src/workflows/sessions.ts
+++ b/src/workflows/sessions.ts
@@ -1,28 +1,165 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { closeSync, constants, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { withCrossProcessFileLock } from "../core/file-lock";
 import { resolveProjectPath } from "../core/safe-path";
-import { appendWorkflowEvent } from "./journal";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { appendWorkflowEvent, appendWorkflowEventChecked, readWorkflowJournal } from "./journal";
 import { createWorkflowEvent } from "./events";
-import { markWorkflowOrphaned } from "./ownership";
 
 export const SESSION_LINK_FORMAT_VERSION = 1 as const;
 export type WorkflowLinkStatus = "current" | "archived";
 export interface NormalSessionLink { readonly kind: "normal"; readonly formatVersion: 1; readonly projectId: string; readonly piSessionId: string; readonly piSessionFile: string; readonly normalModel: string; readonly normalThinking: string; readonly normalTools: readonly string[]; readonly createdAt: string; readonly updatedAt: string }
-export interface WorkflowSessionLink { readonly kind: "workflow"; readonly formatVersion: 1; readonly workflowSessionId: string; readonly workflowId: string; readonly activationHash: string; readonly piSessionId: string; readonly piSessionFile: string; readonly normalParentId: string; readonly normalParentFile: string; readonly status: WorkflowLinkStatus; readonly stale: boolean; readonly model: string; readonly thinking: string; readonly tools: readonly string[]; readonly createdAt: string; readonly updatedAt: string; readonly name: string }
+export type WorkflowRecoveryState =
+  | Readonly<{ state: "blocked"; codes: readonly string[]; diagnostic: string; attemptedAt: string }>
+  | Readonly<{ state: "prepared"; previousPiSessionId: string; previousPiSessionFile: string; preparedAt: string; preparedEventHash: string; expectedLinkHash: string }>
+  | Readonly<{ state: "recovered"; previousPiSessionId: string; previousPiSessionFile: string; recoveredAt: string; preparedEventHash: string; eventHash: string }>;
+export interface WorkflowSessionLink { readonly kind: "workflow"; readonly formatVersion: 1; readonly workflowSessionId: string; readonly workflowId: string; readonly activationHash: string; readonly piSessionId: string; readonly piSessionFile: string; readonly normalParentId: string; readonly normalParentFile: string; readonly status: WorkflowLinkStatus; readonly stale: boolean; readonly orphaned?: boolean; readonly orphanedAt?: string; readonly recovery?: WorkflowRecoveryState; readonly model: string; readonly thinking: string; readonly tools: readonly string[]; readonly createdAt: string; readonly updatedAt: string; readonly name: string }
 export type SessionLink = NormalSessionLink | WorkflowSessionLink;
 
-function linksPath(root: string): string { const resolved = resolveProjectPath(root, ".pi/hive/sessions/session-links-v1.json", { allowMissing: true }); if (!resolved) throw new Error("SESSION_LINK_PATH_INVALID"); return resolved.lexicalPath; }
+function sessionInvariant(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(message); }
+function linksPath(root: string): string { const resolved = resolveProjectPath(root, ".pi/hive/sessions/session-links-v1.json", { allowMissing: true }); sessionInvariant(resolved, "SESSION_LINK_PATH_INVALID"); return resolved.lexicalPath; }
 function freeze<T>(value: T): T { if (value && typeof value === "object") { for (const child of Object.values(value as Record<string, unknown>)) freeze(child); Object.freeze(value); } return value; }
-function readLinks(root: string): SessionLink[] { const path = linksPath(root); try { if (lstatSync(path).isSymbolicLink()) throw new Error("SESSION_LINK_PATH_INVALID"); const raw = readFileSync(path, "utf8"); if (Buffer.byteLength(raw) > 1_048_576) throw new Error("SESSION_LINK_LIMIT_EXCEEDED"); const value = JSON.parse(raw) as { formatVersion: number; links: SessionLink[] }; if (value.formatVersion !== 1 || !Array.isArray(value.links)) throw new Error("SESSION_LINK_INVALID"); return value.links; } catch (error: unknown) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw error; } }
-function writeLinksUnlocked(root: string, links: readonly SessionLink[]): void { const path = linksPath(root); const dir = dirname(path); mkdirSync(dir, { recursive: true, mode: 0o700 }); const content = `${JSON.stringify({ formatVersion: 1, links })}\n`; if (Buffer.byteLength(content) > 1_048_576) throw new Error("SESSION_LINK_LIMIT_EXCEEDED"); const temp = `${path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined; try { fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; renameSync(temp, path); const dirFd = openSync(dir, constants.O_RDONLY); try { fsyncSync(dirFd); } finally { closeSync(dirFd); } } finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } } }
+function readLinks(root: string): SessionLink[] { const path = linksPath(root); try { sessionInvariant(!lstatSync(path).isSymbolicLink(), "SESSION_LINK_PATH_INVALID"); const raw = readFileSync(path, "utf8"); sessionInvariant(Buffer.byteLength(raw) <= 1_048_576, "SESSION_LINK_LIMIT_EXCEEDED"); const value = JSON.parse(raw) as { formatVersion: number; links: SessionLink[] }; sessionInvariant(value.formatVersion === 1 && Array.isArray(value.links), "SESSION_LINK_INVALID"); return value.links; } catch (error: unknown) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw error; } }
+function writeLinksUnlocked(root: string, links: readonly SessionLink[]): void { const path = linksPath(root); const dir = dirname(path); mkdirSync(dir, { recursive: true, mode: 0o700 }); const content = `${JSON.stringify({ formatVersion: 1, links })}\n`; sessionInvariant(Buffer.byteLength(content) <= 1_048_576, "SESSION_LINK_LIMIT_EXCEEDED"); const temp = `${path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined; try { fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; renameSync(temp, path); const dirFd = openSync(dir, constants.O_RDONLY); try { fsyncSync(dirFd); } finally { closeSync(dirFd); } } finally { if (fd !== undefined) try { closeSync(fd); } catch { /* best effort */ } try { unlinkSync(temp); } catch { /* published or absent */ } } }
 function compareText(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }
 export function listSessionLinks(projectRoot: string): readonly SessionLink[] { return freeze(readLinks(projectRoot).sort((a, b) => (a.kind === b.kind ? (a.kind === "normal" ? compareText(a.piSessionId, (b as NormalSessionLink).piSessionId) : compareText(a.workflowSessionId, (b as WorkflowSessionLink).workflowSessionId)) : a.kind === "normal" ? -1 : 1))); }
 function mutateLinks(projectRoot: string, mutate: (links: SessionLink[]) => readonly SessionLink[]): void { const path = linksPath(projectRoot); mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); withCrossProcessFileLock(path, () => writeLinksUnlocked(projectRoot, mutate(readLinks(projectRoot)))); }
 export function replaceSessionLinks(projectRoot: string, links: readonly SessionLink[]): void { mutateLinks(projectRoot, () => links); }
-export function commitWorkflowSelection(projectRoot: string, workflowId: string, expectedCurrentId: string | undefined, archived: WorkflowSessionLink | undefined, selected: WorkflowSessionLink): void { mutateLinks(projectRoot, (links) => { const latest = links.find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowId === workflowId && entry.status === "current"); if (latest?.workflowSessionId !== expectedCurrentId) throw new Error("Concurrent workflow selection changed the current session"); return [...links.filter((entry) => entry.kind !== "workflow" || (entry.workflowSessionId !== expectedCurrentId && entry.workflowSessionId !== selected.workflowSessionId)), ...(archived ? [archived] : []), selected]; }); }
+export function commitWorkflowSelection(projectRoot: string, workflowId: string, expectedCurrentId: string | undefined, archived: WorkflowSessionLink | undefined, selected: WorkflowSessionLink): void { mutateLinks(projectRoot, (links) => { const latest = links.find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowId === workflowId && entry.status === "current"); sessionInvariant(latest?.workflowSessionId === expectedCurrentId, "Concurrent workflow selection changed the current session"); return [...links.filter((entry) => entry.kind !== "workflow" || (entry.workflowSessionId !== expectedCurrentId && entry.workflowSessionId !== selected.workflowSessionId)), ...(archived ? [archived] : []), selected]; }); }
 export function initializeNormalParent(input: { configured: boolean; projectRoot: string; projectId: string; piSessionId: string; piSessionFile: string; model: string; thinking: string; activeTools: readonly string[] }): { configured: boolean; commands: readonly string[] } { if (!input.configured) return freeze({ configured: false, commands: [] }); const now = new Date().toISOString(); mutateLinks(input.projectRoot, (links) => { const existing = links.find((entry): entry is NormalSessionLink => entry.kind === "normal" && entry.projectId === input.projectId); const normal: NormalSessionLink = freeze({ kind: "normal", formatVersion: 1, projectId: input.projectId, piSessionId: input.piSessionId, piSessionFile: input.piSessionFile, normalModel: input.model, normalThinking: input.thinking, normalTools: [...new Set(input.activeTools)].sort(), createdAt: existing?.createdAt ?? now, updatedAt: now }); return [normal, ...links.filter((entry) => entry.kind !== "normal")]; }); return freeze({ configured: true, commands: ["hive:select", "hive:exit"] }); }
 export function upsertWorkflowLink(projectRoot: string, link: WorkflowSessionLink): void { mutateLinks(projectRoot, (links) => [...links.filter((entry) => entry.kind !== "workflow" || entry.workflowSessionId !== link.workflowSessionId), freeze(link)]); }
 export function recordWorkflowModelState(projectRoot: string, projectId: string, input: Omit<WorkflowSessionLink, "kind"> | WorkflowSessionLink, model: string, thinking: string, preflight: (model: string, thinking: string) => boolean): WorkflowSessionLink { if (!preflight(model, thinking)) throw new Error("Model/thinking preflight failed"); const now = new Date().toISOString(); const link = freeze({ ...input, kind: "workflow" as const, formatVersion: 1 as const, model, thinking, tools: [...input.tools].sort(), updatedAt: now }); upsertWorkflowLink(projectRoot, link); appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: link.workflowSessionId, type: "session.selected", payload: { model, thinking }, producer: "runtime" })); return link; }
-export function markMissingPiSession(projectRoot: string, projectId: string, workflowSessionId: string): void { markWorkflowOrphaned(projectRoot, workflowSessionId, projectId, "linked Pi session is missing"); }
+export function markMissingPiSession(projectRoot: string, projectId: string, workflowSessionId: string): void {
+  const now = new Date().toISOString();
+  const generation = listSessionLinks(projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === workflowSessionId);
+  const matchesGeneration = (event: { type: string; payload: unknown }): boolean => {
+    if (event.type !== "session.orphaned" || !event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) return false;
+    const payload = event.payload as Record<string, unknown>;
+    return generation
+      ? payload.piSessionId === generation.piSessionId && payload.piSessionFile === generation.piSessionFile
+      : payload.piSessionId === undefined && payload.piSessionFile === undefined;
+  };
+  const existingEvent = readWorkflowJournal(projectRoot, workflowSessionId).some(matchesGeneration);
+  if (!existingEvent) {
+    try {
+      appendWorkflowEventChecked(projectRoot, createWorkflowEvent({
+        projectId, sessionId: workflowSessionId, type: "session.orphaned",
+        payload: { reason: "linked Pi session is missing", ...(generation ? { piSessionId: generation.piSessionId, piSessionFile: generation.piSessionFile } : {}) },
+        producer: "recovery", timestamp: now,
+      }), (events) => {
+        if (events.some(matchesGeneration)) throw new Error("Workflow session generation was orphaned concurrently");
+      });
+    } catch (error) {
+      if (!readWorkflowJournal(projectRoot, workflowSessionId).some(matchesGeneration)) throw error;
+    }
+  }
+  mutateLinks(projectRoot, (links) => links.map((entry) => {
+    if (entry.kind !== "workflow" || entry.workflowSessionId !== workflowSessionId) return entry;
+    sessionInvariant(generation && entry.piSessionId === generation.piSessionId && entry.piSessionFile === generation.piSessionFile, "Workflow session generation changed before orphan marking");
+    return freeze({ ...entry, orphaned: true, orphanedAt: entry.orphanedAt ?? now, updatedAt: now });
+  }));
+}
+export function workflowLinkGenerationHash(link: WorkflowSessionLink): string {
+  return createHash("sha256").update("pi-hive-workflow-link-generation-v1\0").update(canonicalJson(link)).digest("hex");
+}
+export function sameWorkflowLinkGeneration(actual: WorkflowSessionLink, expected: WorkflowSessionLink): boolean {
+  return workflowLinkGenerationHash(actual) === workflowLinkGenerationHash(expected);
+}
+export function recordWorkflowRecoveryBlocked(projectRoot: string, projectId: string, expected: WorkflowSessionLink, codes: readonly string[], diagnostic: string): WorkflowSessionLink {
+  const attemptedAt = new Date().toISOString();
+  const boundedCodes = Object.freeze([...new Set(codes.map((code) => String(code).slice(0, 256)))].sort().slice(0, 64));
+  const boundedDiagnostic = String(diagnostic).slice(0, 2_048);
+  let result: WorkflowSessionLink | undefined;
+  mutateLinks(projectRoot, (links) => links.map((entry) => {
+    if (entry.kind !== "workflow" || entry.workflowSessionId !== expected.workflowSessionId) return entry;
+    sessionInvariant(sameWorkflowLinkGeneration(entry, expected), "Orphan workflow link changed before blocked recovery update");
+    result = freeze({ ...entry, orphaned: true, recovery: { state: "blocked" as const, codes: boundedCodes, diagnostic: boundedDiagnostic, attemptedAt }, updatedAt: attemptedAt });
+    return result;
+  }));
+  sessionInvariant(result, "Orphan workflow session link is missing");
+  try {
+    appendWorkflowEvent(projectRoot, createWorkflowEvent({
+      projectId, sessionId: expected.workflowSessionId, type: "session.recovery.blocked",
+      payload: { codes: [...boundedCodes], diagnostic: boundedDiagnostic, expectedLinkHash: workflowLinkGenerationHash(expected) },
+      producer: "recovery", timestamp: attemptedAt,
+    }));
+  } catch {
+    // The exact-CAS link state is the fail-closed authority when the audit journal is unavailable.
+  }
+  return result;
+}
+function preparedEventMatches(event: { type: string; eventHash: string; payload: unknown }, expected: WorkflowSessionLink, replacement: { piSessionId: string; piSessionFile: string; preparedAt: string; preparedEventHash: string }): boolean {
+  if (event.type !== "session.recovery.prepared" || event.eventHash !== replacement.preparedEventHash || !event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) return false;
+  const payload = event.payload as Record<string, unknown>;
+  return payload.expectedLinkHash === workflowLinkGenerationHash(expected)
+    && canonicalJson(payload.expectedLink) === canonicalJson(expected)
+    && payload.previousPiSessionId === expected.piSessionId
+    && payload.previousPiSessionFile === expected.piSessionFile
+    && payload.piSessionId === replacement.piSessionId
+    && payload.piSessionFile === replacement.piSessionFile
+    && payload.activationHash === expected.activationHash
+    && payload.preparedAt === replacement.preparedAt;
+}
+export function prepareWorkflowRecoveryLink(projectRoot: string, expected: WorkflowSessionLink, replacement: { piSessionId: string; piSessionFile: string; preparedAt: string; preparedEventHash: string }): WorkflowSessionLink {
+  const published = readWorkflowJournal(projectRoot, expected.workflowSessionId).find((event) => event.eventHash === replacement.preparedEventHash);
+  sessionInvariant(published && preparedEventMatches(published, expected, replacement), "Workflow recovery preparation journal is missing or inconsistent");
+  let result: WorkflowSessionLink | undefined;
+  mutateLinks(projectRoot, (links) => links.map((entry) => {
+    if (entry.kind !== "workflow" || entry.workflowSessionId !== expected.workflowSessionId) return entry;
+    sessionInvariant(sameWorkflowLinkGeneration(entry, expected), "Orphan workflow link changed during recovery preparation");
+    result = freeze({
+      ...entry, piSessionId: replacement.piSessionId, piSessionFile: replacement.piSessionFile, orphaned: true,
+      recovery: { state: "prepared" as const, previousPiSessionId: expected.piSessionId, previousPiSessionFile: expected.piSessionFile, preparedAt: replacement.preparedAt, preparedEventHash: replacement.preparedEventHash, expectedLinkHash: workflowLinkGenerationHash(expected) },
+      updatedAt: replacement.preparedAt,
+    });
+    return result;
+  }));
+  sessionInvariant(result, "Orphan workflow session link is missing");
+  return result;
+}
+function committedEventMatches(event: { type: string; eventHash: string; payload: unknown }, prepared: WorkflowSessionLink, replacement: { recoveredAt: string; preparedEventHash: string; eventHash: string }): boolean {
+  if (event.type !== "session.recovered" || event.eventHash !== replacement.eventHash || !event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) return false;
+  const payload = event.payload as Record<string, unknown>;
+  return prepared.recovery?.state === "prepared"
+    && prepared.recovery.preparedEventHash === replacement.preparedEventHash
+    && payload.preparedEventHash === replacement.preparedEventHash
+    && payload.previousPiSessionId === prepared.recovery.previousPiSessionId
+    && payload.previousPiSessionFile === prepared.recovery.previousPiSessionFile
+    && payload.piSessionId === prepared.piSessionId
+    && payload.piSessionFile === prepared.piSessionFile
+    && payload.activationHash === prepared.activationHash
+    && payload.recoveredAt === replacement.recoveredAt;
+}
+export function commitWorkflowRecovery(projectRoot: string, expectedPrepared: WorkflowSessionLink, replacement: { recoveredAt: string; preparedEventHash: string; eventHash: string }): WorkflowSessionLink {
+  const published = readWorkflowJournal(projectRoot, expectedPrepared.workflowSessionId).find((event) => event.eventHash === replacement.eventHash);
+  sessionInvariant(published && committedEventMatches(published, expectedPrepared, replacement), "Workflow recovery commit journal is missing or inconsistent");
+  const preparedRecovery = expectedPrepared.recovery;
+  sessionInvariant(preparedRecovery?.state === "prepared", "Workflow recovery link is not prepared");
+  let result: WorkflowSessionLink | undefined;
+  mutateLinks(projectRoot, (links) => links.map((entry) => {
+    if (entry.kind !== "workflow" || entry.workflowSessionId !== expectedPrepared.workflowSessionId) return entry;
+    sessionInvariant(sameWorkflowLinkGeneration(entry, expectedPrepared), "Prepared workflow link changed during recovery commit");
+    result = freeze({
+      ...entry, orphaned: false, orphanedAt: undefined,
+      recovery: { state: "recovered" as const, previousPiSessionId: preparedRecovery.previousPiSessionId, previousPiSessionFile: preparedRecovery.previousPiSessionFile, recoveredAt: replacement.recoveredAt, preparedEventHash: replacement.preparedEventHash, eventHash: replacement.eventHash },
+      updatedAt: replacement.recoveredAt,
+    });
+    return result;
+  }));
+  sessionInvariant(result, "Prepared workflow session link is missing");
+  return result;
+}
+export function rollbackWorkflowRecovery(projectRoot: string, expectedCurrent: WorkflowSessionLink, restore: WorkflowSessionLink, preparedEventHash: string): boolean {
+  sessionInvariant(expectedCurrent.workflowSessionId === restore.workflowSessionId, "Workflow recovery rollback identity mismatch");
+  sessionInvariant(expectedCurrent.recovery?.state === "prepared" && expectedCurrent.recovery.preparedEventHash === preparedEventHash, "Workflow recovery rollback requires an exact prepared generation");
+  let rolledBack = false;
+  mutateLinks(projectRoot, (links) => links.map((entry) => {
+    if (entry.kind !== "workflow" || entry.workflowSessionId !== expectedCurrent.workflowSessionId) return entry;
+    sessionInvariant(sameWorkflowLinkGeneration(entry, expectedCurrent), "Prepared workflow link changed before recovery rollback");
+    rolledBack = true;
+    return restore;
+  }));
+  sessionInvariant(rolledBack, "Prepared workflow session link is missing");
+  return true;
+}

--- a/src/workflows/tools.ts
+++ b/src/workflows/tools.ts
@@ -9,6 +9,7 @@ import { classifyTrustedTool, classifyTrustedToolRegistration } from "../capabil
 import type { BudgetState } from "./budgets";
 import type { DelegationState, DelegationStatusPage } from "./delegation";
 import type { RunLifecycleState } from "./runs";
+import type { HandoffPacket } from "./handoff";
 import type { WorkerTrustedDispatch } from "./workers";
 import { boundedJson } from "./values";
 
@@ -83,7 +84,8 @@ export const GENERIC_WORKFLOW_TOOL_SCHEMAS = Object.freeze({
     }, strict),
   ]),
   workflow_status: Type.Object({
-    section: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("inputs"), Type.Literal("file-changes"), Type.Literal("artifact-refs"), Type.Literal("evidence-refs")])),
+    section: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("inputs"), Type.Literal("handoff"), Type.Literal("file-changes"), Type.Literal("artifact-refs"), Type.Literal("evidence-refs")])),
+    packetHash: Type.Optional(Type.String({ pattern: "^[0-9a-f]{64}$", maxLength: 64 })),
     ...CursorPage,
   }, strict),
   workflow_finish: Type.Object({
@@ -96,7 +98,7 @@ export const GENERIC_WORKFLOW_TOOL_SCHEMAS = Object.freeze({
 });
 
 export type GenericWorkflowToolName = keyof typeof GENERIC_WORKFLOW_TOOL_SCHEMAS;
-export interface WorkflowStatusRequest { readonly section?: "summary" | "inputs" | "file-changes" | "artifact-refs" | "evidence-refs"; readonly limit?: number; readonly cursor?: string }
+export interface WorkflowStatusRequest { readonly section?: "summary" | "inputs" | "handoff" | "file-changes" | "artifact-refs" | "evidence-refs"; readonly packetHash?: string; readonly limit?: number; readonly cursor?: string }
 export interface WorkflowStatusPage { readonly section: string; readonly total: number; readonly items: readonly unknown[]; readonly nextCursor?: string; readonly summary?: Readonly<Record<string, unknown>> }
 
 interface TeamRuntime {
@@ -382,10 +384,40 @@ export function buildWorkflowStatusPage(input: {
   readonly lifecycle: RunLifecycleState;
   readonly budget?: BudgetState;
   readonly delegation?: DelegationState;
+  readonly handoff?: HandoffPacket;
 }, request: WorkflowStatusRequest): WorkflowStatusPage {
   const section = request.section ?? "summary";
   const run = input.lifecycle.latestRun;
   const terminal = run?.terminal;
+  if (section === "handoff") {
+    if (!request.packetHash) throw new Error("Workflow handoff status requires an exact packet hash");
+    if (!input.handoff || input.handoff.packetHash !== request.packetHash || run?.handoffPacketHash !== request.packetHash) throw new Error("Workflow handoff packet hash is not bound to the current run");
+    const encoded = canonicalJson(input.handoff);
+    const chunks: string[] = [];
+    let remaining = encoded;
+    while (remaining) {
+      const chunk = utf8Prefix(remaining, 8_192);
+      if (!chunk) throw new Error("Workflow handoff pagination could not make progress");
+      chunks.push(chunk);
+      remaining = remaining.slice(chunk.length);
+    }
+    const items = chunks.map((content, index) => Object.freeze({
+      packetHash: request.packetHash,
+      chunk: index,
+      bytes: Buffer.byteLength(content, "utf8"),
+      contentHash: hashText(content),
+      content,
+      readRef: `workflow_status:handoff?packetHash=${request.packetHash}&cursor=${index}`,
+    }));
+    const page = paginate(section, items, { ...request, limit: Math.min(3, request.limit ?? 3) }, Object.freeze({
+      packetHash: request.packetHash,
+      totalBytes: Buffer.byteLength(encoded, "utf8"),
+      contentHash: hashText(encoded),
+      chunks: chunks.length,
+    }));
+    return page.nextCursor === undefined ? page : Object.freeze({ ...page, summary: Object.freeze({ ...page.summary, nextRef: `workflow_status:handoff?packetHash=${request.packetHash}&cursor=${page.nextCursor}` }) });
+  }
+  if (request.packetHash !== undefined) throw new Error("Workflow packetHash is only valid for handoff status reads");
   if (section === "inputs") {
     const items = (run?.inputs ?? []).map((entry) => {
       const preview = utf8Prefix(entry.text, TOOL_CONTRACT_LIMITS.previewBytes);
@@ -410,7 +442,7 @@ export function buildWorkflowStatusPage(input: {
     } : null,
     team: { tasks: tasks.length, queued: tasks.filter((task) => task.queueState === "queued").length, active: tasks.filter((task) => task.queueState === "active").length, suspended: tasks.filter((task) => task.queueState === "suspended").length, terminal: tasks.filter((task) => task.queueState === "terminal").length },
     budget: input.budget ? { run: input.budget.run, limits: input.budget.limits.run, paused: input.budget.paused, activeBatches: input.budget.activeBatches.length } : null,
-    readback: ["inputs", "file-changes", "artifact-refs", "evidence-refs"],
+    readback: [...(input.handoff ? ["handoff"] : []), "inputs", "file-changes", "artifact-refs", "evidence-refs"],
   });
   return paginate(section, [summary], request, summary);
 }

--- a/tests/integration/workflow-lifecycle-handlers.test.ts
+++ b/tests/integration/workflow-lifecycle-handlers.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createWorkflowLifecycleServiceHandlers } from "../../src/integration/workflow-lifecycle-handlers.ts";
+import { initializeNormalParent } from "../../src/workflows/sessions.ts";
+
+test("schema-v1 lifecycle service handlers expose control operations without registering or invoking legacy commands", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-lifecycle-handlers-"));
+  initializeNormalParent({ configured: true, projectRoot, projectId: "project-1", piSessionId: "normal", piSessionFile: "/pi/normal", model: "provider/normal", thinking: "low", activeTools: [] });
+  let currentPiSessionId = "normal";
+  let created = 0;
+  const adapter = {
+    async create() { created += 1; return { piSessionId: `pi-${created}`, piSessionFile: `/pi/${created}` }; },
+    async switch(input: { piSessionFile: string; withSession: (ctx: unknown) => Promise<void> | void }) { await input.withSession({}); return { cancelled: false }; },
+  };
+  const handlers = createWorkflowLifecycleServiceHandlers({
+    projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: () => currentPiSessionId,
+    adapter,
+    owner: () => ({ pid: 123, processMarker: "marker", nonce: "owner", verifyDead: () => true }),
+  });
+  assert.deepEqual(Object.keys(handlers).sort(), ["clearHandoff", "detectOrphans", "recover", "reload", "select"]);
+  const selected = await handlers.select({ workflow: { workflowId: "build", activationHash: "a".repeat(64), source: "current", resumable: true, freshEnabled: true, model: "provider/model", thinking: "medium", tools: [] } });
+  currentPiSessionId = selected.link.piSessionId;
+  assert.equal(selected.kind, "created");
+  assert.equal(created, 1);
+  assert.equal(handlers.clearHandoff(selected.link.workflowSessionId).cleared, false);
+  assert.deepEqual(handlers.detectOrphans(), [{ workflowSessionId: selected.link.workflowSessionId, workflowId: "build", piSessionId: selected.link.piSessionId, piSessionFile: selected.link.piSessionFile, orphaned: true }]);
+  assert.throws(() => handlers.recover(selected.link.workflowSessionId, { validateActivation: () => ({ ok: true, codes: [] }) }), /mandatory runtime.*navigation dependencies/i);
+  assert.equal(created, 1, "public recovery blocks before Pi navigation when mandatory dependencies are absent");
+});
+
+test("lifecycle handlers forward optional selectors, fresh reloads, CAS clears, and recovery dependency faults", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-lifecycle-edges-"));
+  initializeNormalParent({ configured: true, projectRoot, projectId: "project-1", piSessionId: "normal", piSessionFile: "/pi/normal", model: "provider/normal", thinking: "low", activeTools: [] });
+  let currentPiSessionId = "normal";
+  let next = 0;
+  const adapter = {
+    async create() { next += 1; return { piSessionId: `pi-${next}`, piSessionFile: `/pi/${next}` }; },
+    async switch(input: { withSession: (ctx: unknown) => Promise<void> | void }) { await input.withSession({}); return { cancelled: false }; },
+  };
+  const base = {
+    projectRoot, projectId: "project-1", currentPiSessionId: () => currentPiSessionId, adapter,
+    owner: () => ({ pid: 123, processMarker: "marker", nonce: "owner", verifyDead: () => true }),
+  };
+  const workflow = { workflowId: "build", activationHash: "a".repeat(64), source: "current" as const, resumable: true, freshEnabled: true, model: "provider/model", thinking: "medium", tools: [] };
+  const handlers = createWorkflowLifecycleServiceHandlers(base);
+  await assert.rejects(() => handlers.select({ workflow, from: "last", packet: {} as never }), /either a source selector/i);
+  await assert.rejects(() => handlers.select({ workflow, from: "missing" }), /source run is missing/i);
+  await assert.rejects(() => handlers.select({ workflow, packet: {} as never }), /handoff packet.*(?:invalid|missing)/i);
+
+  const selected = await handlers.select({ workflow, fresh: true });
+  currentPiSessionId = selected.link.piSessionId;
+  assert.equal(handlers.clearHandoff(selected.link.workflowSessionId, "f".repeat(64)).cleared, false);
+  const reloaded = await handlers.reload(() => ({ workflow, validateBeforeCommit: () => {} }));
+  currentPiSessionId = reloaded.link.piSessionId;
+  assert.equal(reloaded.kind, "created");
+
+  const noRuntime = createWorkflowLifecycleServiceHandlers({ ...base, recovery: { runtime: () => undefined as never, currentPiSessionFile: () => "/pi/normal" } });
+  assert.throws(() => noRuntime.recover(reloaded.link.workflowSessionId), /dependencies are incomplete/i);
+  const noRestore = createWorkflowLifecycleServiceHandlers({ ...base, recovery: { runtime: () => ({}) as never, currentPiSessionFile: () => "" } });
+  assert.throws(() => noRestore.recover(reloaded.link.workflowSessionId), /dependencies are incomplete/i);
+});

--- a/tests/workflows/session-links.test.ts
+++ b/tests/workflows/session-links.test.ts
@@ -3,6 +3,30 @@ import { test } from "node:test";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { createPiSessionNavigationAdapter, WORKFLOW_SESSION_MARKER_TYPE } from "../../src/integration/session-links.ts";
 
+test("Pi navigation adapter compensates a created replacement back to its restore session", async () => {
+  const switched: string[] = [];
+  let cancelRestore = false;
+  const context = {
+    async newSession(options: { setup?: (manager: unknown) => Promise<void>; withSession?: (ctx: unknown) => Promise<void> }) {
+      await options.setup?.({ appendSessionInfo() {}, appendCustomEntry() {} });
+      await options.withSession?.({ sessionManager: { getSessionId: () => "replacement", getSessionFile: () => "/pi/replacement.jsonl" } });
+      return { cancelled: false };
+    },
+    async switchSession(path: string, options: { withSession?: (ctx: unknown) => Promise<void> }) {
+      switched.push(path);
+      await options.withSession?.({});
+      return { cancelled: cancelRestore };
+    },
+  } as unknown as ExtensionCommandContext;
+  const adapter = createPiSessionNavigationAdapter(context);
+  const created = await adapter.create({ parentSession: "/pi/normal", restoreSession: "/pi/current.jsonl", name: "hive:build:aaaaaaaa", workflowId: "build", activationHash: "a".repeat(64) });
+  assert.equal(typeof created.compensate, "function");
+  await created.compensate?.();
+  assert.deepEqual(switched, ["/pi/current.jsonl"]);
+  cancelRestore = true;
+  await assert.rejects(async () => { await created.compensate!(); }, /restoration was cancelled/i);
+});
+
 test("Pi navigation adapter initializes markers and uses only replacement context", async () => {
   const setupCalls: unknown[] = [];
   const freshManager = { getSessionId: () => "fresh-id", getSessionFile: () => "/pi/fresh.jsonl" };

--- a/tests/workflows/workflow-attempts-recovery.test.ts
+++ b/tests/workflows/workflow-attempts-recovery.test.ts
@@ -134,6 +134,8 @@ test("hash recovery proves applied/not-applied and otherwise remains unknown", (
   assert.deepEqual(reconcileExpectedHashes({ expectedAfterHash: "after", currentHash: "after", appliedResult: { custom: true } }), {
     state: "applied", result: { ok: true, value: { custom: true } },
   });
+  assert.equal(reconcileExpectedHashes({ currentHash: "untracked" }).state, "unknown");
+  assert.equal(reconcileExpectedHashes({}).state, "not-applied");
 });
 
 test("recovery with no pending effects is a no-op and never pauses", async () => {

--- a/tests/workflows/workflow-handoff.test.ts
+++ b/tests/workflows/workflow-handoff.test.ts
@@ -1,0 +1,485 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { canonicalJson } from "../../src/config/snapshot-canonical.ts";
+import { appendWorkflowEvent, readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../../src/workflows/events.ts";
+import {
+  HANDOFF_LIMITS,
+  clearStagedHandoff,
+  createEmptyHandoffState,
+  createHandoffPacket,
+  handoffForRun,
+  handoffPromptInput,
+  hasOpenRun,
+  readHandoffPacket,
+  readHandoffState,
+  reduceHandoffState,
+  restoreHandoffState,
+  stageHandoff,
+  verifyHandoffPacket,
+  verifyHandoffPacketSource,
+} from "../../src/workflows/handoff.ts";
+import {
+  resolveHandoffSource,
+  selectWorkflowSession,
+} from "../../src/workflows/navigation.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+import { TOOL_CONTRACT_LIMITS, buildWorkflowStatusPage } from "../../src/workflows/tools.ts";
+import { initializeNormalParent, listSessionLinks, replaceSessionLinks, type NormalSessionLink, type WorkflowSessionLink } from "../../src/workflows/sessions.ts";
+
+const digest = (character: string) => `sha256:${character.repeat(64)}`;
+const workflow = (workflowId: string, character: string) => ({
+  workflowId,
+  activationHash: character.repeat(64),
+  source: "current" as const,
+  resumable: true,
+  freshEnabled: true,
+  model: "provider/model",
+  thinking: "medium",
+  tools: workflowId === "plan" ? ["read"] : ["write", "bash"],
+});
+
+function fixture() {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-handoff-"));
+  initializeNormalParent({ configured: true, projectRoot, projectId: "project-1", piSessionId: "normal", piSessionFile: "/pi/normal", model: "provider/normal", thinking: "low", activeTools: ["read"] });
+  let next = 0;
+  const calls: string[] = [];
+  const adapter = {
+    async create() { next += 1; calls.push(`create:${next}`); return { piSessionId: `pi-${next}`, piSessionFile: `/pi/${next}.jsonl` }; },
+    async switch(input: { piSessionFile: string; withSession: (ctx: unknown) => Promise<void> | void }) { calls.push(`switch:${input.piSessionFile}`); await input.withSession({}); return { cancelled: false }; },
+  };
+  const owner = (nonce: string) => ({ pid: 100 + next, processMarker: `marker-${nonce}`, nonce, verifyDead: () => true });
+  return { projectRoot, adapter, owner, calls };
+}
+
+function lifecycle(projectRoot: string, sessionId: string, snapshotId: string, runId: string, status: "completed" | "blocked" | "failed" = "completed") {
+  const runtime = new WorkflowRunLifecycle({
+    projectRoot,
+    projectId: "project-1",
+    sessionId,
+    snapshotId,
+    rootNodeId: "root",
+    createRunId: () => runId,
+    completion: {
+      evidence: () => ({ state: "satisfied" }),
+      artifacts: () => ({ state: "satisfied" }),
+      projectState: () => ({
+        state: "satisfied",
+        changeCoverage: "recorded",
+        fileChanges: [{ path: "src/result.ts", operation: "create", afterHash: digest("a"), attribution: "recorded" }],
+      }),
+    },
+  });
+  runtime.recordUserInput({ inputId: `${runId}-input`, text: "produce the source result", source: "interactive" });
+  const delivery = runtime.prepareInputDelivery(`${runId}-request`);
+  runtime.confirmInputDelivery(delivery.requestId);
+  return runtime.finish({
+    status,
+    summary: `${status} source result`,
+    artifactRefs: [{ workspaceId: "workspace-1", checkpoint: "tasks", digest: digest("b") }],
+    evidenceRefs: [{ kind: "test", toolCallId: "call-1", claim: "focused tests passed" }],
+    data: { suggested: "inspect, never authorize" },
+  }, { callerNodeId: "root", toolBatch: ["workflow_finish"] }).then((result) => {
+    assert.equal(result.ok, true);
+    return runtime;
+  });
+}
+
+test("completed, blocked, and failed terminal runs produce bounded authority-free content-addressed packets", async () => {
+  for (const [index, status] of (["completed", "blocked", "failed"] as const).entries()) {
+    const f = fixture();
+    const selected = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner(`source-${index}`) });
+    await lifecycle(f.projectRoot, selected.link.workflowSessionId, selected.link.activationHash, `run-${status}`, status);
+    const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: `run-${status}`, currentPiSessionId: "normal" });
+    assert.equal(packet.terminal.status, status);
+    assert.equal(packet.source.workflowId, "plan");
+    assert.equal(packet.source.snapshotId, selected.link.activationHash);
+    assert.equal(packet.fileChanges[0].path, "src/result.ts");
+    assert.equal(packet.artifactRefs[0].workspaceId, "workspace-1");
+    assert.equal(packet.artifactRefsAreCandidates, true);
+    assert.ok(Buffer.byteLength(JSON.stringify(packet), "utf8") <= HANDOFF_LIMITS.packetBytes);
+    assert.equal(verifyHandoffPacket(packet, "project-1").packetHash, packet.packetHash);
+    const encoded = JSON.stringify(packet);
+    for (const excluded of ["capabilities", "approval", "lease", "budget", "model", "team", "transcript", "pendingQuestion"]) assert.equal(encoded.includes(excluded), false, excluded);
+    assert.deepEqual(handoffPromptInput(packet), {
+      source: "handoff",
+      provenance: `handoff:${packet.packetHash}:plan:run-${status}`,
+      content: packet,
+      ref: `workflow_status:handoff?packetHash=${packet.packetHash}`,
+    });
+  }
+});
+
+test("source resolution rejects missing, nonterminal, cross-project, and invalid last contexts", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  const runtime = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: source.link.workflowSessionId, snapshotId: source.link.activationHash, rootNodeId: "root", createRunId: () => "open-run" });
+  runtime.recordUserInput({ inputId: "open-input", text: "still running", source: "interactive" });
+  assert.throws(() => resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "open-run", currentPiSessionId: "normal" }), /terminal/i);
+  assert.throws(() => resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "missing", currentPiSessionId: "normal" }), /missing/i);
+  assert.throws(() => resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "other-project", runId: "open-run", currentPiSessionId: "normal" }), /project/i);
+  assert.throws(() => resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "last", currentPiSessionId: "normal" }), /last.*workflow/i);
+  assert.throws(() => resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "last", currentPiSessionId: source.link.piSessionId }), /terminal/i);
+});
+
+test("last chooses the newest terminal run only in the selected source workflow", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "older");
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "newer");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "last", currentPiSessionId: source.link.piSessionId });
+  assert.equal(packet.source.runId, "newer");
+});
+
+test("staging survives restart, rejects conflicts/open targets, clears only while idle, and consumes once with run creation", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "source-run");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-run", currentPiSessionId: "normal" });
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), fresh: true, stagedHandoff: packet, adapter: f.adapter, owner: f.owner("target") });
+  assert.equal(f.calls.some((call) => call.startsWith("run:") || call.startsWith("model:")), false);
+  assert.equal(readHandoffState(f.projectRoot, target.link.workflowSessionId).staged?.packetHash, packet.packetHash);
+  assert.equal(readHandoffState(f.projectRoot, target.link.workflowSessionId).consumed.length, 0);
+
+  const restarted = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: target.link.workflowSessionId, snapshotId: target.link.activationHash, rootNodeId: "root", createRunId: () => "target-run" });
+  const first = restarted.recordUserInput({ inputId: "ordinary-callback", text: "implement independently", source: "interactive" });
+  const duplicate = restarted.recordUserInput({ inputId: "ordinary-callback", text: "implement independently", source: "interactive" });
+  assert.equal(first.created, true);
+  assert.equal(duplicate.duplicate, true);
+  assert.equal(restarted.restore().latestRun?.handoffPacketHash, packet.packetHash);
+  const consumed = readHandoffState(f.projectRoot, target.link.workflowSessionId);
+  assert.equal(consumed.staged, undefined);
+  assert.deepEqual(consumed.consumed.map((entry) => [entry.packet.packetHash, entry.runId]), [[packet.packetHash, "target-run"]]);
+  assert.equal(readWorkflowJournal(f.projectRoot, target.link.workflowSessionId).filter((event) => event.type === "run.started").length, 1);
+  assert.throws(() => clearStagedHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId }), /idle/i);
+  assert.throws(() => stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, targetWorkflowId: "build", packet }), /idle|open run/i);
+});
+
+test("clear is CAS/idempotent and a conflicting packet rejects before a target switch", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "source-1");
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "source-2");
+  const one = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-1", currentPiSessionId: "normal" });
+  const two = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-2", currentPiSessionId: "normal" });
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), fresh: true, stagedHandoff: one, adapter: f.adapter, owner: f.owner("target") });
+  assert.deepEqual(stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, targetWorkflowId: "build", packet: one }).duplicate, true);
+  assert.throws(() => stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, targetWorkflowId: "build", packet: two }), /conflicting staged handoff/i);
+  assert.throws(() => stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: source.link.workflowSessionId, targetWorkflowId: "plan", packet: one }), /different workflow/i);
+  assert.throws(() => clearStagedHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, expectedPacketHash: "f".repeat(64) }), /changed before clear/i);
+  const switches = f.calls.length;
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), stagedHandoff: two, adapter: f.adapter, owner: f.owner("target") }), /conflicting.*handoff/i);
+  assert.equal(f.calls.length, switches, "conflict must reject before any navigation callback");
+  assert.equal(clearStagedHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, expectedPacketHash: one.packetHash, now: () => "2025-01-01T00:00:00.000Z" }).cleared, true);
+  assert.equal(clearStagedHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId }).cleared, false);
+  assert.equal(readHandoffState(f.projectRoot, target.link.workflowSessionId).staged, undefined);
+});
+
+test("staging rejects a self-consistent caller-hashed packet that diverges from its authoritative source terminal", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "source-run");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-run", currentPiSessionId: "normal" });
+  const { packetHash: _packetHash, ...identity } = packet;
+  const fabricatedIdentity = { ...identity, terminal: { ...identity.terminal, summary: "caller-fabricated but self-hashed" } };
+  const fabricated = {
+    ...fabricatedIdentity,
+    packetHash: createHash("sha256").update("pi-hive-handoff-packet-v1\0").update(canonicalJson(fabricatedIdentity)).digest("hex"),
+  };
+  assert.equal(verifyHandoffPacket(fabricated, "project-1").terminal.summary, "caller-fabricated but self-hashed", "structural verification alone cannot establish journal authority");
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), adapter: f.adapter, owner: f.owner("target") });
+  const calls = f.calls.length;
+  assert.throws(() => stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, targetWorkflowId: "build", packet: fabricated as never }), /authoritative source terminal envelope/i);
+  assert.equal(f.calls.length, calls);
+  assert.equal(readHandoffState(f.projectRoot, target.link.workflowSessionId).staged, undefined);
+});
+
+test("large handoff content exposes bounded actionable workflow_status pages resolved by packet hash", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  const runtime = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: source.link.workflowSessionId, snapshotId: source.link.activationHash, rootNodeId: "root", createRunId: () => "large-run" });
+  runtime.recordUserInput({ inputId: "large-input", text: "produce large handoff", source: "interactive" });
+  const delivery = runtime.prepareInputDelivery("large-delivery");
+  runtime.confirmInputDelivery(delivery.requestId);
+  const finished = await runtime.finish({ status: "completed", summary: "large", data: { body: "x".repeat(50_000) } }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(finished.ok, true);
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "large-run", currentPiSessionId: "normal" });
+  const promptInput = handoffPromptInput(packet);
+  assert.equal(promptInput.ref, `workflow_status:handoff?packetHash=${packet.packetHash}`);
+  const lifecycleState = { sessionId: "target", latestRun: { runId: "target-run", handoffPacketHash: packet.packetHash } } as never;
+  const chunks: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = buildWorkflowStatusPage({ snapshot: {} as never, lifecycle: lifecycleState, handoff: packet }, { section: "handoff", packetHash: packet.packetHash, limit: 1, ...(cursor ? { cursor } : {}) });
+    assert.ok(Buffer.byteLength(canonicalJson(page), "utf8") <= TOOL_CONTRACT_LIMITS.outputBytes);
+    chunks.push(...(page.items as Array<{ content: string }>).map((item) => item.content));
+    cursor = page.nextCursor;
+  } while (cursor);
+  assert.equal(chunks.join(""), canonicalJson(packet));
+  assert.throws(() => buildWorkflowStatusPage({ snapshot: {} as never, lifecycle: lifecycleState, handoff: packet }, { section: "handoff", packetHash: "0".repeat(64) }), /not bound/i);
+});
+
+test("packet structural and byte limits reject authority smuggling and preserve candidate artifact evidence", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "source-run");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-run", currentPiSessionId: "normal" });
+  assert.throws(() => verifyHandoffPacket({ ...packet, capabilities: { filesystem: ["**"] } } as never, "project-1"), /unsupported field/i);
+  assert.throws(() => verifyHandoffPacket({ ...packet, data: { oversized: "x".repeat(HANDOFF_LIMITS.dataBytes + 1) } } as never, "project-1"), /limit/i);
+  const malformed: Array<[unknown, RegExp]> = [
+    [null, /invalid/i],
+    [{ ...packet, formatVersion: 2 }, /unsupported/i],
+    [{ ...packet, packetHash: "bad" }, /digest/i],
+    [{ ...packet, createdAt: "never" }, /createdAt/i],
+    [{ ...packet, source: { ...packet.source, projectId: "other" } }, /project/i],
+    [{ ...packet, source: { ...packet.source, terminalEventHash: "0" } }, /digest/i],
+    [{ ...packet, terminal: { ...packet.terminal, status: "running" } }, /status/i],
+    [{ ...packet, terminal: { ...packet.terminal, finishedAt: "never" } }, /finishedAt/i],
+    [{ ...packet, artifactRefsAreCandidates: false }, /candidate/i],
+    [{ ...packet, fileChanges: "none" }, /file changes/i],
+    [{ ...packet, artifactRefs: [{ ...packet.artifactRefs[0], extra: true }] }, /unsupported field/i],
+    [{ ...packet, evidenceRefs: [{ kind: "test", claim: "ok", extra: true }] }, /unsupported field/i],
+    [{ ...packet, data: [] }, /plain JSON object/i],
+    [{ ...packet, data: { invalid: Number.NaN } }, /not JSON/i],
+    [{ ...packet, terminal: { ...packet.terminal, summary: "changed" } }, /hash mismatch/i],
+  ];
+  for (const [candidate, expected] of malformed) assert.throws(() => verifyHandoffPacket(candidate, "project-1"), expected);
+  assert.equal(packet.artifactRefsAreCandidates, true);
+  assert.equal(Object.isFrozen(packet), true);
+});
+
+function packetFixture(overrides: Record<string, unknown> = {}) {
+  return createHandoffPacket({
+    projectId: "project-1",
+    workflowId: "plan",
+    sessionId: "workflow-plan",
+    createdAt: "2025-01-01T00:00:01.000Z",
+    terminal: {
+      runId: "run-1",
+      snapshotId: "a".repeat(64),
+      terminalEventHash: "b".repeat(64),
+      status: "completed",
+      summary: "done",
+      finishedAt: "2025-01-01T00:00:00.000Z",
+      fileChanges: [],
+      changeCoverage: "recorded",
+      artifactRefs: [],
+      evidenceRefs: [],
+      data: {},
+      ...overrides,
+    } as never,
+  });
+}
+
+function handoffEvent(type: string, payload: unknown, producer = "harness", runId?: string) {
+  return {
+    projectId: "project-1",
+    sessionId: "target",
+    eventId: `event-${type}-${producer}-${runId ?? "none"}`,
+    sequence: 1,
+    previousHash: null,
+    eventHash: "c".repeat(64),
+    timestamp: "2025-01-01T00:00:02.000Z",
+    type,
+    payload,
+    producer,
+    ...(runId === undefined ? {} : { runId }),
+  } as never;
+}
+
+test("handoff validation exercises every file-change shape, JSON kind, and optional reference field", () => {
+  const packet = packetFixture({
+    fileChanges: [
+      { path: "created.ts", operation: "create", afterHash: digest("1"), attribution: "recorded" },
+      { path: "updated.ts", operation: "update", beforeHash: digest("2"), afterHash: digest("3"), attribution: "reconciled" },
+      { path: "deleted.ts", operation: "delete", beforeHash: digest("4"), attribution: "unknown" },
+      { path: "renamed.ts", previousPath: "old.ts", operation: "rename", beforeHash: digest("5"), afterHash: digest("6"), attribution: "git-reconciled" },
+      { path: "scoped.ts", operation: "create", afterHash: digest("7"), attribution: "scoped-reconciled" },
+      { path: "conflict.ts", operation: "create", afterHash: digest("8"), attribution: "conflicted" },
+      { path: "unknown.ts", operation: "create", afterHash: digest("9"), attribution: "unattributed" },
+    ],
+    artifactRefs: [{ workspaceId: "workspace", checkpoint: "checkpoint", digest: digest("d") }],
+    evidenceRefs: [{ kind: "test", claim: "passed" }, { kind: "tool", toolCallId: "call-1", claim: "observed" }],
+    data: { nil: null, flag: true, count: 2, nested: [{ value: "ok" }, false] },
+  });
+  const verified = verifyHandoffPacket(packet);
+  assert.deepEqual(verified.fileChanges.map((change) => change.operation), ["create", "update", "delete", "rename", "create", "create", "create"]);
+  assert.equal("toolCallId" in verified.evidenceRefs[0], false);
+  assert.equal(verified.evidenceRefs[1].toolCallId, "call-1");
+  assert.equal(Object.isFrozen(verified.data.nested), true);
+  assert.match(createHandoffPacket({
+    projectId: "project-1", workflowId: "plan", sessionId: "workflow-plan",
+    terminal: {
+      runId: "default-time", snapshotId: "a".repeat(64), terminalEventHash: "b".repeat(64), status: "completed", summary: "done",
+      finishedAt: "2025-01-01T00:00:00.000Z", fileChanges: [], changeCoverage: "recorded", artifactRefs: [], evidenceRefs: [], data: {},
+    } as never,
+  }).createdAt, /^\d{4}-/u);
+});
+
+test("handoff validation rejects bounded-field, path, collection, and hash-shape edge cases", () => {
+  const packet = packetFixture();
+  const candidates: Array<[unknown, RegExp]> = [
+    [{ ...packet, terminal: { ...packet.terminal, summary: 7 } }, /summary.*invalid/i],
+    [{ ...packet, terminal: { ...packet.terminal, summary: " " } }, /summary.*invalid/i],
+    [{ ...packet, terminal: { ...packet.terminal, summary: "bad\0text" } }, /summary.*invalid/i],
+    [{ ...packet, source: null }, /source.*invalid/i],
+    [{ ...packet, source: { ...packet.source, sessionId: "" } }, /session.*invalid/i],
+    [{ ...packet, source: { ...packet.source, extra: true } }, /unsupported field/i],
+    [{ ...packet, source: { projectId: "project-1" } }, /missing field/i],
+    [{ ...packet, terminal: null }, /terminal.*invalid/i],
+    [{ ...packet, terminal: { status: "completed", summary: "done" } }, /missing field/i],
+    [{ ...packet, fileChanges: Array(HANDOFF_LIMITS.fileChanges + 1).fill(null) }, /file changes.*limit/i],
+    [{ ...packet, fileChanges: [null] }, /fileChanges\[0\].*invalid/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "create", afterHash: digest("1"), attribution: "recorded", authority: true }] }, /unsupported field/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "move", attribution: "recorded" }] }, /operation.*invalid/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "create", afterHash: digest("1"), attribution: "invented" }] }, /attribution.*invalid/i],
+    ...(["/absolute", "back\\slash", "double//part", "dot/./part", "up/../part"] as const).map((path) => [{ ...packet, fileChanges: [{ path, operation: "create", afterHash: digest("1"), attribution: "recorded" }] }, /normalized project-relative path/i] as [unknown, RegExp]),
+    [{ ...packet, fileChanges: [{ path: "a", operation: "create", beforeHash: digest("1"), afterHash: digest("2"), attribution: "recorded" }] }, /create change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "old", operation: "create", afterHash: digest("2"), attribution: "recorded" }] }, /create change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "create", attribution: "recorded" }] }, /create change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "update", afterHash: digest("2"), attribution: "recorded" }] }, /update change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "update", beforeHash: digest("1"), attribution: "recorded" }] }, /update change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "old", operation: "update", beforeHash: digest("1"), afterHash: digest("2"), attribution: "recorded" }] }, /update change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "delete", attribution: "recorded" }] }, /delete change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "delete", beforeHash: digest("1"), afterHash: digest("2"), attribution: "recorded" }] }, /delete change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "old", operation: "delete", beforeHash: digest("1"), attribution: "recorded" }] }, /delete change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "old", operation: "rename", afterHash: digest("2"), attribution: "recorded" }] }, /rename change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "old", operation: "rename", beforeHash: digest("1"), attribution: "recorded" }] }, /rename change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", operation: "rename", beforeHash: digest("1"), afterHash: digest("2"), attribution: "recorded" }] }, /rename change hash shape/i],
+    [{ ...packet, fileChanges: [{ path: "a", previousPath: "a", operation: "rename", beforeHash: digest("1"), afterHash: digest("2"), attribution: "recorded" }] }, /rename change hash shape/i],
+    [{ ...packet, artifactRefs: "none" }, /artifact refs.*limit/i],
+    [{ ...packet, artifactRefs: Array(HANDOFF_LIMITS.referenceItems + 1).fill(null) }, /artifact refs.*limit/i],
+    [{ ...packet, artifactRefs: [null] }, /artifactRefs\[0\].*invalid/i],
+    [{ ...packet, artifactRefs: [{ workspaceId: "w", checkpoint: "c" }] }, /missing field/i],
+    [{ ...packet, evidenceRefs: "none" }, /evidence refs.*limit/i],
+    [{ ...packet, evidenceRefs: Array(HANDOFF_LIMITS.referenceItems + 1).fill(null) }, /evidence refs.*limit/i],
+    [{ ...packet, evidenceRefs: [null] }, /evidenceRefs\[0\].*invalid/i],
+    [{ ...packet, evidenceRefs: [{ kind: "test" }] }, /missing field/i],
+    [{ ...packet, evidenceRefs: [{ kind: "test", toolCallId: "", claim: "ok" }] }, /tool call.*invalid/i],
+    [{ ...packet, data: { deep: Array.from({ length: HANDOFF_LIMITS.dataDepth + 1 }).reduce<unknown[]>((value) => [value], []) } }, /structural limit/i],
+    [{ ...packet, data: Object.fromEntries(Array.from({ length: HANDOFF_LIMITS.dataNodes + 1 }, (_, index) => [`k${index}`, null])) }, /structural limit/i],
+    [{ ...packet, data: { date: new Date() } }, /not JSON/i],
+    [{ ...packet, data: { "": true } }, /data key.*invalid/i],
+  ];
+  for (const [candidate, expected] of candidates) assert.throws(() => verifyHandoffPacket(candidate, "project-1"), expected);
+
+  const refs = Array.from({ length: HANDOFF_LIMITS.referenceItems }, (_, index) => ({ workspaceId: `w${index}${"x".repeat(2_000)}`, checkpoint: `c${index}${"y".repeat(2_000)}`, digest: digest("d") }));
+  assert.throws(() => packetFixture({ artifactRefs: refs }), /packet exceeds.*byte limit/i);
+});
+
+test("handoff reducer rejects malformed authority transitions and resolves staged and consumed lookups", () => {
+  const packet = packetFixture();
+  const stage = handoffEvent("handoff.recorded", { formatVersion: 1, operation: "stage", packet });
+  const staged = reduceHandoffState(createEmptyHandoffState(), stage);
+  assert.equal(staged.staged?.packetHash, packet.packetHash);
+  assert.throws(() => reduceHandoffState(staged, stage), /already exists/i);
+  assert.throws(() => reduceHandoffState(createEmptyHandoffState(), handoffEvent("handoff.recorded", { formatVersion: 1, operation: "stage", packet }, "runtime")), /authority/i);
+  assert.throws(() => reduceHandoffState(createEmptyHandoffState(), handoffEvent("handoff.recorded", null)), /payload.*invalid/i);
+  assert.throws(() => reduceHandoffState(createEmptyHandoffState(), handoffEvent("handoff.recorded", { formatVersion: 2, operation: "stage", packet })), /payload.*invalid/i);
+  assert.throws(() => reduceHandoffState(createEmptyHandoffState(), handoffEvent("handoff.recorded", { formatVersion: 1, operation: "replace" })), /operation.*unsupported/i);
+  assert.throws(() => reduceHandoffState(createEmptyHandoffState(), handoffEvent("handoff.recorded", { formatVersion: 1, operation: "clear", packetHash: packet.packetHash })), /changed before clear/i);
+  assert.throws(() => reduceHandoffState(staged, handoffEvent("handoff.recorded", { formatVersion: 1, operation: "clear", packetHash: "f".repeat(64) })), /changed before clear/i);
+
+  const noHandoff = handoffEvent("run.started", { input: { inputId: "input" } }, "runtime", "run-1");
+  assert.equal(reduceHandoffState(staged, noHandoff), staged);
+  assert.throws(() => reduceHandoffState(staged, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: null }, "runtime", "run-1")), /input.*invalid/i);
+  assert.throws(() => reduceHandoffState(staged, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: { inputId: "input" } }, "harness", "run-1")), /runtime authority/i);
+  assert.throws(() => reduceHandoffState(staged, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: { inputId: "input" } }, "runtime")), /runtime authority/i);
+  assert.throws(() => reduceHandoffState(staged, handoffEvent("run.started", { handoffPacketHash: "f".repeat(64), input: { inputId: "input" } }, "runtime", "run-1")), /missing or different/i);
+  assert.throws(() => reduceHandoffState({ staged: packet, consumed: Array(HANDOFF_LIMITS.consumedRecords).fill({}) } as never, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: { inputId: "input" } }, "runtime", "run-1")), /history exceeds/i);
+
+  const consumed = reduceHandoffState(staged, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: { inputId: "input" } }, "runtime", "run-1"));
+  assert.equal(handoffForRun([stage, handoffEvent("run.started", { handoffPacketHash: packet.packetHash, input: { inputId: "input" } }, "runtime", "run-1")], "run-1")?.packetHash, packet.packetHash);
+  assert.equal(handoffForRun([stage], "missing"), undefined);
+  assert.equal(consumed.consumed[0].inputId, "input");
+  assert.equal(hasOpenRun([handoffEvent("run.started", {}, "runtime", "run-1")]), true);
+  assert.equal(hasOpenRun([handoffEvent("run.started", {}, "runtime", "run-1"), handoffEvent("terminal.recorded", {}, "harness", "other")]), true);
+  assert.equal(hasOpenRun([handoffEvent("run.started", {}, "runtime", "run-1"), handoffEvent("terminal.recorded", {}, "harness", "run-1")]), false);
+  assert.deepEqual(restoreHandoffState([]), { consumed: [] });
+});
+
+test("authoritative handoff source verification rejects each link, journal, and terminal mismatch", async () => {
+  const link = (overrides: Partial<WorkflowSessionLink> = {}): WorkflowSessionLink => ({
+    kind: "workflow", formatVersion: 1, workflowSessionId: "workflow-plan", workflowId: "plan", activationHash: "a".repeat(64),
+    piSessionId: "pi-plan", piSessionFile: "/pi/plan", normalParentId: "normal", normalParentFile: "/pi/normal", status: "current",
+    stale: false, model: "provider/model", thinking: "medium", tools: [], createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z", name: "hive:plan:aaaaaaaa", ...overrides,
+  });
+  const packet = packetFixture();
+
+  const unlinked = fixture();
+  assert.throws(() => verifyHandoffPacketSource(unlinked.projectRoot, "project-1", packet), /not linked/i);
+
+  const wrongWorkflow = fixture();
+  replaceSessionLinks(wrongWorkflow.projectRoot, [listNormal(wrongWorkflow.projectRoot), link({ workflowId: "other" })]);
+  assert.throws(() => verifyHandoffPacketSource(wrongWorkflow.projectRoot, "project-1", packet), /not linked/i);
+
+  const wrongActivation = fixture();
+  replaceSessionLinks(wrongActivation.projectRoot, [listNormal(wrongActivation.projectRoot), link({ activationHash: "c".repeat(64) })]);
+  assert.throws(() => verifyHandoffPacketSource(wrongActivation.projectRoot, "project-1", packet), /snapshot.*linked activation/i);
+
+  const emptyJournal = fixture();
+  replaceSessionLinks(emptyJournal.projectRoot, [listNormal(emptyJournal.projectRoot), link()]);
+  assert.throws(() => verifyHandoffPacketSource(emptyJournal.projectRoot, "project-1", packet), /missing canonical project/i);
+
+  const missingTerminal = fixture();
+  replaceSessionLinks(missingTerminal.projectRoot, [listNormal(missingTerminal.projectRoot), link()]);
+  appendWorkflowEvent(missingTerminal.projectRoot, createWorkflowEvent({ projectId: "project-1", sessionId: "workflow-plan", type: "session.created", payload: {}, producer: "runtime" }));
+  assert.throws(() => verifyHandoffPacketSource(missingTerminal.projectRoot, "project-1", packet), /one authoritative terminal/i);
+
+  const wrongTerminal = fixture();
+  replaceSessionLinks(wrongTerminal.projectRoot, [listNormal(wrongTerminal.projectRoot), link()]);
+  await lifecycle(wrongTerminal.projectRoot, "workflow-plan", "a".repeat(64), "run-1");
+  assert.throws(() => verifyHandoffPacketSource(wrongTerminal.projectRoot, "project-1", packet), /terminal event hash or authority/i);
+});
+
+function listNormal(projectRoot: string): NormalSessionLink {
+  return listSessionLinks(projectRoot).find((entry): entry is NormalSessionLink => entry.kind === "normal")!;
+}
+
+test("selection compensates a staged handoff when target resume navigation is cancelled", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "cancel-source");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "cancel-source", currentPiSessionId: "normal" });
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("plan", "a"), stagedHandoff: packet, adapter: f.adapter, owner: f.owner("source") }), /different workflow/i);
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), adapter: f.adapter, owner: f.owner("target") });
+  assert.equal(stageHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, targetWorkflowId: "build", packet, now: () => "2025-01-01T00:00:00.000Z" }).staged, true);
+  assert.equal(clearStagedHandoff({ projectRoot: f.projectRoot, projectId: "project-1", targetSessionId: target.link.workflowSessionId, now: () => "2025-01-01T00:00:01.000Z" }).cleared, true);
+  const cancelling = { ...f.adapter, async switch() { return { cancelled: true }; } };
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: target.link.piSessionId, workflow: workflow("build", "b"), stagedHandoff: packet, adapter: cancelling, owner: f.owner("target") }), /switch cancelled/i);
+  assert.equal(readHandoffState(f.projectRoot, target.link.workflowSessionId).staged, undefined, "failed navigation clears the newly staged packet");
+});
+
+test("source resolution rejects ambiguous run IDs and terminal/link snapshot drift", async () => {
+  const ambiguous = fixture();
+  const plan = await selectWorkflowSession({ projectRoot: ambiguous.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: ambiguous.adapter, owner: ambiguous.owner("plan") });
+  const build = await selectWorkflowSession({ projectRoot: ambiguous.projectRoot, projectId: "project-1", currentPiSessionId: plan.link.piSessionId, workflow: workflow("build", "b"), adapter: ambiguous.adapter, owner: ambiguous.owner("build") });
+  await lifecycle(ambiguous.projectRoot, plan.link.workflowSessionId, plan.link.activationHash, "duplicate-run");
+  await lifecycle(ambiguous.projectRoot, build.link.workflowSessionId, build.link.activationHash, "duplicate-run");
+  assert.throws(() => resolveHandoffSource({ projectRoot: ambiguous.projectRoot, projectId: "project-1", runId: "duplicate-run", currentPiSessionId: "normal" }), /ambiguous/i);
+
+  const drift = fixture();
+  const selected = await selectWorkflowSession({ projectRoot: drift.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: drift.adapter, owner: drift.owner("drift") });
+  await lifecycle(drift.projectRoot, selected.link.workflowSessionId, selected.link.activationHash, "drift-run");
+  replaceSessionLinks(drift.projectRoot, listSessionLinks(drift.projectRoot).map((entry) => entry.kind === "workflow" ? { ...entry, activationHash: "c".repeat(64) } : entry));
+  assert.throws(() => resolveHandoffSource({ projectRoot: drift.projectRoot, projectId: "project-1", runId: "drift-run", currentPiSessionId: "normal" }), /snapshot.*linked activation/i);
+});
+
+test("handoff packet lookup finds staged and consumed packets and validates references", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: f.owner("source") });
+  await lifecycle(f.projectRoot, source.link.workflowSessionId, source.link.activationHash, "lookup-source");
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "lookup-source", currentPiSessionId: "normal" });
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), fresh: true, stagedHandoff: packet, adapter: f.adapter, owner: f.owner("target") });
+  assert.equal(readHandoffPacket(f.projectRoot, target.link.workflowSessionId, packet.packetHash)?.packetHash, packet.packetHash);
+  assert.equal(readHandoffPacket(f.projectRoot, target.link.workflowSessionId, "f".repeat(64)), undefined);
+  const runtime = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: target.link.workflowSessionId, snapshotId: target.link.activationHash, rootNodeId: "root", createRunId: () => "lookup-target" });
+  runtime.recordUserInput({ inputId: "lookup-input", text: "consume", source: "interactive" });
+  assert.equal(readHandoffPacket(f.projectRoot, target.link.workflowSessionId, packet.packetHash)?.packetHash, packet.packetHash);
+  assert.throws(() => readHandoffPacket(f.projectRoot, target.link.workflowSessionId, "bad"), /digest/i);
+});

--- a/tests/workflows/workflow-navigation.test.ts
+++ b/tests/workflows/workflow-navigation.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { initializeNormalParent, listSessionLinks } from "../../src/workflows/sessions.ts";
-import { exitWorkflowSession, selectWorkflowSession } from "../../src/workflows/navigation.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+import { releaseRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import { exitWorkflowSession, reloadWorkflowSession, selectWorkflowSession } from "../../src/workflows/navigation.ts";
 
 function setup() { const projectRoot = mkdtempSync(join(tmpdir(), "hive-nav-")); initializeNormalParent({ configured: true, projectRoot, projectId: "p", piSessionId: "normal", piSessionFile: "/pi/normal", model: "provider/normal", thinking: "low", activeTools: ["read"] }); const calls: any[] = []; let next = 0; const adapter = { async create(input: any) { calls.push(["create", input]); next++; return { piSessionId: `child-${next}`, piSessionFile: `/pi/child-${next}` }; }, async switch(input: any) { calls.push(["switch", input.piSessionFile]); await input.withSession({ fresh: true, sessionId: input.piSessionFile }); return { cancelled: false }; } }; return { projectRoot, adapter, calls }; }
 const workflow = { workflowId: "build", activationHash: "b".repeat(64), source: "current" as const, resumable: true, freshEnabled: true, model: "provider/model", thinking: "high", tools: ["bash", "write"] };
@@ -44,4 +46,107 @@ test("failed fresh creation preserves the current activation and ownership", asy
   assert.ok(current?.kind === "workflow");
   assert.equal(current.workflowSessionId, first.link.workflowSessionId);
   assert.equal((await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "original", verifyDead: () => false } })).kind, "resumed");
+});
+
+test("selection rejects missing parents, project mismatches, and each incompatible resume condition", async () => {
+  const empty = mkdtempSync(join(tmpdir(), "hive-nav-empty-"));
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: empty, projectId: "p", currentPiSessionId: "normal", workflow, adapter: setup().adapter, owner: { pid: 1, processMarker: "m", nonce: "o", verifyDead: () => true } }), /normal parent.*missing/i);
+
+  const mismatch = setup();
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: mismatch.projectRoot, projectId: "other", currentPiSessionId: "normal", workflow, adapter: mismatch.adapter, owner: { pid: 1, processMarker: "m", nonce: "o", verifyDead: () => true } }), /project identity/i);
+
+  for (const candidate of [{ ...workflow, resumable: false }, { ...workflow, activationHash: "c".repeat(64) }]) {
+    const f = setup();
+    await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } });
+    await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow: candidate, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } }), /not resumable|compatible/i);
+  }
+});
+
+test("cancelled resume and fresh-source gates fail before publishing selection events", async () => {
+  const cancelled = setup();
+  await selectWorkflowSession({ projectRoot: cancelled.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: cancelled.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } });
+  const cancellingAdapter = { ...cancelled.adapter, async switch() { return { cancelled: true }; } };
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: cancelled.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: cancellingAdapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } }), /switch cancelled/i);
+
+  for (const candidate of [{ ...workflow, source: "missing" as const }, { ...workflow, freshEnabled: false }]) {
+    const f = setup();
+    await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow: candidate, fresh: true, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "fresh", verifyDead: () => true } }), /fresh selection blocked/i);
+  }
+});
+
+test("fresh selection compensates pre-commit faults and reports compensation failure", async () => {
+  for (const compensateFails of [false, true, "non-error"] as const) {
+    const f = setup();
+    let compensated = 0;
+    const adapter = {
+      ...f.adapter,
+      async create(input: any) {
+        await f.adapter.create(input);
+        return {
+          piSessionId: "candidate", piSessionFile: "/pi/candidate",
+          async compensate() { compensated += 1; if (compensateFails === true) throw new Error("compensate failed"); if (compensateFails === "non-error") throw "compensate failed"; },
+        };
+      },
+    };
+    const selection = selectWorkflowSession({
+      projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "unknown", workflow, adapter,
+      owner: { pid: 1, processMarker: "m", nonce: "candidate-owner", verifyDead: () => true },
+      beforeCommit: () => { throw new Error("commit probe failed"); },
+    });
+    await assert.rejects(() => selection, compensateFails === false ? /commit probe failed/i : /compensation was incomplete/i);
+    assert.equal(compensated, 1);
+    assert.equal(listSessionLinks(f.projectRoot).some((entry) => entry.kind === "workflow"), false);
+  }
+});
+
+test("reload rejects normal chat, open runs, and every invalid prepared activation dimension", async () => {
+  const normal = setup();
+  await assert.rejects(() => reloadWorkflowSession({ projectRoot: normal.projectRoot, projectId: "p", currentPiSessionId: "normal", adapter: normal.adapter, owner: { pid: 1, processMarker: "m", nonce: "o", verifyDead: () => true }, prepareActivation: () => ({ workflow }) }), /currently selected workflow/i);
+
+  const open = setup();
+  const selected = await selectWorkflowSession({ projectRoot: open.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: open.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } });
+  const runtime = new WorkflowRunLifecycle({ projectRoot: open.projectRoot, projectId: "p", sessionId: selected.link.workflowSessionId, snapshotId: selected.link.activationHash, rootNodeId: "root", createRunId: () => "open" });
+  runtime.recordUserInput({ inputId: "input", text: "work", source: "interactive" });
+  await assert.rejects(() => reloadWorkflowSession({ projectRoot: open.projectRoot, projectId: "p", currentPiSessionId: selected.link.piSessionId, adapter: open.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false }, prepareActivation: () => ({ workflow }) }), /idle workflow/i);
+
+  for (const candidate of [{ ...workflow, workflowId: "other" }, { ...workflow, source: "stale" as const }, { ...workflow, freshEnabled: false }]) {
+    const f = setup();
+    const current = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false } });
+    await assert.rejects(() => reloadWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: current.link.piSessionId, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "held", verifyDead: () => false }, prepareActivation: () => ({ workflow: candidate }) }), /fresh-compatible workflow/i);
+  }
+});
+
+test("fresh creation releases newly acquired prior ownership when the adapter fails", async () => {
+  const f = setup();
+  const selected = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "original", verifyDead: () => true } });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, selected.link.workflowSessionId, "original"), true);
+  const failing = { ...f.adapter, async create() { throw new Error("fresh create failed"); } };
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: selected.link.piSessionId, workflow, fresh: true, adapter: failing, owner: { pid: 2, processMarker: "m2", nonce: "replacement", verifyDead: () => true } }), /fresh create failed/i);
+  const reacquired = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 3, processMarker: "m3", nonce: "after-fault", verifyDead: () => true } });
+  assert.equal(reacquired.kind, "resumed");
+});
+
+test("corrupt ownership state is not mistaken for an absent owner", async () => {
+  const f = setup();
+  const selected = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "owner", verifyDead: () => true } });
+  writeFileSync(join(f.projectRoot, ".pi/hive/sessions", selected.link.workflowSessionId, "runtime-owner.json"), "not-json");
+  await assert.rejects(() => selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: selected.link.piSessionId, workflow, adapter: f.adapter, owner: { pid: 2, processMarker: "m2", nonce: "other", verifyDead: () => true } }), /Unexpected|JSON|owner/i);
+});
+
+test("exit from normal chat does not require workflow ownership and cancellation stays fail-closed", async () => {
+  const f = setup();
+  assert.equal((await exitWorkflowSession({ projectRoot: f.projectRoot, currentPiSessionId: "normal", ownerNonce: "none", adapter: f.adapter })).piSessionId, "normal");
+  const cancelledAdapter = { ...f.adapter, async switch() { return { cancelled: true }; } };
+  await assert.rejects(() => exitWorkflowSession({ projectRoot: f.projectRoot, currentPiSessionId: "normal", ownerNonce: "none", adapter: cancelledAdapter }), /switch cancelled/i);
+
+  const selected = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "p", currentPiSessionId: "normal", workflow, adapter: f.adapter, owner: { pid: 1, processMarker: "m", nonce: "exit-owner", verifyDead: () => true } });
+  const releasingAdapter = {
+    ...f.adapter,
+    async switch(input: any) {
+      await input.withSession({});
+      assert.equal(releaseRuntimeOwnership(f.projectRoot, selected.link.workflowSessionId, "exit-owner"), true);
+      return { cancelled: false };
+    },
+  };
+  await assert.rejects(() => exitWorkflowSession({ projectRoot: f.projectRoot, currentPiSessionId: selected.link.piSessionId, ownerNonce: "exit-owner", adapter: releasingAdapter }), /ownership release failed/i);
 });

--- a/tests/workflows/workflow-reload-recovery.test.ts
+++ b/tests/workflows/workflow-reload-recovery.test.ts
@@ -1,0 +1,544 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { hashActivationPayload } from "../../src/config/snapshot-canonical.ts";
+import { snapshotFilePath, writeActivationSnapshot } from "../../src/config/snapshot-store.ts";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { reloadWorkflowSession, selectWorkflowSession } from "../../src/workflows/navigation.ts";
+import { releaseRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import {
+  detectOrphanedWorkflowSessions,
+  recoverOrphanedWorkflowSession,
+} from "../../src/workflows/recovery.ts";
+import { buildWorkflowSelector } from "../../src/workflows/registry.ts";
+import { initializeNormalParent, listSessionLinks, replaceSessionLinks } from "../../src/workflows/sessions.ts";
+import { readHandoffState } from "../../src/workflows/handoff.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+
+const selectable = (activationHash: string) => ({ workflowId: "build", activationHash, source: "current" as const, resumable: true, freshEnabled: true, model: "provider/model", thinking: "medium", tools: ["write"] });
+
+function recoverySnapshot(identity: { projectId?: string; workflowId?: string } = {}): ActivationSnapshotFileV1 {
+  const effective = { filesystem: [], shell: [], git: false, "external-network": false, "human-input": false, artifact: [], knowledge: [] };
+  const provenance = { filesystem: ["agent-ceiling", "inherited"], shell: ["agent-ceiling", "inherited"], git: ["agent-ceiling", "inherited"], "external-network": ["agent-ceiling", "inherited"], "human-input": ["agent-ceiling", "inherited"], artifact: ["agent-ceiling", "inherited"], knowledge: ["agent-ceiling", "inherited"] };
+  const payload = {
+    versions: { snapshot: 1, packageContract: "pi-hive-package-contract-v1", schema: 1, capability: 1, catalogHash: "pi-hive-catalog-hash-v1", artifact: "pi-hive-artifact-contract-v1", contextPolicy: "pi-hive-context-policy-v1", package: "0.1.0" },
+    project: { projectId: identity.projectId ?? "project-1", rootRef: "." },
+    workflow: { id: identity.workflowId ?? "build", artifact: { adapter: "none", profile: "default", binding: "none", options: {}, contractVersion: "pi-hive-artifact-contract-v1", checkpoints: [], approvals: {} }, team: { rootId: "root", nodes: [{ id: "root", agentId: "agent", memberIds: [], responsibilities: [], skills: { resolved: [] }, knowledge: { resolved: [] }, budgets: {} }] } },
+    agents: [{ id: "agent", name: "Agent", tags: [], frontmatter: {}, prompt: "recover", sourceHash: "a".repeat(64), canonicalSourceHash: "b".repeat(64), promptHash: "c".repeat(64) }],
+    skills: [], knowledge: [],
+    authority: { capabilityContractVersion: 1, nodes: [{ nodeId: "root", capabilities: { effective, provenance, budgets: {}, attachments: { skills: [], knowledge: [] }, directMemberIds: [] }, tools: ["workflow_finish", "workflow_status"] }] },
+    models: [{ nodeId: "root", modelId: "provider/model", thinking: "off", staticTokens: 8192, dynamicReserve: 20000, contextWindow: 100000 }],
+    sources: [],
+  } as any;
+  return { snapshotHash: hashActivationPayload(payload), createdAt: "2026-01-01T00:00:00.000Z", payload };
+}
+
+function fixture(snapshot = recoverySnapshot()) {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-reload-"));
+  const piRoot = mkdtempSync(join(tmpdir(), "hive-pi-sessions-"));
+  const normalFile = join(piRoot, "normal.jsonl");
+  writeFileSync(normalFile, "normal\n");
+  initializeNormalParent({ configured: true, projectRoot, projectId: "project-1", piSessionId: "normal", piSessionFile: normalFile, model: "provider/normal", thinking: "low", activeTools: ["read"] });
+  writeActivationSnapshot(projectRoot, snapshot);
+  let next = 0;
+  const calls: string[] = [];
+  let failCreate = false;
+  let activeSessionFile = normalFile;
+  const adapter = {
+    async create(input: { recovery?: unknown; restoreSession?: string }) {
+      calls.push(input.recovery ? "recover-create" : "create");
+      if (failCreate) throw new Error("injected create fault");
+      next += 1;
+      const piSessionFile = join(piRoot, `workflow-${next}.jsonl`);
+      writeFileSync(piSessionFile, "workflow\n");
+      activeSessionFile = piSessionFile;
+      return { piSessionId: `pi-${next}`, piSessionFile, ...(input.restoreSession ? { compensate: () => { calls.push("compensate"); activeSessionFile = input.restoreSession!; } } : {}) };
+    },
+    async switch(input: { piSessionFile: string; withSession: (ctx: unknown) => Promise<void> | void }) { calls.push(`switch:${input.piSessionFile}`); await input.withSession({}); return { cancelled: false }; },
+  };
+  return { projectRoot, piRoot, normalFile, adapter, calls, activationHash: snapshot.snapshotHash, snapshot, activeSessionFile: () => activeSessionFile, setFailCreate(value: boolean) { failCreate = value; } };
+}
+
+const owner = (nonce: string) => ({ pid: 123, processMarker: `marker-${nonce}`, nonce, verifyDead: () => true });
+function runRecoveryProcess(f: ReturnType<typeof fixture>, workflowSessionId: string, suffix: string, crashStage?: string) {
+  const candidate = join(f.piRoot, `process-${suffix}.jsonl`);
+  const script = `
+    import { writeFileSync } from "node:fs";
+    import { recoverOrphanedWorkflowSession } from "./src/workflows/recovery.ts";
+    const runtime = {
+      sourceState: "current",
+      model: {
+        defaultModel: "provider/model", defaultThinking: "off",
+        find: (modelId) => modelId === "provider/model" ? { id: modelId, contextWindow: 100000, thinking: ["off"] } : undefined,
+        canActivate: (modelId) => modelId === "provider/model", estimateTokens: (text) => text.length,
+      },
+      knowledgeAvailable: () => true, workspaceAvailable: () => true,
+      artifactProfileAvailable: (adapter, profile) => adapter === "none" && profile === "default",
+    };
+    const adapter = {
+      async create() {
+        writeFileSync(${JSON.stringify(candidate)}, "process recovery\\n");
+        return { piSessionId: ${JSON.stringify(`process-${suffix}`)}, piSessionFile: ${JSON.stringify(candidate)} };
+      },
+      async switch({ withSession }) { await withSession({}); return { cancelled: false }; },
+    };
+    await recoverOrphanedWorkflowSession({
+      projectRoot: ${JSON.stringify(f.projectRoot)}, projectId: "project-1", workflowSessionId: ${JSON.stringify(workflowSessionId)},
+      adapter, owner: { nonce: ${JSON.stringify(`process-${suffix}`)}, verifyDead: () => true }, runtime,
+      restorePiSessionFile: ${JSON.stringify(f.normalFile)},
+      ${crashStage ? `recoveryFault: (stage) => { if (stage === ${JSON.stringify(crashStage)}) process.exit(86); },` : ""}
+    });
+  `;
+  const result = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], { cwd: process.cwd(), encoding: "utf8" });
+  if (result.status === 86 && crashStage === "afterCommitted") {
+    unlinkSync(join(f.projectRoot, ".pi", "hive", "sessions", workflowSessionId, "recovery-settlement.lock"));
+  }
+  return result;
+}
+
+const recoveryDependencies = (f: ReturnType<typeof fixture>, overrides: Record<string, unknown> = {}) => ({
+  restorePiSessionFile: f.normalFile,
+  runtime: {
+    sourceState: "current" as const,
+    model: {
+      defaultModel: "provider/model",
+      defaultThinking: "off",
+      find: (modelId: string) => modelId === "provider/model" ? { id: modelId, contextWindow: 100_000, thinking: ["off"] } : undefined,
+      canActivate: (modelId: string) => modelId === "provider/model",
+      estimateTokens: (text: string) => text.length,
+    },
+    knowledgeAvailable: () => true,
+    workspaceAvailable: () => true,
+    artifactProfileAvailable: (adapter: string, profile: string) => adapter === "none" && profile === "default",
+    ...overrides,
+  },
+});
+
+async function selected(f: ReturnType<typeof fixture>, nonce = "owner") {
+  return selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: selectable(f.activationHash), adapter: f.adapter, owner: owner(nonce) });
+}
+
+test("reload validates a complete fresh activation before archiving and switches only while idle", async () => {
+  const f = fixture();
+  const original = await selected(f);
+  const order: string[] = [];
+  const reloaded = await reloadWorkflowSession({
+    projectRoot: f.projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: original.link.piSessionId,
+    adapter: f.adapter,
+    owner: owner("owner"),
+    prepareActivation: async () => {
+      order.push("prepared");
+      return { workflow: selectable("b".repeat(64)), validateBeforeCommit: () => { order.push("revalidated"); } };
+    },
+  });
+  assert.equal(reloaded.kind, "created");
+  assert.deepEqual(order, ["prepared", "revalidated"]);
+  const links = listSessionLinks(f.projectRoot).filter((entry) => entry.kind === "workflow");
+  assert.equal(links.filter((entry) => entry.status === "current").length, 1);
+  assert.equal(links.filter((entry) => entry.status === "archived").length, 1);
+  assert.equal(links.find((entry) => entry.status === "current")?.activationHash, "b".repeat(64));
+  assert.equal(links.find((entry) => entry.status === "archived")?.workflowSessionId, original.link.workflowSessionId);
+
+  const runtime = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: reloaded.link.workflowSessionId, snapshotId: reloaded.link.activationHash, rootNodeId: "root" });
+  runtime.recordUserInput({ inputId: "open", text: "active", source: "interactive" });
+  let prepared = false;
+  await assert.rejects(() => reloadWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: reloaded.link.piSessionId, adapter: f.adapter, owner: owner("owner"),
+    prepareActivation: async () => { prepared = true; return { workflow: selectable("c".repeat(64)) }; },
+  }), /idle/i);
+  assert.equal(prepared, false, "idle preflight runs before expensive activation building");
+});
+
+test("reload validation, creation, and source-race faults preserve the current activation", async () => {
+  for (const failure of ["prepare", "create", "source-race"] as const) {
+    const f = fixture();
+    const original = await selected(f);
+    if (failure === "create") f.setFailCreate(true);
+    await assert.rejects(() => reloadWorkflowSession({
+      projectRoot: f.projectRoot,
+      projectId: "project-1",
+      currentPiSessionId: original.link.piSessionId,
+      adapter: f.adapter,
+      owner: owner("owner"),
+      prepareActivation: async () => {
+        if (failure === "prepare") throw new Error("activation invalid");
+        return {
+          workflow: selectable("b".repeat(64)),
+          ...(failure === "source-race" ? { validateBeforeCommit: () => { throw new Error("activation sources changed"); } } : {}),
+        };
+      },
+    }), /invalid|fault|changed/i);
+    const current = listSessionLinks(f.projectRoot).filter((entry): entry is Extract<typeof entry, { kind: "workflow" }> => entry.kind === "workflow" && entry.status === "current");
+    assert.equal(current.length, 1, failure);
+    assert.equal(current[0].workflowSessionId, original.link.workflowSessionId, failure);
+    assert.equal(current[0].activationHash, original.link.activationHash, failure);
+  }
+});
+
+test("reload rechecks run state after async preparation and compensates a post-creation CAS race", async () => {
+  const prepareRace = fixture();
+  const prepareOriginal = await selected(prepareRace);
+  const createsBefore = prepareRace.calls.filter((call) => call === "create").length;
+  await assert.rejects(() => reloadWorkflowSession({
+    projectRoot: prepareRace.projectRoot, projectId: "project-1", currentPiSessionId: prepareOriginal.link.piSessionId, adapter: prepareRace.adapter, owner: owner("owner"),
+    prepareActivation: async () => {
+      const runtime = new WorkflowRunLifecycle({ projectRoot: prepareRace.projectRoot, projectId: "project-1", sessionId: prepareOriginal.link.workflowSessionId, snapshotId: prepareOriginal.link.activationHash, rootNodeId: "root" });
+      runtime.recordUserInput({ inputId: "prepare-race", text: "run won during prepare", source: "interactive" });
+      return { workflow: selectable("b".repeat(64)) };
+    },
+  }), /run|journal|compare-and-swap/i);
+  assert.equal(prepareRace.calls.filter((call) => call === "create").length, createsBefore, "prepare race rejects before Pi session creation");
+
+  const commitRace = fixture();
+  const commitOriginal = await selected(commitRace);
+  await assert.rejects(() => reloadWorkflowSession({
+    projectRoot: commitRace.projectRoot, projectId: "project-1", currentPiSessionId: commitOriginal.link.piSessionId, adapter: commitRace.adapter, owner: owner("owner"),
+    prepareActivation: async () => ({
+      workflow: selectable("b".repeat(64)),
+      validateBeforeCommit: () => {
+        const runtime = new WorkflowRunLifecycle({ projectRoot: commitRace.projectRoot, projectId: "project-1", sessionId: commitOriginal.link.workflowSessionId, snapshotId: commitOriginal.link.activationHash, rootNodeId: "root" });
+        runtime.recordUserInput({ inputId: "commit-race", text: "run won during create", source: "interactive" });
+      },
+    }),
+  }), /run|journal|compare-and-swap/i);
+  const current = listSessionLinks(commitRace.projectRoot).filter((entry): entry is Extract<typeof entry, { kind: "workflow" }> => entry.kind === "workflow" && entry.status === "current");
+  assert.deepEqual(current.map((entry) => entry.workflowSessionId), [commitOriginal.link.workflowSessionId]);
+  assert.equal(commitRace.activeSessionFile(), commitOriginal.link.piSessionFile, "failed CAS compensates the Pi replacement session");
+  assert.equal(commitRace.calls.includes("compensate"), true);
+  assert.equal(current.some((entry) => readHandoffState(commitRace.projectRoot, entry.workflowSessionId).staged !== undefined), false);
+});
+
+test("missing linked Pi sessions become idempotently orphaned without deleting journal/history", async () => {
+  const f = fixture();
+  const original = await selected(f);
+  const journalBefore = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).length;
+  unlinkSync(original.link.piSessionFile);
+  assert.equal(existsSync(original.link.piSessionFile), false);
+  const first = detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  const second = detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.deepEqual(first.map((entry) => entry.workflowSessionId), [original.link.workflowSessionId]);
+  assert.deepEqual(second.map((entry) => entry.workflowSessionId), [original.link.workflowSessionId]);
+  const link = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.equal(link?.kind === "workflow" && link.orphaned, true);
+  const orphanEvents = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).filter((event) => event.type === "session.orphaned");
+  assert.equal(orphanEvents.length, 1);
+  assert.ok(readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).length > journalBefore);
+});
+
+test("recovery refuses a live owner, blocks corrupt/unsupported contracts, then creates an auditable fresh Pi link", async () => {
+  const f = fixture();
+  const original = await selected(f, "live");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: f.adapter, owner: owner("recovery"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: true, codes: [] }),
+  }), /live owner|ownership/i);
+  assert.equal(f.calls.includes("recover-create"), false);
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live"), true);
+  unlinkSync(snapshotFilePath(f.projectRoot, f.activationHash));
+
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: f.adapter, owner: owner("corrupt"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: true, codes: [] }),
+  }), /snapshot.*missing|invalid|corrupt/i);
+  let blocked = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.equal(blocked?.kind === "workflow" && blocked.recovery?.state, "blocked");
+  assert.ok(blocked?.kind === "workflow" && blocked.recovery?.state === "blocked" && blocked.recovery.codes.includes("SNAPSHOT_INVALID"));
+
+  writeActivationSnapshot(f.projectRoot, f.snapshot);
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: f.adapter, owner: owner("unsupported"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: false, codes: ["SNAPSHOT_PACKAGE_CONTRACT_UNSUPPORTED"] }),
+  }), /unsupported|blocked/i);
+  blocked = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(blocked?.kind === "workflow" && blocked.recovery?.state === "blocked" && blocked.recovery.codes.includes("SNAPSHOT_PACKAGE_CONTRACT_UNSUPPORTED"));
+
+  const recovered = await recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: f.adapter, owner: owner("recovered"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: true, codes: [] }),
+  });
+  assert.notEqual(recovered.piSessionId, original.link.piSessionId);
+  assert.equal(recovered.workflowSessionId, original.link.workflowSessionId);
+  assert.equal(recovered.orphaned, false);
+  assert.equal(recovered.recovery?.state, "recovered");
+  assert.equal(recovered.recovery?.previousPiSessionId, original.link.piSessionId);
+  assert.equal(existsSync(original.link.piSessionFile), false, "recovery never fabricates or deletes old transcript paths");
+  const recoveredEvent = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).find((event) => event.type === "session.recovered");
+  const recoveryPayload = recoveredEvent?.payload as Record<string, unknown> | undefined;
+  assert.equal(recoveryPayload?.previousPiSessionId, original.link.piSessionId);
+  assert.equal(recoveryPayload?.piSessionId, recovered.piSessionId);
+
+  unlinkSync(recovered.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  const orphanEvents = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).filter((event) => event.type === "session.orphaned");
+  assert.equal(orphanEvents.length, 2, "a recovered Pi-link generation receives its own orphan event");
+  assert.deepEqual(orphanEvents.map((event) => (event.payload as Record<string, unknown>).piSessionId), [original.link.piSessionId, recovered.piSessionId]);
+});
+
+test("recovery creation faults leave the orphan link unchanged and release acquired ownership", async () => {
+  const f = fixture();
+  const original = await selected(f, "live");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live"), true);
+  f.setFailCreate(true);
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: f.adapter, owner: owner("fault"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: true, codes: [] }),
+  }), /injected create fault/);
+  const link = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.equal(link?.kind === "workflow" && link.orphaned, true);
+  const reacquired = await recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId, adapter: { ...f.adapter, async create() { const path = join(f.piRoot, "retry.jsonl"); writeFileSync(path, "retry\n"); return { piSessionId: "retry", piSessionFile: path }; } }, owner: owner("retry"),
+    ...recoveryDependencies(f), validateActivation: () => ({ ok: true, codes: [] }),
+  });
+  assert.equal(reacquired.piSessionId, "retry");
+});
+
+test("mandatory recovery validation rejects identity and runtime incompatibility even when optional policy approves", async () => {
+  const unavailableModel = {
+    defaultModel: "provider/model", defaultThinking: "off",
+    find: () => undefined, canActivate: () => false, estimateTokens: (text: string) => text.length,
+  };
+  const cases = [
+    { label: "project identity", snapshot: recoverySnapshot({ projectId: "different-project" }), overrides: {}, code: "SNAPSHOT_PROJECT_IDENTITY_MISMATCH" },
+    { label: "workflow identity", snapshot: recoverySnapshot({ workflowId: "different-workflow" }), overrides: {}, code: "SNAPSHOT_WORKFLOW_IDENTITY_MISMATCH" },
+    { label: "model runtime", snapshot: recoverySnapshot(), overrides: { model: unavailableModel }, code: "SNAPSHOT_MODEL_UNAVAILABLE" },
+    { label: "artifact adapter", snapshot: recoverySnapshot(), overrides: { artifactProfileAvailable: () => false }, code: "SNAPSHOT_ARTIFACT_CONTRACT_UNSUPPORTED" },
+    { label: "workspace", snapshot: recoverySnapshot(), overrides: { workspaceAvailable: () => false }, code: "SNAPSHOT_WORKSPACE_UNAVAILABLE" },
+  ];
+  for (const entry of cases) {
+    const f = fixture(entry.snapshot);
+    const original = await selected(f, `live-${entry.label}`);
+    unlinkSync(original.link.piSessionFile);
+    detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+    assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, `live-${entry.label}`), true);
+    await assert.rejects(() => recoverOrphanedWorkflowSession({
+      projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId,
+      adapter: f.adapter, owner: owner(`validate-${entry.label}`), ...recoveryDependencies(f, entry.overrides),
+      validateActivation: () => ({ ok: true, codes: [] }),
+    }), /unsupported|blocked/i, entry.label);
+    const blocked = listSessionLinks(f.projectRoot).find((candidate) => candidate.kind === "workflow" && candidate.workflowSessionId === original.link.workflowSessionId);
+    assert.ok(blocked?.kind === "workflow" && blocked.recovery?.state === "blocked" && blocked.recovery.codes.includes(entry.code), entry.label);
+    assert.equal(f.calls.includes("recover-create"), false, `${entry.label} blocks before Pi navigation`);
+  }
+});
+
+test("stale validation cannot replace a concurrently recovered link with blocked state", async () => {
+  const f = fixture();
+  const original = await selected(f, "live");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live"), true);
+
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId,
+    adapter: f.adapter, owner: owner("stale-validation"), ...recoveryDependencies(f),
+    validateActivation: () => {
+      const concurrent = runRecoveryProcess(f, original.link.workflowSessionId, "validation-winner");
+      assert.equal(concurrent.status, 0, concurrent.stderr || concurrent.stdout);
+      return { ok: false, codes: ["STALE_POLICY_DECISION"] };
+    },
+  }), /changed before blocked recovery update/i);
+
+  const link = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(link?.kind === "workflow" && link.recovery?.state === "recovered");
+  assert.equal(link?.kind === "workflow" && link.piSessionId, "process-validation-winner");
+  const staleBlocked = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId)
+    .filter((event) => event.type === "session.recovery.blocked")
+    .some((event) => (event.payload as Record<string, unknown>).codes instanceof Array && ((event.payload as Record<string, unknown>).codes as unknown[]).includes("STALE_POLICY_DECISION"));
+  assert.equal(staleBlocked, false, "the losing validation publishes no blocked authority");
+});
+
+test("process restart reconciles every durable recovery crash boundary", async () => {
+  for (const stage of ["afterPrepared", "afterLinkPrepared", "afterCommitted"] as const) {
+    const f = fixture();
+    const original = await selected(f, `live-${stage}`);
+    unlinkSync(original.link.piSessionFile);
+    detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+    assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, `live-${stage}`), true);
+
+    const crashed = runRecoveryProcess(f, original.link.workflowSessionId, stage, stage);
+    assert.equal(crashed.status, 86, `${stage}: ${crashed.stderr || crashed.stdout}`);
+    const before = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+    assert.ok(before?.kind === "workflow" && before.orphaned === true, stage);
+    assert.notEqual(before?.kind === "workflow" && before.recovery?.state, "recovered", `${stage} is not recovered authority before restart reconciliation`);
+
+    const preparedBefore = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).filter((event) => event.type === "session.recovery.prepared");
+    assert.equal(preparedBefore.length, 1, stage);
+    const detected = detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+    assert.deepEqual(detected, [], `${stage} is completed before orphan reporting`);
+
+    const recovered = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+    assert.ok(recovered?.kind === "workflow" && recovered.orphaned === false && recovered.recovery?.state === "recovered", stage);
+    const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+    const committed = events.filter((event) => event.type === "session.recovered");
+    assert.equal(committed.length, 1, stage);
+    assert.equal((committed[0].payload as Record<string, unknown>).preparedEventHash, preparedBefore[0].eventHash, stage);
+    assert.equal(recovered?.kind === "workflow" && recovered.recovery?.state === "recovered" && recovered.recovery.eventHash, committed[0].eventHash, stage);
+  }
+});
+
+test("multiprocess restart reconciliation serializes one commit decision with no rollback event", async () => {
+  const f = fixture();
+  const original = await selected(f, "live-multiprocess");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live-multiprocess"), true);
+
+  const crashed = runRecoveryProcess(f, original.link.workflowSessionId, "multiprocess", "afterLinkPrepared");
+  assert.equal(crashed.status, 86, crashed.stderr || crashed.stdout);
+  const prepared = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId).find((event) => event.type === "session.recovery.prepared");
+  assert.ok(prepared);
+
+  const lockPath = join(f.projectRoot, ".pi", "hive", "sessions", original.link.workflowSessionId, "recovery-settlement.lock");
+  writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+  const script = `
+    import { detectOrphanedWorkflowSessions } from "./src/workflows/recovery.ts";
+    detectOrphanedWorkflowSessions({ projectRoot: ${JSON.stringify(f.projectRoot)}, projectId: "project-1" });
+  `;
+  const children = ["one", "two"].map(() => spawn(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] }));
+  const completed = children.map((child) => new Promise<{ code: number | null; output: string }>((resolve) => {
+    let output = "";
+    child.stdout?.on("data", (chunk) => { output += String(chunk); });
+    child.stderr?.on("data", (chunk) => { output += String(chunk); });
+    child.on("close", (code) => resolve({ code, output }));
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  assert.equal(children.every((child) => child.exitCode === null), true, "each process waits for the shared session settlement lock");
+  unlinkSync(lockPath);
+  for (const result of await Promise.all(completed)) assert.equal(result.code, 0, result.output);
+
+  const link = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(link?.kind === "workflow" && link.recovery?.state === "recovered" && link.orphaned === false);
+  const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+  assert.equal(events.filter((event) => event.type === "session.recovered" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash).length, 1);
+  assert.equal(events.some((event) => event.type === "session.orphaned" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash && (event.payload as Record<string, unknown>).rolledBack === true), false);
+});
+
+test("restart rolls back a prepared recovery whose candidate session was lost", async () => {
+  const f = fixture();
+  const original = await selected(f, "live-lost-candidate");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live-lost-candidate"), true);
+
+  const crashed = runRecoveryProcess(f, original.link.workflowSessionId, "lost-candidate", "afterLinkPrepared");
+  assert.equal(crashed.status, 86, crashed.stderr || crashed.stdout);
+  const preparedLink = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(preparedLink?.kind === "workflow" && preparedLink.recovery?.state === "prepared");
+  if (preparedLink?.kind === "workflow") unlinkSync(preparedLink.piSessionFile);
+
+  const detected = detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.deepEqual(detected.map((entry) => entry.workflowSessionId), [original.link.workflowSessionId]);
+  const rolledBack = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(rolledBack?.kind === "workflow" && rolledBack.orphaned === true && rolledBack.recovery?.state !== "recovered");
+  assert.equal(rolledBack?.kind === "workflow" && rolledBack.piSessionId, original.link.piSessionId);
+  const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+  const prepared = events.find((event) => event.type === "session.recovery.prepared");
+  assert.ok(prepared);
+  assert.ok(events.some((event) => event.type === "session.orphaned" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash && (event.payload as Record<string, unknown>).rolledBack === true));
+  assert.equal(events.some((event) => event.type === "session.recovered" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash), false);
+});
+
+test("restart rollback never overwrites unrelated changes to the prepared link generation", async () => {
+  const f = fixture();
+  const original = await selected(f, "live-prepared-race");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live-prepared-race"), true);
+
+  const crashed = runRecoveryProcess(f, original.link.workflowSessionId, "prepared-race", "afterLinkPrepared");
+  assert.equal(crashed.status, 86, crashed.stderr || crashed.stdout);
+  const preparedLink = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(preparedLink?.kind === "workflow" && preparedLink.recovery?.state === "prepared");
+  if (preparedLink?.kind !== "workflow") return;
+  replaceSessionLinks(f.projectRoot, listSessionLinks(f.projectRoot).map((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId
+    ? { ...entry, updatedAt: "2027-02-01T00:00:00.000Z" }
+    : entry));
+  unlinkSync(preparedLink.piSessionFile);
+
+  assert.throws(() => detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" }), /changed|exact link generation/i);
+  const preserved = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.equal(preserved?.kind === "workflow" && preserved.updatedAt, "2027-02-01T00:00:00.000Z");
+  assert.equal(preserved?.kind === "workflow" && preserved.piSessionId, preparedLink.piSessionId, "rollback does not restore over the unrelated generation");
+  const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+  const prepared = events.find((event) => event.type === "session.recovery.prepared");
+  assert.ok(prepared);
+  assert.equal(events.some((event) => event.type === "session.orphaned" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash && (event.payload as Record<string, unknown>).rolledBack === true), false);
+});
+
+test("recovery rollback refuses a concurrently changed complete link generation", async () => {
+  const f = fixture();
+  const original = await selected(f, "live");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live"), true);
+  const racingAdapter = {
+    ...f.adapter,
+    async create(input: Parameters<typeof f.adapter.create>[0]) {
+      const created = await f.adapter.create(input);
+      replaceSessionLinks(f.projectRoot, listSessionLinks(f.projectRoot).map((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId
+        ? { ...entry, updatedAt: "2027-01-01T00:00:00.000Z" }
+        : entry));
+      return created;
+    },
+  };
+  await assert.rejects(() => recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId,
+    adapter: racingAdapter, owner: owner("race"), ...recoveryDependencies(f),
+  }), /compensation was incomplete/i);
+  const link = listSessionLinks(f.projectRoot).find((entry) => entry.kind === "workflow" && entry.workflowSessionId === original.link.workflowSessionId);
+  assert.ok(link?.kind === "workflow" && link.orphaned === true);
+  assert.equal(link?.kind === "workflow" && link.piSessionId, original.link.piSessionId);
+  assert.equal(link?.kind === "workflow" && link.updatedAt, "2027-01-01T00:00:00.000Z", "rollback never overwrites an unrelated complete-generation change");
+  assert.equal(f.activeSessionFile(), f.normalFile, "failed link CAS restores the previously active Pi session");
+  const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+  const prepared = events.find((event) => event.type === "session.recovery.prepared");
+  assert.ok(prepared);
+  assert.equal(events.some((event) => event.type === "session.recovered" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash), false);
+  assert.equal(events.some((event) => event.type === "session.orphaned" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash), false, "an unverified generation publishes no rollback claim");
+});
+
+test("a published recovery commit wins an after-rename fault without a contradictory rollback", async () => {
+  const f = fixture();
+  const original = await selected(f, "live");
+  unlinkSync(original.link.piSessionFile);
+  detectOrphanedWorkflowSessions({ projectRoot: f.projectRoot, projectId: "project-1" });
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, original.link.workflowSessionId, "live"), true);
+  const recoveredLink = await recoverOrphanedWorkflowSession({
+    projectRoot: f.projectRoot, projectId: "project-1", workflowSessionId: original.link.workflowSessionId,
+    adapter: f.adapter, owner: owner("journal-fault"), ...recoveryDependencies(f),
+    journalFault: (stage) => { if (stage === "afterRename") throw new Error("injected after-publish fault"); },
+  });
+  assert.ok(recoveredLink.orphaned === false && recoveredLink.recovery?.state === "recovered");
+  assert.equal(f.activeSessionFile(), recoveredLink.piSessionFile);
+  const events = readWorkflowJournal(f.projectRoot, original.link.workflowSessionId);
+  const prepared = events.find((event) => event.type === "session.recovery.prepared");
+  assert.ok(prepared);
+  assert.equal(events.filter((event) => event.type === "session.recovered" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash).length, 1);
+  assert.equal(events.some((event) => event.type === "session.orphaned" && (event.payload as Record<string, unknown>).preparedEventHash === prepared.eventHash && (event.payload as Record<string, unknown>).rolledBack === true), false);
+});
+
+test("selector status carries staged/source/archive/orphan/recovery metadata while suggested-next remains inert", () => {
+  const rows = buildWorkflowSelector([{
+    workflowId: "build", name: "Build", source: "stale", resumable: true, freshEnabled: false, diagnostics: ["source changed"],
+    stagedHandoff: { packetHash: "a".repeat(64), sourceWorkflowId: "plan", sourceRunId: "run-1" },
+    currentSessionState: "orphaned", archiveCount: 2, recoveryState: "blocked", suggestedNext: ["review"],
+  }]);
+  assert.equal(rows[0].sourceStale, true);
+  assert.equal(rows[0].currentSessionState, "orphaned");
+  assert.equal(rows[0].archiveCount, 2);
+  assert.equal(rows[0].recoveryState, "blocked");
+  assert.equal(rows[0].stagedHandoff?.sourceRunId, "run-1");
+  assert.equal(JSON.stringify(rows).includes("suggestedNext"), false);
+  assert.equal(JSON.stringify(rows).includes("review"), false, "suggested-next is presentation input only and never an invocation edge");
+});

--- a/tests/workflows/workflow-sessions.test.ts
+++ b/tests/workflows/workflow-sessions.test.ts
@@ -1,9 +1,26 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { initializeNormalParent, listSessionLinks, recordWorkflowModelState } from "../../src/workflows/sessions.ts";
+import { appendWorkflowEvent } from "../../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../../src/workflows/events.ts";
+import {
+  commitWorkflowRecovery,
+  commitWorkflowSelection,
+  initializeNormalParent,
+  listSessionLinks,
+  markMissingPiSession,
+  prepareWorkflowRecoveryLink,
+  recordWorkflowModelState,
+  recordWorkflowRecoveryBlocked,
+  replaceSessionLinks,
+  rollbackWorkflowRecovery,
+  sameWorkflowLinkGeneration,
+  upsertWorkflowLink,
+  workflowLinkGenerationHash,
+  type WorkflowSessionLink,
+} from "../../src/workflows/sessions.ts";
 
 const root = () => mkdtempSync(join(tmpdir(), "hive-links-"));
 
@@ -24,4 +41,195 @@ test("normal and workflow model/thinking/tool state remain distinct and model ch
   const stored = listSessionLinks(project).find((entry) => entry.kind === "workflow")!; assert.deepEqual(stored.tools, ["bash", "write"]); assert.equal(stored.model, "provider/other");
   const normal = listSessionLinks(project).find((entry) => entry.kind === "normal")!; assert.deepEqual(normal.normalTools, ["read"]); assert.equal(normal.normalModel, "provider/normal"); assert.equal(normal.normalThinking, "low");
   assert.throws(() => recordWorkflowModelState(project, "p", stored as any, "bad", "max", () => false), /preflight/i);
+});
+
+function workflowLink(id = "ws", overrides: Partial<WorkflowSessionLink> = {}): WorkflowSessionLink {
+  return {
+    kind: "workflow", formatVersion: 1, workflowSessionId: id, workflowId: "build", activationHash: "a".repeat(64),
+    piSessionId: `pi-${id}`, piSessionFile: `/pi/${id}`, normalParentId: "normal", normalParentFile: "/pi/normal", status: "current",
+    stale: false, model: "provider/model", thinking: "high", tools: ["write"], createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z", name: `hive:build:${id}`, ...overrides,
+  };
+}
+
+test("session-link storage rejects symlink, malformed, oversized, and invalid envelopes", () => {
+  for (const content of ["not-json", JSON.stringify({ formatVersion: 2, links: [] }), JSON.stringify({ formatVersion: 1, links: null })]) {
+    const project = root();
+    const directory = join(project, ".pi/hive/sessions");
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, "session-links-v1.json"), content);
+    assert.throws(() => listSessionLinks(project), /JSON|invalid|Unexpected/i);
+  }
+  const oversized = root();
+  mkdirSync(join(oversized, ".pi/hive/sessions"), { recursive: true });
+  writeFileSync(join(oversized, ".pi/hive/sessions/session-links-v1.json"), "x".repeat(1_048_577));
+  assert.throws(() => listSessionLinks(oversized), /limit/i);
+
+  const symlinked = root();
+  mkdirSync(join(symlinked, ".pi/hive/sessions"), { recursive: true });
+  writeFileSync(join(symlinked, "outside.json"), JSON.stringify({ formatVersion: 1, links: [] }));
+  symlinkSync(join(symlinked, "outside.json"), join(symlinked, ".pi/hive/sessions/session-links-v1.json"));
+  assert.throws(() => listSessionLinks(symlinked), /path[_ ]invalid/i);
+
+  const tooLargeToWrite = root();
+  assert.throws(() => replaceSessionLinks(tooLargeToWrite, [workflowLink("huge", { name: "x".repeat(1_048_577) })]), /limit/i);
+});
+
+test("session-link sorting, replacement, and selection CAS cover every link kind", () => {
+  const project = root();
+  const normals = [
+    { kind: "normal" as const, formatVersion: 1 as const, projectId: "p", piSessionId: "z", piSessionFile: "/z", normalModel: "m", normalThinking: "l", normalTools: [], createdAt: "t", updatedAt: "t" },
+    { kind: "normal" as const, formatVersion: 1 as const, projectId: "p", piSessionId: "a", piSessionFile: "/a", normalModel: "m", normalThinking: "l", normalTools: [], createdAt: "t", updatedAt: "t" },
+  ];
+  replaceSessionLinks(project, [workflowLink("z"), normals[0], workflowLink("a"), normals[1]]);
+  assert.deepEqual(listSessionLinks(project).map((link) => link.kind === "normal" ? `n:${link.piSessionId}` : `w:${link.workflowSessionId}`), ["n:a", "n:z", "w:a", "w:z"]);
+  assert.equal(sameWorkflowLinkGeneration(workflowLink("a"), workflowLink("a")), true);
+  assert.equal(sameWorkflowLinkGeneration(workflowLink("a"), workflowLink("a", { model: "other" })), false);
+
+  const selected = workflowLink("selected");
+  assert.throws(() => commitWorkflowSelection(project, "build", undefined, undefined, selected), /concurrent/i);
+  replaceSessionLinks(project, [normals[0], workflowLink("current")]);
+  commitWorkflowSelection(project, "build", "current", workflowLink("current", { status: "archived" }), selected);
+  assert.deepEqual(listSessionLinks(project).filter((link) => link.kind === "workflow").map((link) => link.status).sort(), ["archived", "current"]);
+  upsertWorkflowLink(project, { ...selected, model: "replacement" });
+  assert.equal((listSessionLinks(project).find((link) => link.kind === "workflow" && link.workflowSessionId === "selected") as WorkflowSessionLink).model, "replacement");
+});
+
+test("normal reinitialization preserves creation time and orphan marking is generation-idempotent", () => {
+  const project = root();
+  initializeNormalParent({ configured: true, projectRoot: project, projectId: "p", piSessionId: "normal", piSessionFile: "/pi/normal", model: "m", thinking: "low", activeTools: [] });
+  const createdAt = listSessionLinks(project).find((entry) => entry.kind === "normal")!.createdAt;
+  initializeNormalParent({ configured: true, projectRoot: project, projectId: "p", piSessionId: "normal-2", piSessionFile: "/pi/normal-2", model: "m2", thinking: "high", activeTools: [] });
+  assert.equal(listSessionLinks(project).find((entry) => entry.kind === "normal")!.createdAt, createdAt);
+
+  upsertWorkflowLink(project, workflowLink("missing"));
+  markMissingPiSession(project, "p", "missing");
+  const first = listSessionLinks(project).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === "missing")!;
+  markMissingPiSession(project, "p", "missing");
+  const second = listSessionLinks(project).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === "missing")!;
+  assert.equal(second.orphanedAt, first.orphanedAt);
+  markMissingPiSession(project, "p", "unlinked");
+});
+
+test("recovery-link helpers fail closed on missing and changed generations", () => {
+  const missing = root();
+  const expected = workflowLink("expected", { orphaned: true });
+  assert.throws(() => recordWorkflowRecoveryBlocked(missing, "p", expected, ["B", "A", "A"], "diagnostic"), /missing/i);
+
+  const changed = root();
+  replaceSessionLinks(changed, [{ ...expected, model: "changed" }]);
+  assert.throws(() => recordWorkflowRecoveryBlocked(changed, "p", expected, ["X"], "diagnostic"), /changed/i);
+  assert.throws(() => rollbackWorkflowRecovery(changed, workflowLink("one"), workflowLink("two"), "hash"), /identity mismatch/i);
+  assert.throws(() => rollbackWorkflowRecovery(changed, workflowLink("one"), workflowLink("one"), "hash"), /exact prepared generation/i);
+  const prepared = workflowLink("one", { recovery: { state: "prepared", previousPiSessionId: "old", previousPiSessionFile: "/old", preparedAt: "2025-01-01T00:00:00.000Z", preparedEventHash: "e".repeat(64), expectedLinkHash: "f".repeat(64) } });
+  assert.throws(() => rollbackWorkflowRecovery(changed, prepared, workflowLink("one"), "e".repeat(64)), /missing/i);
+
+  assert.equal(workflowLinkGenerationHash(expected).length, 64);
+});
+
+test("recovery-link journal matching rejects each inconsistent preparation field", () => {
+  const expected = workflowLink("recover", { orphaned: true });
+  const replacement = { piSessionId: "new-pi", piSessionFile: "/pi/new", preparedAt: "2025-01-02T00:00:00.000Z" };
+  const validPayload = {
+    expectedLinkHash: workflowLinkGenerationHash(expected), expectedLink: expected,
+    previousPiSessionId: expected.piSessionId, previousPiSessionFile: expected.piSessionFile,
+    piSessionId: replacement.piSessionId, piSessionFile: replacement.piSessionFile,
+    activationHash: expected.activationHash, preparedAt: replacement.preparedAt,
+  };
+  const variants: unknown[] = [
+    null,
+    { ...validPayload, expectedLinkHash: "bad" },
+    { ...validPayload, expectedLink: { ...expected, model: "changed" } },
+    { ...validPayload, previousPiSessionId: "bad" },
+    { ...validPayload, previousPiSessionFile: "bad" },
+    { ...validPayload, piSessionId: "bad" },
+    { ...validPayload, piSessionFile: "bad" },
+    { ...validPayload, activationHash: "bad" },
+    { ...validPayload, preparedAt: "2026-01-01T00:00:00.000Z" },
+  ];
+  for (const [index, payload] of variants.entries()) {
+    const project = root(); replaceSessionLinks(project, [expected]);
+    const event = appendWorkflowEvent(project, createWorkflowEvent({ projectId: "p", sessionId: expected.workflowSessionId, type: "session.recovery.prepared", payload: payload as never, producer: "recovery" }));
+    assert.throws(() => prepareWorkflowRecoveryLink(project, expected, { ...replacement, preparedEventHash: event.eventHash }), /missing or inconsistent/i, `variant ${index}`);
+  }
+});
+
+test("recovery-link preparation, rollback, and commit enforce exact persisted generations", () => {
+  const expected = workflowLink("protocol", { orphaned: true, orphanedAt: "2025-01-01T00:00:00.000Z" });
+  const preparedAt = "2025-01-02T00:00:00.000Z";
+  const createPreparation = (project: string) => {
+    replaceSessionLinks(project, [expected]);
+    const event = appendWorkflowEvent(project, createWorkflowEvent({
+      projectId: "p", sessionId: expected.workflowSessionId, type: "session.recovery.prepared", producer: "recovery", timestamp: preparedAt,
+      payload: {
+        expectedLinkHash: workflowLinkGenerationHash(expected), expectedLink: expected as never,
+        previousPiSessionId: expected.piSessionId, previousPiSessionFile: expected.piSessionFile,
+        piSessionId: "new-pi", piSessionFile: "/pi/new", activationHash: expected.activationHash, preparedAt,
+      },
+    }));
+    return { event, replacement: { piSessionId: "new-pi", piSessionFile: "/pi/new", preparedAt, preparedEventHash: event.eventHash } };
+  };
+
+  const rollbackProject = root();
+  const rollbackPreparation = createPreparation(rollbackProject);
+  const preparedForRollback = prepareWorkflowRecoveryLink(rollbackProject, expected, rollbackPreparation.replacement);
+  assert.equal(rollbackWorkflowRecovery(rollbackProject, preparedForRollback, expected, rollbackPreparation.event.eventHash), true);
+  assert.equal(sameWorkflowLinkGeneration(listSessionLinks(rollbackProject).find((entry) => entry.kind === "workflow")!, expected), true);
+
+  const commitProject = root();
+  const commitPreparation = createPreparation(commitProject);
+  const preparedForCommit = prepareWorkflowRecoveryLink(commitProject, expected, commitPreparation.replacement);
+  const recoveredAt = "2025-01-03T00:00:00.000Z";
+  const recoveredEvent = appendWorkflowEvent(commitProject, createWorkflowEvent({
+    projectId: "p", sessionId: expected.workflowSessionId, type: "session.recovered", producer: "recovery", timestamp: recoveredAt,
+    payload: {
+      preparedEventHash: commitPreparation.event.eventHash,
+      previousPiSessionId: expected.piSessionId, previousPiSessionFile: expected.piSessionFile,
+      piSessionId: preparedForCommit.piSessionId, piSessionFile: preparedForCommit.piSessionFile,
+      activationHash: preparedForCommit.activationHash, recoveredAt,
+    },
+  }));
+  const committed = commitWorkflowRecovery(commitProject, preparedForCommit, { recoveredAt, preparedEventHash: commitPreparation.event.eventHash, eventHash: recoveredEvent.eventHash });
+  assert.equal(committed.orphaned, false);
+  assert.equal(committed.recovery?.state, "recovered");
+
+  const changedProject = root();
+  const changedPreparation = createPreparation(changedProject);
+  replaceSessionLinks(changedProject, [{ ...expected, model: "changed" }]);
+  assert.throws(() => prepareWorkflowRecoveryLink(changedProject, expected, changedPreparation.replacement), /changed during recovery preparation/i);
+
+  const missingProject = root();
+  const missingPreparation = createPreparation(missingProject);
+  replaceSessionLinks(missingProject, []);
+  assert.throws(() => prepareWorkflowRecoveryLink(missingProject, expected, missingPreparation.replacement), /link is missing/i);
+
+  replaceSessionLinks(commitProject, [{ ...preparedForCommit, model: "changed" }]);
+  assert.throws(() => commitWorkflowRecovery(commitProject, preparedForCommit, { recoveredAt, preparedEventHash: commitPreparation.event.eventHash, eventHash: recoveredEvent.eventHash }), /changed during recovery commit/i);
+  replaceSessionLinks(commitProject, []);
+  assert.throws(() => commitWorkflowRecovery(commitProject, preparedForCommit, { recoveredAt, preparedEventHash: commitPreparation.event.eventHash, eventHash: recoveredEvent.eventHash }), /link is missing/i);
+});
+
+test("recovery-link journal matching rejects each inconsistent commit field", () => {
+  const recovery = { state: "prepared" as const, previousPiSessionId: "old", previousPiSessionFile: "/old", preparedAt: "2025-01-01T00:00:00.000Z", preparedEventHash: "a".repeat(64), expectedLinkHash: "b".repeat(64) };
+  const prepared = workflowLink("commit", { orphaned: true, recovery, piSessionId: "new", piSessionFile: "/new" });
+  const replacement = { recoveredAt: "2025-01-02T00:00:00.000Z", preparedEventHash: recovery.preparedEventHash };
+  const validPayload = {
+    preparedEventHash: replacement.preparedEventHash, previousPiSessionId: recovery.previousPiSessionId, previousPiSessionFile: recovery.previousPiSessionFile,
+    piSessionId: prepared.piSessionId, piSessionFile: prepared.piSessionFile, activationHash: prepared.activationHash, recoveredAt: replacement.recoveredAt,
+  };
+  const variants: unknown[] = [
+    null,
+    { ...validPayload, preparedEventHash: "bad" },
+    { ...validPayload, previousPiSessionId: "bad" },
+    { ...validPayload, previousPiSessionFile: "bad" },
+    { ...validPayload, piSessionId: "bad" },
+    { ...validPayload, piSessionFile: "bad" },
+    { ...validPayload, activationHash: "bad" },
+    { ...validPayload, recoveredAt: "bad" },
+  ];
+  for (const [index, payload] of variants.entries()) {
+    const project = root(); replaceSessionLinks(project, [prepared]);
+    const event = appendWorkflowEvent(project, createWorkflowEvent({ projectId: "p", sessionId: prepared.workflowSessionId, type: "session.recovered", payload: payload as never, producer: "recovery" }));
+    assert.throws(() => commitWorkflowRecovery(project, prepared, { ...replacement, eventHash: event.eventHash }), /missing or inconsistent/i, `variant ${index}`);
+  }
 });

--- a/tests/workflows/workflow-w15-edge-branches.test.ts
+++ b/tests/workflows/workflow-w15-edge-branches.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { readHandoffState } from "../../src/workflows/handoff.ts";
+import { reloadWorkflowSession, resolveHandoffSource, selectWorkflowSession } from "../../src/workflows/navigation.ts";
+import { releaseRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+import { initializeNormalParent, listSessionLinks, replaceSessionLinks, type NormalSessionLink, type WorkflowSessionLink } from "../../src/workflows/sessions.ts";
+
+const digest = (character: string) => `sha256:${character.repeat(64)}`;
+const workflow = (workflowId: string, character: string) => ({
+  workflowId,
+  activationHash: character.repeat(64),
+  source: "current" as const,
+  resumable: true,
+  freshEnabled: true,
+  model: "provider/model",
+  thinking: "medium",
+  tools: ["read"],
+});
+const owner = (nonce: string) => ({ pid: 100, processMarker: `marker-${nonce}`, nonce, verifyDead: () => true });
+
+function fixture() {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-w15-edges-"));
+  initializeNormalParent({ configured: true, projectRoot, projectId: "project-1", piSessionId: "normal", piSessionFile: "/pi/normal", model: "provider/normal", thinking: "low", activeTools: ["read"] });
+  let next = 0;
+  let compensations = 0;
+  const adapter = {
+    async create() {
+      next += 1;
+      return { piSessionId: `pi-${next}`, piSessionFile: `/pi/${next}.jsonl`, compensate: () => { compensations += 1; } };
+    },
+    async switch(input: { withSession: (ctx: unknown) => Promise<void> | void }) {
+      await input.withSession({});
+      return { cancelled: false };
+    },
+  };
+  return { projectRoot, adapter, compensations: () => compensations };
+}
+
+async function finishSource(projectRoot: string, sessionId: string, snapshotId: string) {
+  const runtime = new WorkflowRunLifecycle({
+    projectRoot,
+    projectId: "project-1",
+    sessionId,
+    snapshotId,
+    rootNodeId: "root",
+    createRunId: () => "source-run",
+    completion: {
+      evidence: () => ({ state: "satisfied" }),
+      artifacts: () => ({ state: "satisfied" }),
+      projectState: () => ({ state: "satisfied", changeCoverage: "recorded", fileChanges: [] }),
+    },
+  });
+  runtime.recordUserInput({ inputId: "source-input", text: "prepare handoff", source: "interactive" });
+  const delivery = runtime.prepareInputDelivery("source-delivery");
+  runtime.confirmInputDelivery(delivery.requestId);
+  const result = await runtime.finish({
+    status: "completed",
+    summary: "source complete",
+    artifactRefs: [],
+    evidenceRefs: [{ kind: "test", claim: "source verified" }],
+    data: { digest: digest("d") },
+  }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(result.ok, true);
+}
+
+test("W15 reload preserves a staged handoff and compensates navigation races after staging", async () => {
+  const f = fixture();
+  const source = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: "normal", workflow: workflow("plan", "a"), adapter: f.adapter, owner: owner("source") });
+  await finishSource(f.projectRoot, source.link.workflowSessionId, source.link.activationHash);
+  const packet = resolveHandoffSource({ projectRoot: f.projectRoot, projectId: "project-1", runId: "source-run", currentPiSessionId: source.link.piSessionId });
+  const target = await selectWorkflowSession({ projectRoot: f.projectRoot, projectId: "project-1", currentPiSessionId: source.link.piSessionId, workflow: workflow("build", "b"), fresh: true, stagedHandoff: packet, adapter: f.adapter, owner: owner("target") });
+
+  const reloaded = await reloadWorkflowSession({
+    projectRoot: f.projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: target.link.piSessionId,
+    adapter: f.adapter,
+    owner: owner("target"),
+    prepareActivation: () => ({ workflow: workflow("build", "c") }),
+  });
+  assert.equal(readHandoffState(f.projectRoot, reloaded.link.workflowSessionId).staged?.packetHash, packet.packetHash);
+
+  assert.equal(releaseRuntimeOwnership(f.projectRoot, reloaded.link.workflowSessionId, "target"), true);
+  const cancellingAdapter = { ...f.adapter, async switch() { return { cancelled: true }; } };
+  await assert.rejects(() => selectWorkflowSession({
+    projectRoot: f.projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: reloaded.link.piSessionId,
+    workflow: workflow("build", "c"),
+    adapter: cancellingAdapter,
+    owner: owner("cancelled-resume"),
+  }), /switch cancelled/i);
+
+  const current = listSessionLinks(f.projectRoot).find((entry): entry is WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === reloaded.link.workflowSessionId)!;
+  await assert.rejects(() => selectWorkflowSession({
+    projectRoot: f.projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: current.piSessionId,
+    workflow: workflow("build", "d"),
+    fresh: true,
+    stagedHandoff: packet,
+    adapter: f.adapter,
+    owner: owner("handoff-race"),
+    beforeCommit: () => {
+      const links = listSessionLinks(f.projectRoot);
+      const racer: WorkflowSessionLink = { ...current, workflowSessionId: "workflow-racer", piSessionId: "pi-racer", piSessionFile: "/pi/racer.jsonl", activationHash: "e".repeat(64), name: "hive:build:racer" };
+      replaceSessionLinks(f.projectRoot, [...links.filter((entry) => entry.kind !== "workflow" || entry.workflowId !== "build"), racer]);
+    },
+  }), /concurrent workflow selection/i);
+  assert.equal(f.compensations(), 1);
+  assert.equal(readHandoffState(f.projectRoot, current.workflowSessionId).staged?.packetHash, packet.packetHash);
+});
+
+test("W15 reload accepts a durable current link whose journal has not recorded an event yet", async () => {
+  const f = fixture();
+  const normal = listSessionLinks(f.projectRoot).find((entry): entry is NormalSessionLink => entry.kind === "normal")!;
+  const current: WorkflowSessionLink = {
+    kind: "workflow",
+    formatVersion: 1,
+    workflowSessionId: "workflow-empty-journal",
+    workflowId: "build",
+    activationHash: "a".repeat(64),
+    piSessionId: "pi-empty-journal",
+    piSessionFile: "/pi/empty-journal.jsonl",
+    normalParentId: normal.piSessionId,
+    normalParentFile: normal.piSessionFile,
+    status: "current",
+    stale: false,
+    model: "provider/model",
+    thinking: "medium",
+    tools: ["read"],
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    name: "hive:build:empty",
+  };
+  replaceSessionLinks(f.projectRoot, [normal, current]);
+
+  const reloaded = await reloadWorkflowSession({
+    projectRoot: f.projectRoot,
+    projectId: "project-1",
+    currentPiSessionId: current.piSessionId,
+    adapter: f.adapter,
+    owner: owner("empty-journal"),
+    prepareActivation: () => ({ workflow: workflow("build", "b") }),
+  });
+  assert.equal(reloaded.kind, "created");
+  assert.equal(reloaded.link.activationHash, "b".repeat(64));
+});


### PR DESCRIPTION
## Summary
- add verified one-shot cross-workflow handoff packets and bounded readback
- implement idle transactional activation reload
- add auditable generation-safe orphan recovery with crash reconciliation

## Validation
- focused handoff, reload, recovery, navigation, and integration tests
- `just coverage-core`
- `just verify`