### PR TITLE
feat(artifacts): add checkpoint approvals

### DIFF
--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 export const PACKAGE_BASELINES = Object.freeze({
-  packedBytes: 541_762,
+  packedBytes: 605_461,
   unpackedBytes: 2_164_548,
   reviewRawBytes: 12_625,
   reviewCompressedBytes: 4_304,

--- a/src/artifacts/approvals.ts
+++ b/src/artifacts/approvals.ts
@@ -1,0 +1,681 @@
+import { createHash, randomUUID } from "node:crypto";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { createWorkflowEvent, sealWorkflowEvent, type WorkflowEventEnvelope, type WorkflowEventProducer } from "../workflows/events";
+import { appendWorkflowEventChecked, readWorkflowJournal, type JournalFaultStage } from "../workflows/journal";
+import { createEmptyRunLifecycleState, isOpenRunStatus, reduceRunLifecycle, type CompletionGateResult, type OpenRunStatus, type RunCheckpointSnapshotProvider } from "../workflows/runs";
+import { boundedId, boundedText, deepFreeze, exactKeys, plainRecord } from "../workflows/values";
+import { canonicalJson as canonical } from "../config/snapshot-canonical";
+import {
+  resolveCheckpointDigest,
+  validateRunCheckpointSnapshot,
+  type CheckpointDescriptorV1,
+  type CheckpointPolicy,
+  type ResolvedCheckpointDigestV1,
+  type RunCheckpointSnapshotV1,
+} from "./checkpoints";
+import { hashArtifactWorkspace, isArtifactHash, requireExpectedArtifactHash, type ArtifactWorkspaceHashesV1 } from "./hashes";
+import { withWorkspaceLeaseRunValidation } from "./leases";
+import type { ArtifactWorkspaceBinding } from "./types";
+
+export const CHECKPOINT_APPROVAL_FORMAT_VERSION = 1 as const;
+export const CHECKPOINT_APPROVAL_LIMITS = Object.freeze({ requests: 4_096, decisions: 4_096, feedbackBytes: 8_192, outputBytes: 65_536 });
+
+export type CheckpointDecisionValue = "approved" | "denied";
+export type CheckpointControlChannel = "dashboard" | "tui";
+export type CheckpointRuntimeMode = "tui" | "headless";
+
+export interface HumanControlIdentity {
+  readonly approverId: string;
+  readonly authenticationId: string;
+  readonly mechanism: string;
+}
+export interface AuthenticateCheckpointControlInput {
+  readonly channel: CheckpointControlChannel;
+  readonly credential: unknown;
+  readonly action: "checkpoint-decision";
+  readonly operationId: string;
+}
+export interface CheckpointControlContext {
+  readonly channel: CheckpointControlChannel;
+  readonly mode: CheckpointRuntimeMode;
+  readonly dashboardAvailable: boolean;
+  readonly credential: unknown;
+}
+export interface ResolveCheckpointDescriptorInput {
+  readonly runId: string;
+  readonly checkpointId: string;
+  readonly binding: ArtifactWorkspaceBinding;
+}
+
+export interface CheckpointApprovalServiceOptions {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  readonly profileSchemaVersion: string;
+  readonly checkpointPolicies: Readonly<Record<string, CheckpointPolicy>>;
+  readonly resolveDescriptor?: (input: ResolveCheckpointDescriptorInput) => CheckpointDescriptorV1;
+  readonly authenticateControl: (input: AuthenticateCheckpointControlInput) => HumanControlIdentity | undefined;
+  readonly createRequestId?: () => string;
+  readonly createDecisionId?: () => string;
+  readonly now?: () => string;
+  readonly fault?: (operation: "default" | "request" | "decision", stage: JournalFaultStage) => void;
+  /** Projection hook shared with the run lifecycle so active-time clocks follow approval waits. */
+  readonly onRunStatusChanged?: (runId: string, status: OpenRunStatus, timestamp: string) => void;
+}
+
+export interface CheckpointDefaultView {
+  readonly checkpointId: string;
+  readonly policy: CheckpointPolicy;
+  readonly enabled: boolean;
+  readonly defaultsRevision: number;
+}
+export interface SetOptionalCheckpointDefaultInput {
+  readonly operationId: string;
+  readonly checkpointId: string;
+  readonly enabled: boolean;
+  readonly expectedDefaultsRevision: number;
+}
+export interface CheckpointDecisionRecord {
+  readonly decisionId: string;
+  readonly requestId: string;
+  readonly operationId: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly workspaceId: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  readonly profileSchemaVersion: string;
+  readonly checkpointId: string;
+  readonly checkpointVersion: string;
+  readonly decision: CheckpointDecisionValue;
+  readonly digest: string;
+  readonly expectedRequestSequence: number;
+  readonly decisionSequence: number;
+  readonly decidedAt: string;
+  readonly decisionWorkspaceHash: string;
+  readonly approverId: string;
+  readonly channel: CheckpointControlChannel;
+  readonly provenance: Readonly<{ authenticationId: string; mechanism: string }>;
+  readonly feedback?: string;
+}
+export interface CheckpointApprovalRequestRecord {
+  readonly requestId: string;
+  readonly operationId: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly workspaceId: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  readonly profileSchemaVersion: string;
+  readonly checkpointId: string;
+  readonly checkpointVersion: string;
+  readonly digest: string;
+  readonly contributorCount: number;
+  readonly requestWorkspaceHash: string;
+  readonly requestedAt: string;
+  readonly requestSequence: number;
+  readonly decision?: CheckpointDecisionRecord;
+}
+type OperationRecord =
+  | Readonly<{ kind: "default"; inputHash: string; result: CheckpointDefaultView }>
+  | Readonly<{ kind: "request"; inputHash: string; requestId: string }>
+  | Readonly<{ kind: "decision"; inputHash: string; requestId: string; decisionId: string }>;
+export interface CheckpointApprovalState {
+  readonly defaults: Readonly<Record<string, boolean>>;
+  readonly defaultsRevision: number;
+  readonly runSnapshots: Readonly<Record<string, RunCheckpointSnapshotV1>>;
+  readonly requests: Readonly<Record<string, CheckpointApprovalRequestRecord>>;
+  readonly requestOrder: readonly string[];
+  readonly operations: Readonly<Record<string, OperationRecord>>;
+  readonly openRunId?: string;
+}
+
+export interface RequestCheckpointApprovalInput {
+  readonly operationId: string;
+  readonly checkpointId: string;
+  readonly expectedWorkspaceHash: string;
+}
+export interface DecideCheckpointApprovalInput {
+  readonly operationId: string;
+  readonly requestId: string;
+  readonly expectedRequestSequence: number;
+  readonly digest: string;
+  readonly expectedWorkspaceHash: string;
+  readonly decision: CheckpointDecisionValue;
+  readonly feedback?: string;
+}
+
+function inputHash(kind: string, value: unknown): string {
+  return createHash("sha256").update(`pi-hive-checkpoint-${kind}-input-v1\0`).update(canonicalJson(value)).digest("hex");
+}
+function identifier(value: unknown, label: string): string {
+  const result = boundedId(value, label);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(result)) throw new Error(`${label} is invalid`);
+  return result;
+}
+function timestamp(value: unknown, label: string): string {
+  const result = boundedText(value, label, 256);
+  if (!Number.isFinite(Date.parse(result))) throw new Error(`${label} is invalid`);
+  return result;
+}
+function payload(event: WorkflowEventEnvelope): Record<string, unknown> | undefined {
+  if (event.type !== "approval.recorded" || !plainRecord(event.payload) || event.payload.subsystem !== "checkpoint-approval") return undefined;
+  if (event.payload.formatVersion !== CHECKPOINT_APPROVAL_FORMAT_VERSION) throw new Error("Checkpoint approval event format is unsupported");
+  return event.payload;
+}
+function persistedInputHash(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) throw new Error(`${label} is invalid`);
+  return value;
+}
+function withOperation(state: CheckpointApprovalState, operationId: string, operation: OperationRecord): Readonly<Record<string, OperationRecord>> {
+  if (state.operations[operationId]) throw new Error("Checkpoint operation is duplicated");
+  if (Object.keys(state.operations).length >= CHECKPOINT_APPROVAL_LIMITS.requests + CHECKPOINT_APPROVAL_LIMITS.decisions) throw new Error("Checkpoint operation history exceeds its bound");
+  return Object.freeze({ ...state.operations, [operationId]: Object.freeze(operation) });
+}
+
+export function createEmptyCheckpointApprovalState(): CheckpointApprovalState {
+  return deepFreeze({ defaults: {}, defaultsRevision: 0, runSnapshots: {}, requests: {}, requestOrder: [], operations: {} });
+}
+
+export function reduceCheckpointApprovalState(state: CheckpointApprovalState, event: WorkflowEventEnvelope): CheckpointApprovalState {
+  if (event.type === "run.started") {
+    if (!event.runId) throw new Error("Checkpoint run snapshot has no run ID");
+    if (state.openRunId) throw new Error("Checkpoint state already has an open run");
+    if (!plainRecord(event.payload)) throw new Error("Run start payload is invalid");
+    if (event.payload.checkpointSnapshot === undefined) return deepFreeze({ ...state, openRunId: event.runId });
+    const snapshot = validateRunCheckpointSnapshot(event.payload.checkpointSnapshot);
+    if (snapshot.runId !== event.runId || snapshot.defaultsRevision !== state.defaultsRevision) throw new Error("Run checkpoint snapshot is stale or targets another run");
+    if (state.runSnapshots[event.runId]) throw new Error("Run checkpoint snapshot is duplicated");
+    return deepFreeze({ ...state, openRunId: event.runId, runSnapshots: { ...state.runSnapshots, [event.runId]: snapshot } });
+  }
+  if (event.type === "terminal.recorded" && event.runId === state.openRunId) return deepFreeze({ ...state, openRunId: undefined });
+  const data = payload(event);
+  if (!data) return state;
+  const operation = data.operation;
+  const operationId = identifier(data.operationId, "Checkpoint operation ID");
+
+  if (operation === "default-set") {
+    exactKeys(data, ["formatVersion", "subsystem", "operation", "operationId", "inputHash", "checkpointId", "enabled", "expectedDefaultsRevision"], [], "Checkpoint default event");
+    if (event.producer !== "harness" || event.runId || state.openRunId) throw new Error("Checkpoint defaults can change only through the idle harness");
+    if (!Number.isSafeInteger(data.expectedDefaultsRevision) || (data.expectedDefaultsRevision as number) < 0 || data.expectedDefaultsRevision !== state.defaultsRevision) {
+      throw new Error("Checkpoint default revision CAS failed");
+    }
+    const checkpointId = identifier(data.checkpointId, "Checkpoint default ID");
+    if (typeof data.enabled !== "boolean") throw new Error("Checkpoint default enabled value is invalid");
+    const hash = persistedInputHash(data.inputHash, "Checkpoint default input hash");
+    const result: CheckpointDefaultView = Object.freeze({ checkpointId, policy: "optional", enabled: data.enabled, defaultsRevision: event.sequence });
+    return deepFreeze({
+      ...state,
+      defaults: { ...state.defaults, [checkpointId]: data.enabled },
+      defaultsRevision: event.sequence,
+      operations: withOperation(state, operationId, { kind: "default", inputHash: hash, result }),
+    });
+  }
+
+  if (operation === "request-bind") {
+    exactKeys(data, ["formatVersion", "subsystem", "operation", "operationId", "inputHash", "requestId"], [], "Checkpoint request binding event");
+    if (event.producer !== "harness" || !event.runId || event.runId !== state.openRunId) throw new Error("Checkpoint request binding lacks harness authority or an open run");
+    const requestId = identifier(data.requestId, "Checkpoint bound request ID");
+    const request = state.requests[requestId];
+    if (!request || request.runId !== event.runId) throw new Error("Checkpoint request binding result is missing or targets another run");
+    const hash = persistedInputHash(data.inputHash, "Checkpoint request binding input hash");
+    return deepFreeze({ ...state, operations: withOperation(state, operationId, { kind: "request", inputHash: hash, requestId }) });
+  }
+
+  if (operation === "request") {
+    exactKeys(data, ["formatVersion", "subsystem", "operation", "operationId", "inputHash", "requestId", "workspaceId", "adapterId", "adapterVersion", "profileId", "profileVersion", "profileSchemaVersion", "checkpointId", "checkpointVersion", "digest", "contributorCount", "requestWorkspaceHash"], [], "Checkpoint request event");
+    if (event.producer !== "harness" || !event.runId || event.runId !== state.openRunId) throw new Error("Checkpoint request lacks harness authority or an open run");
+    if (state.requestOrder.length >= CHECKPOINT_APPROVAL_LIMITS.requests) throw new Error("Checkpoint approval requests exceed their bound");
+    const requestId = identifier(data.requestId, "Checkpoint request ID");
+    if (state.requests[requestId]) throw new Error("Checkpoint request ID is duplicated");
+    const snapshot = state.runSnapshots[event.runId];
+    const checkpointId = identifier(data.checkpointId, "Checkpoint request checkpoint ID");
+    if (!snapshot?.enabledCheckpointIds.includes(checkpointId)) throw new Error("Checkpoint request does not target an enabled run checkpoint");
+    if (!isArtifactHash(data.digest) || !isArtifactHash(data.requestWorkspaceHash) || !Number.isSafeInteger(data.contributorCount) || (data.contributorCount as number) < 0) throw new Error("Checkpoint request digest or contributor count is invalid");
+    const hash = persistedInputHash(data.inputHash, "Checkpoint request input hash");
+    const request: CheckpointApprovalRequestRecord = Object.freeze({
+      requestId, operationId, projectId: event.projectId, sessionId: event.sessionId, runId: event.runId,
+      workspaceId: identifier(data.workspaceId, "Checkpoint workspace ID"),
+      adapterId: identifier(data.adapterId, "Checkpoint adapter ID"), adapterVersion: identifier(data.adapterVersion, "Checkpoint adapter version"),
+      profileId: identifier(data.profileId, "Checkpoint profile ID"), profileVersion: identifier(data.profileVersion, "Checkpoint profile version"),
+      profileSchemaVersion: identifier(data.profileSchemaVersion, "Checkpoint profile schema version"), checkpointId,
+      checkpointVersion: identifier(data.checkpointVersion, "Checkpoint version"), digest: data.digest,
+      contributorCount: data.contributorCount as number, requestWorkspaceHash: data.requestWorkspaceHash,
+      requestedAt: timestamp(event.timestamp, "Checkpoint request timestamp"), requestSequence: event.sequence,
+    });
+    return deepFreeze({
+      ...state,
+      requests: { ...state.requests, [requestId]: request }, requestOrder: [...state.requestOrder, requestId],
+      operations: withOperation(state, operationId, { kind: "request", inputHash: hash, requestId }),
+    });
+  }
+
+  if (operation === "decision") {
+    exactKeys(data, ["formatVersion", "subsystem", "operation", "operationId", "inputHash", "decisionId", "requestId", "expectedRequestSequence", "digest", "decisionWorkspaceHash", "decision", "approverId", "channel", "provenance"], ["feedback"], "Checkpoint decision event");
+    if (!event.runId || event.runId !== state.openRunId) throw new Error("Checkpoint decision does not target the open run");
+    const channel = data.channel;
+    if ((channel !== "dashboard" && channel !== "tui") || (channel === "dashboard" ? event.producer !== "dashboard" : event.producer !== "harness")) throw new Error("Checkpoint decision channel lacks persisted control authority");
+    const requestId = identifier(data.requestId, "Checkpoint decision request ID");
+    const request = state.requests[requestId];
+    if (!request || request.runId !== event.runId || request.decision) throw new Error("Checkpoint request is missing or already decided; first valid decision wins");
+    if (!Number.isSafeInteger(data.expectedRequestSequence) || data.expectedRequestSequence !== request.requestSequence || data.digest !== request.digest) throw new Error("Checkpoint decision exact request CAS failed");
+    if (data.decision !== "approved" && data.decision !== "denied") throw new Error("Checkpoint decision value is invalid");
+    if (!isArtifactHash(data.decisionWorkspaceHash)) throw new Error("Checkpoint decision workspace hash is invalid");
+    const feedback = data.feedback === undefined ? undefined : boundedText(data.feedback, "Checkpoint decision feedback", CHECKPOINT_APPROVAL_LIMITS.feedbackBytes);
+    if (!plainRecord(data.provenance)) throw new Error("Checkpoint decision provenance is invalid");
+    exactKeys(data.provenance, ["authenticationId", "mechanism"], [], "Checkpoint decision provenance");
+    const provenance = Object.freeze({
+      authenticationId: identifier(data.provenance.authenticationId, "Checkpoint authentication ID"),
+      mechanism: identifier(data.provenance.mechanism, "Checkpoint authentication mechanism"),
+    });
+    const decisionId = identifier(data.decisionId, "Checkpoint decision ID");
+    if (Object.values(state.requests).some((candidate) => candidate.decision?.decisionId === decisionId)) throw new Error("Checkpoint decision ID is duplicated");
+    const hash = persistedInputHash(data.inputHash, "Checkpoint decision input hash");
+    const decision: CheckpointDecisionRecord = Object.freeze({
+      decisionId, requestId, operationId,
+      projectId: request.projectId, sessionId: request.sessionId, runId: request.runId, workspaceId: request.workspaceId,
+      adapterId: request.adapterId, adapterVersion: request.adapterVersion, profileId: request.profileId, profileVersion: request.profileVersion,
+      profileSchemaVersion: request.profileSchemaVersion, checkpointId: request.checkpointId, checkpointVersion: request.checkpointVersion,
+      decision: data.decision, digest: request.digest,
+      expectedRequestSequence: request.requestSequence, decisionSequence: event.sequence, decidedAt: timestamp(event.timestamp, "Checkpoint decision timestamp"),
+      decisionWorkspaceHash: data.decisionWorkspaceHash, approverId: identifier(data.approverId, "Checkpoint approver ID"), channel, provenance,
+      ...(feedback === undefined ? {} : { feedback }),
+    });
+    return deepFreeze({
+      ...state,
+      requests: { ...state.requests, [requestId]: { ...request, decision } },
+      operations: withOperation(state, operationId, { kind: "decision", inputHash: hash, requestId, decisionId }),
+    });
+  }
+  throw new Error("Checkpoint approval operation is unsupported");
+}
+
+interface ResolvedCurrentCheckpoint {
+  readonly runId: string;
+  readonly binding: ArtifactWorkspaceBinding;
+  readonly hashes: ArtifactWorkspaceHashesV1;
+  readonly resolved: ResolvedCheckpointDigestV1;
+}
+
+export class CheckpointApprovalService {
+  readonly options: CheckpointApprovalServiceOptions;
+  private readonly policies: Readonly<Record<string, CheckpointPolicy>>;
+
+  constructor(options: CheckpointApprovalServiceOptions) {
+    this.options = options;
+    identifier(options.projectId, "Checkpoint project ID"); identifier(options.sessionId, "Checkpoint session ID");
+    identifier(options.adapterId, "Checkpoint adapter ID"); identifier(options.adapterVersion, "Checkpoint adapter version");
+    identifier(options.profileId, "Checkpoint profile ID"); identifier(options.profileVersion, "Checkpoint profile version"); identifier(options.profileSchemaVersion, "Checkpoint profile schema version");
+    if (!plainRecord(options.checkpointPolicies)) throw new Error("Checkpoint policies are invalid");
+    const policies: Record<string, CheckpointPolicy> = {};
+    for (const key of Object.keys(options.checkpointPolicies).sort()) {
+      const id = identifier(key, "Checkpoint policy ID");
+      const policy = options.checkpointPolicies[key];
+      if (policy !== "required" && policy !== "optional" && policy !== "none") throw new Error("Checkpoint policy value is invalid");
+      policies[id] = policy;
+    }
+    if (Object.values(policies).some((policy) => policy !== "none") && !options.resolveDescriptor) throw new Error("Enabled checkpoint profiles require a trusted descriptor resolver");
+    this.policies = Object.freeze(policies);
+  }
+
+  restore(events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId)): CheckpointApprovalState {
+    return events.reduce(reduceCheckpointApprovalState, createEmptyCheckpointApprovalState());
+  }
+
+  nextRunDefaults(): readonly CheckpointDefaultView[] {
+    const state = this.restore();
+    return Object.freeze(Object.entries(this.policies).map(([checkpointId, policy]) => Object.freeze({
+      checkpointId, policy, enabled: policy === "required" || (policy === "optional" && (state.defaults[checkpointId] ?? true)), defaultsRevision: state.defaultsRevision,
+    })));
+  }
+
+  setOptionalDefault(input: SetOptionalCheckpointDefaultInput): CheckpointDefaultView {
+    if (!plainRecord(input)) throw new Error("Checkpoint default input is invalid");
+    exactKeys(input, ["operationId", "checkpointId", "enabled", "expectedDefaultsRevision"], [], "Checkpoint default input");
+    const operationId = identifier(input.operationId, "Checkpoint default operation ID");
+    const checkpointId = identifier(input.checkpointId, "Checkpoint default ID");
+    if (this.policies[checkpointId] !== "optional") throw new Error(`Checkpoint ${checkpointId} is not optional; required/none policy cannot be changed`);
+    if (typeof input.enabled !== "boolean") throw new Error("Checkpoint default enabled value is invalid");
+    if (!Number.isSafeInteger(input.expectedDefaultsRevision) || input.expectedDefaultsRevision < 0) throw new Error("Checkpoint expected default revision is invalid");
+    const expectedHash = inputHash("default", { checkpointId, enabled: input.enabled, expectedDefaultsRevision: input.expectedDefaultsRevision });
+    const initialOperation = this.restore().operations[operationId];
+    if (initialOperation) return this.replayDefaultOperation(initialOperation, expectedHash);
+    const current = this.restore();
+    if (current.openRunId) throw new Error("Checkpoint defaults can change only while the workflow session is idle; an open run exists");
+    if (current.defaultsRevision !== input.expectedDefaultsRevision) throw new Error("Checkpoint default revision CAS failed; expected revision is stale");
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, type: "approval.recorded", producer: "harness", timestamp: this.time(),
+      payload: {
+        formatVersion: 1, subsystem: "checkpoint-approval", operation: "default-set", operationId, inputHash: expectedHash,
+        checkpointId, enabled: input.enabled, expectedDefaultsRevision: input.expectedDefaultsRevision,
+      },
+    });
+    try {
+      this.appendValidated(draft, "default", (events) => {
+        const locked = this.restore(events);
+        const operation = locked.operations[operationId];
+        if (operation) throw new Error("Checkpoint default operation was recorded concurrently");
+        if (locked.openRunId) throw new Error("Checkpoint defaults can change only while the workflow session is idle; an open run exists");
+        if (locked.defaultsRevision !== input.expectedDefaultsRevision) throw new Error("Checkpoint default revision CAS failed; expected revision is stale");
+      });
+    } catch (error) {
+      const replayed = this.restore().operations[operationId];
+      if (!replayed) throw error;
+      return this.replayDefaultOperation(replayed, expectedHash);
+    }
+    return this.replayDefaultOperation(this.restore().operations[operationId], expectedHash);
+  }
+
+  private replayDefaultOperation(operation: OperationRecord | undefined, expectedHash: string): CheckpointDefaultView {
+    if (!operation || operation.kind !== "default" || operation.inputHash !== expectedHash) throw new Error("Checkpoint default operation ID reuse with different input is rejected");
+    return operation.result;
+  }
+
+  private createSnapshot(runId: string, state = this.restore()): RunCheckpointSnapshotV1 {
+    identifier(runId, "Checkpoint snapshot run ID");
+    if (state.openRunId) throw new Error("A checkpoint run snapshot can be created only while the session is idle");
+    const checkpoints = Object.entries(this.policies).map(([checkpointId, policy]) => Object.freeze({
+      checkpointId, policy, enabled: policy === "required" || (policy === "optional" && (state.defaults[checkpointId] ?? true)),
+    }));
+    return validateRunCheckpointSnapshot({
+      formatVersion: 1, runId, adapterId: this.options.adapterId, adapterVersion: this.options.adapterVersion,
+      profileId: this.options.profileId, profileVersion: this.options.profileVersion, profileSchemaVersion: this.options.profileSchemaVersion,
+      defaultsRevision: state.defaultsRevision, checkpoints, enabledCheckpointIds: checkpoints.filter((entry) => entry.enabled).map((entry) => entry.checkpointId),
+    });
+  }
+
+  runSnapshotProvider(): RunCheckpointSnapshotProvider {
+    return Object.freeze({
+      create: (runId: string) => this.createSnapshot(runId),
+      validate: (snapshot: RunCheckpointSnapshotV1, events: readonly WorkflowEventEnvelope[]) => {
+        const current = this.restore(events);
+        const expected = this.createSnapshot(snapshot.runId, current);
+        if (canonical(expected) !== canonical(snapshot)) throw new Error("Checkpoint defaults changed before atomic run creation");
+      },
+    });
+  }
+
+  private time(): string { return timestamp(this.options.now?.() ?? new Date().toISOString(), "Checkpoint event timestamp"); }
+
+  private appendValidated(draft: ReturnType<typeof createWorkflowEvent>, operation: "default" | "request" | "decision", check?: (events: readonly WorkflowEventEnvelope[]) => void): WorkflowEventEnvelope {
+    return appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+      check?.(events);
+      const previous = events.at(-1);
+      const candidate = sealWorkflowEvent(draft, (previous?.sequence ?? 0) + 1, previous?.eventHash ?? null);
+      reduceCheckpointApprovalState(this.restore(events), candidate);
+      reduceRunLifecycle(
+        events.reduce(reduceRunLifecycle, createEmptyRunLifecycleState(this.options.sessionId)),
+        candidate,
+      );
+    }, { fault: (stage) => this.options.fault?.(operation, stage) });
+  }
+
+  private publishedDraft(draft: ReturnType<typeof createWorkflowEvent>): WorkflowEventEnvelope | undefined {
+    return readWorkflowJournal(this.options.projectRoot, this.options.sessionId).find((event) => event.eventId === draft.eventId);
+  }
+
+  private projectApprovalStatus(event: WorkflowEventEnvelope, status: Extract<OpenRunStatus, "running" | "waiting_for_human">): void {
+    if (!event.runId) throw new Error("Checkpoint status projection requires a run ID");
+    this.options.onRunStatusChanged?.(event.runId, status, event.timestamp);
+  }
+
+  private currentRunBinding(events: readonly WorkflowEventEnvelope[], requestedRunId?: string): Readonly<{ runId: string; binding: ArtifactWorkspaceBinding; snapshot: RunCheckpointSnapshotV1 }> {
+    const run = events.reduce(reduceRunLifecycle, createEmptyRunLifecycleState(this.options.sessionId)).latestRun;
+    if (!run || !isOpenRunStatus(run.status) || (requestedRunId && run.runId !== requestedRunId)) throw new Error("Checkpoint operation requires the current open run");
+    const binding = run.artifactWorkspace;
+    if (!binding || binding.workspace.kind !== "physical" || !binding.path) throw new Error("Checkpoint operation requires a bound physical artifact workspace");
+    const snapshot = run.checkpointSnapshot;
+    if (!snapshot || snapshot.runId !== run.runId) throw new Error("Run has no frozen checkpoint policy snapshot");
+    if (binding.adapterId !== this.options.adapterId || binding.adapterVersion !== this.options.adapterVersion || binding.profileId !== this.options.profileId || binding.profileVersion !== this.options.profileVersion
+      || snapshot.adapterId !== this.options.adapterId || snapshot.adapterVersion !== this.options.adapterVersion || snapshot.profileId !== this.options.profileId || snapshot.profileVersion !== this.options.profileVersion || snapshot.profileSchemaVersion !== this.options.profileSchemaVersion) {
+      throw new Error("Checkpoint service identity does not match the bound adapter/profile snapshot");
+    }
+    return Object.freeze({ runId: run.runId, binding, snapshot });
+  }
+
+  private assertCheckpointAvailable(current: Readonly<{ binding: ArtifactWorkspaceBinding; snapshot: RunCheckpointSnapshotV1 }>, checkpointId: string): void {
+    if (!current.snapshot.enabledCheckpointIds.includes(checkpointId)) throw new Error(`Checkpoint ${checkpointId} is disabled for this frozen run and has no human gate`);
+    if (!current.binding.checkpointIds.includes(checkpointId)) throw new Error("Checkpoint is not published by the bound adapter profile");
+  }
+
+  private resolveCurrent(events: readonly WorkflowEventEnvelope[], checkpointId: string, expectedWorkspaceHash: string, runId?: string): ResolvedCurrentCheckpoint {
+    const current = this.currentRunBinding(events, runId);
+    this.assertCheckpointAvailable(current, checkpointId);
+    const hashes = hashArtifactWorkspace(current.binding.path!);
+    requireExpectedArtifactHash(expectedWorkspaceHash, hashes);
+    const descriptor = this.options.resolveDescriptor?.({ runId: current.runId, checkpointId, binding: current.binding });
+    if (!descriptor) throw new Error("Trusted checkpoint descriptor is unavailable");
+    const resolved = resolveCheckpointDigest(descriptor, hashes);
+    if (resolved.adapterId !== this.options.adapterId || resolved.adapterVersion !== this.options.adapterVersion || resolved.profileId !== this.options.profileId
+      || resolved.profileVersion !== this.options.profileVersion || resolved.profileSchemaVersion !== this.options.profileSchemaVersion || resolved.checkpointId !== checkpointId) {
+      throw new Error("Checkpoint descriptor identity does not match the active adapter/profile/checkpoint");
+    }
+    return Object.freeze({ runId: current.runId, binding: current.binding, hashes, resolved });
+  }
+
+  async requestApproval(rawInput: RequestCheckpointApprovalInput): Promise<CheckpointApprovalRequestRecord> {
+    if (!plainRecord(rawInput)) throw new Error("Checkpoint approval request input is invalid");
+    exactKeys(rawInput, ["operationId", "checkpointId", "expectedWorkspaceHash"], [], "Checkpoint approval request input");
+    const operationId = identifier(rawInput.operationId, "Checkpoint request operation ID");
+    const checkpointId = identifier(rawInput.checkpointId, "Checkpoint request checkpoint ID");
+    if (!isArtifactHash(rawInput.expectedWorkspaceHash)) throw new Error("Checkpoint request expected workspace hash is invalid");
+    const requestInputHash = inputHash("request", { checkpointId, expectedWorkspaceHash: rawInput.expectedWorkspaceHash });
+    const existingOperation = this.restore().operations[operationId];
+    if (existingOperation) return this.replayRequestOperation(existingOperation, requestInputHash);
+    const initialEvents = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+    const initial = this.currentRunBinding(initialEvents);
+    this.assertCheckpointAvailable(initial, checkpointId);
+    return withWorkspaceLeaseRunValidation(this.options.projectRoot, initial.binding.adapterId, initial.binding.workspace.id, { sessionId: this.options.sessionId, runId: initial.runId }, async () => {
+      const replayedOperation = this.restore().operations[operationId];
+      if (replayedOperation) return this.replayRequestOperation(replayedOperation, requestInputHash);
+      const lockedEvents = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+      const current = this.resolveCurrent(lockedEvents, checkpointId, rawInput.expectedWorkspaceHash, initial.runId);
+      const state = this.restore(lockedEvents);
+      const exact = state.requestOrder.map((id) => state.requests[id]).find((request) => request.runId === current.runId && request.checkpointId === checkpointId && request.digest === current.resolved.digest);
+      if (exact) {
+        const bindingDraft = createWorkflowEvent({
+          projectId: this.options.projectId, sessionId: this.options.sessionId, runId: current.runId, type: "approval.recorded", producer: "harness", timestamp: this.time(), attemptId: operationId,
+          payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation: "request-bind", operationId, inputHash: requestInputHash, requestId: exact.requestId },
+        });
+        try {
+          this.appendValidated(bindingDraft, "request", (events) => {
+            const lockedState = this.restore(events);
+            if (lockedState.operations[operationId]) throw new Error("Checkpoint request operation was recorded concurrently");
+            const lockedExact = lockedState.requests[exact.requestId];
+            if (!lockedExact || lockedExact.runId !== current.runId || lockedExact.checkpointId !== checkpointId || lockedExact.digest !== current.resolved.digest) {
+              throw new Error("Checkpoint exact request result changed before operation binding");
+            }
+          });
+        } catch (error) {
+          const replayed = this.restore().operations[operationId];
+          if (!replayed) throw error;
+          return this.replayRequestOperation(replayed, requestInputHash);
+        }
+        return this.replayRequestOperation(this.restore().operations[operationId], requestInputHash);
+      }
+      const pending = state.requestOrder.map((id) => state.requests[id]).find((request) => request.runId === current.runId && request.checkpointId === checkpointId && !request.decision);
+      if (pending) throw new Error("Checkpoint already has a pending exact-digest request");
+      const requestId = identifier(this.options.createRequestId?.() ?? `checkpoint-request-${randomUUID()}`, "Checkpoint request ID");
+      const draft = createWorkflowEvent({
+        projectId: this.options.projectId, sessionId: this.options.sessionId, runId: current.runId, type: "approval.recorded", producer: "harness", timestamp: this.time(), attemptId: operationId,
+        payload: {
+          formatVersion: 1, subsystem: "checkpoint-approval", operation: "request", operationId, inputHash: requestInputHash, requestId,
+          workspaceId: current.binding.workspace.id, adapterId: current.resolved.adapterId, adapterVersion: current.resolved.adapterVersion,
+          profileId: current.resolved.profileId, profileVersion: current.resolved.profileVersion, profileSchemaVersion: current.resolved.profileSchemaVersion,
+          checkpointId, checkpointVersion: current.resolved.checkpointVersion, digest: current.resolved.digest,
+          contributorCount: current.resolved.contributors.length, requestWorkspaceHash: current.hashes.workspaceHash,
+        },
+      });
+      let published: WorkflowEventEnvelope | undefined;
+      try {
+        published = this.appendValidated(draft, "request", (events) => {
+          const lockedState = this.restore(events);
+          const operation = lockedState.operations[operationId];
+          if (operation) throw new Error("Checkpoint request operation was recorded concurrently");
+          const locked = this.resolveCurrent(events, checkpointId, rawInput.expectedWorkspaceHash, current.runId);
+          if (locked.resolved.digest !== current.resolved.digest) throw new Error("Checkpoint digest changed before request publication");
+          const active = lockedState.requestOrder.map((id) => lockedState.requests[id]).find((request) => request.runId === current.runId && request.checkpointId === checkpointId && !request.decision);
+          if (active) throw new Error("Checkpoint request state changed before publication");
+        });
+      } catch (error) {
+        const replayed = this.restore().operations[operationId];
+        if (!replayed) throw error;
+        published = this.publishedDraft(draft);
+        if (published) this.projectApprovalStatus(published, "waiting_for_human");
+        return this.replayRequestOperation(replayed, requestInputHash);
+      }
+      this.projectApprovalStatus(published, "waiting_for_human");
+      return this.restore().requests[requestId];
+    });
+  }
+
+  private replayRequestOperation(operation: OperationRecord, expectedHash: string): CheckpointApprovalRequestRecord {
+    if (operation.kind !== "request" || operation.inputHash !== expectedHash || !operation.requestId) throw new Error("Checkpoint request operation ID reuse with different input is rejected");
+    const request = this.restore().requests[operation.requestId];
+    if (!request) throw new Error("Checkpoint request operation result is missing");
+    return request;
+  }
+
+  async decide(rawInput: DecideCheckpointApprovalInput, context: CheckpointControlContext): Promise<CheckpointDecisionRecord> {
+    const input = this.validateDecisionInput(rawInput);
+    const control = this.authenticate(input.operationId, context);
+    const decisionInputHash = inputHash("decision", input);
+    const existingOperation = this.restore().operations[input.operationId];
+    if (existingOperation) return this.replayDecisionOperation(existingOperation, decisionInputHash);
+    const initial = this.restore();
+    const request = initial.requests[input.requestId];
+    if (!request) throw new Error("Checkpoint approval request does not exist");
+    if (request.decision) throw new Error("Checkpoint request is already decided and immutable; first valid decision wins");
+    if (request.requestSequence !== input.expectedRequestSequence || request.digest !== input.digest) throw new Error("Checkpoint decision must bind the exact request sequence and digest");
+    const producer: WorkflowEventProducer = context.channel === "dashboard" ? "dashboard" : "harness";
+    const decisionId = identifier(this.options.createDecisionId?.() ?? `checkpoint-decision-${randomUUID()}`, "Checkpoint decision ID");
+    return withWorkspaceLeaseRunValidation(this.options.projectRoot, request.adapterId, request.workspaceId, { sessionId: this.options.sessionId, runId: request.runId }, async () => {
+      const beforeEvents = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+      const current = this.resolveCurrent(beforeEvents, request.checkpointId, input.expectedWorkspaceHash, request.runId);
+      if (current.resolved.digest !== request.digest || input.digest !== request.digest) throw new Error("Checkpoint decision digest is stale or does not match the exact current contributors");
+      const draft = createWorkflowEvent({
+        projectId: this.options.projectId, sessionId: this.options.sessionId, runId: request.runId, type: "approval.recorded", producer, timestamp: this.time(), attemptId: input.operationId,
+        payload: {
+          formatVersion: 1, subsystem: "checkpoint-approval", operation: "decision", operationId: input.operationId, inputHash: decisionInputHash, decisionId,
+          requestId: request.requestId, expectedRequestSequence: input.expectedRequestSequence, digest: input.digest,
+          decisionWorkspaceHash: current.hashes.workspaceHash, decision: input.decision, approverId: control.approverId,
+          channel: context.channel, provenance: { authenticationId: control.authenticationId, mechanism: control.mechanism },
+          ...(input.feedback === undefined ? {} : { feedback: input.feedback }),
+        },
+      });
+      let published: WorkflowEventEnvelope | undefined;
+      try {
+        published = this.appendValidated(draft, "decision", (events) => {
+          const state = this.restore(events);
+          const operation = state.operations[input.operationId];
+          if (operation) throw new Error("Checkpoint decision operation was recorded concurrently");
+          const lockedRequest = state.requests[request.requestId];
+          if (!lockedRequest || lockedRequest.decision || lockedRequest.requestSequence !== input.expectedRequestSequence || lockedRequest.digest !== input.digest) throw new Error("Checkpoint decision CAS lost; first valid decision wins");
+          const locked = this.resolveCurrent(events, request.checkpointId, input.expectedWorkspaceHash, request.runId);
+          if (locked.resolved.digest !== request.digest) throw new Error("Checkpoint digest changed before decision publication");
+        });
+      } catch (error) {
+        const replayed = this.restore().operations[input.operationId];
+        if (!replayed) throw error;
+        published = this.publishedDraft(draft);
+        if (published) this.projectApprovalStatus(published, "running");
+        return this.replayDecisionOperation(replayed, decisionInputHash);
+      }
+      this.projectApprovalStatus(published, "running");
+      return this.restore().requests[request.requestId].decision!;
+    });
+  }
+
+  private validateDecisionInput(value: DecideCheckpointApprovalInput): Required<Omit<DecideCheckpointApprovalInput, "feedback">> & Pick<DecideCheckpointApprovalInput, "feedback"> {
+    if (!plainRecord(value)) throw new Error("Checkpoint decision input is invalid");
+    exactKeys(value, ["operationId", "requestId", "expectedRequestSequence", "digest", "expectedWorkspaceHash", "decision"], ["feedback"], "Checkpoint decision input");
+    const operationId = identifier(value.operationId, "Checkpoint decision operation ID");
+    const requestId = identifier(value.requestId, "Checkpoint decision request ID");
+    if (!Number.isSafeInteger(value.expectedRequestSequence) || value.expectedRequestSequence < 1) throw new Error("Checkpoint expected request sequence is invalid");
+    if (!isArtifactHash(value.digest) || !isArtifactHash(value.expectedWorkspaceHash)) throw new Error("Checkpoint decision digest/hash is invalid");
+    if (value.decision !== "approved" && value.decision !== "denied") throw new Error("Checkpoint decision value is invalid");
+    const feedback = value.feedback === undefined ? undefined : boundedText(value.feedback, "Checkpoint decision feedback", CHECKPOINT_APPROVAL_LIMITS.feedbackBytes);
+    return Object.freeze({ operationId, requestId, expectedRequestSequence: value.expectedRequestSequence, digest: value.digest, expectedWorkspaceHash: value.expectedWorkspaceHash, decision: value.decision, ...(feedback === undefined ? {} : { feedback }) });
+  }
+
+  private authenticate(operationId: string, context: CheckpointControlContext): HumanControlIdentity {
+    if (!plainRecord(context)) throw new Error("Checkpoint control context is invalid");
+    exactKeys(context, ["channel", "mode", "dashboardAvailable", "credential"], [], "Checkpoint control context");
+    if (context.channel !== "dashboard" && context.channel !== "tui") throw new Error("Checkpoint decisions require a dashboard or TUI human channel");
+    if (context.mode !== "tui" && context.mode !== "headless" || typeof context.dashboardAvailable !== "boolean") throw new Error("Checkpoint control runtime mode is invalid");
+    if (context.channel === "dashboard" && !context.dashboardAvailable) throw new Error("Dashboard control channel is unavailable");
+    if (context.channel === "tui" && (context.mode !== "tui" || context.dashboardAvailable)) throw new Error("TUI approval is allowed only in TUI mode when the dashboard is unavailable; headless requires dashboard");
+    const raw = this.options.authenticateControl({ channel: context.channel, credential: context.credential, action: "checkpoint-decision", operationId });
+    if (!raw || !plainRecord(raw)) throw new Error("Checkpoint decision is not an authenticated explicit human action");
+    exactKeys(raw, ["approverId", "authenticationId", "mechanism"], [], "Checkpoint control identity");
+    return Object.freeze({
+      approverId: identifier(raw.approverId, "Checkpoint approver ID"),
+      authenticationId: identifier(raw.authenticationId, "Checkpoint authentication ID"),
+      mechanism: identifier(raw.mechanism, "Checkpoint authentication mechanism"),
+    });
+  }
+
+  private replayDecisionOperation(operation: OperationRecord, expectedHash: string): CheckpointDecisionRecord {
+    if (operation.kind !== "decision" || operation.inputHash !== expectedHash || !operation.requestId || !operation.decisionId) throw new Error("Checkpoint decision operation ID reuse with different input is rejected");
+    const decision = this.restore().requests[operation.requestId]?.decision;
+    if (!decision || decision.decisionId !== operation.decisionId) throw new Error("Checkpoint decision operation result is missing");
+    return decision;
+  }
+
+  async completionGate(input: Readonly<{ expectedWorkspaceHash?: string; runId?: string }>): Promise<CompletionGateResult> {
+    if (!plainRecord(input)) return Object.freeze({ state: "unsatisfied", issues: Object.freeze(["checkpoint approvals: completion input is invalid"]) });
+    try {
+      exactKeys(input, [], ["expectedWorkspaceHash", "runId"], "Checkpoint completion input");
+      const events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+      const run = events.reduce(reduceRunLifecycle, createEmptyRunLifecycleState(this.options.sessionId)).latestRun;
+      if (!run || !isOpenRunStatus(run.status) || (input.runId !== undefined && input.runId !== run.runId) || !run.checkpointSnapshot) throw new Error("completion requires the current open run checkpoint snapshot");
+      if (!run.checkpointSnapshot.enabledCheckpointIds.length) return Object.freeze({ state: "not-present" });
+      if (!isArtifactHash(input.expectedWorkspaceHash)) throw new Error("expected workspace hash is invalid");
+      const current = this.currentRunBinding(events, input.runId);
+      const enabled = current.snapshot.enabledCheckpointIds;
+      const state = this.restore(events);
+      const issues: string[] = [];
+      for (const checkpointId of enabled) {
+        const resolved = this.resolveCurrent(events, checkpointId, input.expectedWorkspaceHash, current.runId).resolved;
+        const exact = state.requestOrder.map((id) => state.requests[id]).find((request) => request.runId === current.runId && request.checkpointId === checkpointId && request.digest === resolved.digest);
+        if (!exact) issues.push(`checkpoint ${checkpointId}: exact-digest approval is missing`);
+        else if (!exact.decision) issues.push(`checkpoint ${checkpointId}: human decision is pending`);
+        else if (exact.decision.decision === "denied") issues.push(`checkpoint ${checkpointId}: exact digest was denied and requires revision`);
+      }
+      return issues.length ? Object.freeze({ state: "unsatisfied", issues: Object.freeze(issues.slice(0, 128)) }) : Object.freeze({ state: "satisfied" });
+    } catch (error) {
+      return Object.freeze({ state: "unsatisfied", issues: Object.freeze([`checkpoint approvals: ${String(error instanceof Error ? error.message : error).slice(0, 2_048)}`]) });
+    }
+  }
+}
+
+export interface CheckpointControlServiceHandlers {
+  listDefaults(): readonly CheckpointDefaultView[];
+  setOptionalDefault(input: unknown): CheckpointDefaultView;
+  decide(input: unknown, context: CheckpointControlContext): Promise<CheckpointDecisionRecord>;
+}
+
+function boundedControlOutput<T>(value: T): T {
+  if (Buffer.byteLength(canonicalJson(value), "utf8") > CHECKPOINT_APPROVAL_LIMITS.outputBytes) throw new Error("Checkpoint control output exceeds its bound");
+  return value;
+}
+
+/** Typed transport-neutral handlers for W25/W26. This module registers no routes or UI. */
+export function createCheckpointControlHandlers(service: CheckpointApprovalService): CheckpointControlServiceHandlers {
+  if (!(service instanceof CheckpointApprovalService)) throw new Error("Checkpoint control handlers require a checkpoint approval service");
+  return Object.freeze({
+    listDefaults: () => boundedControlOutput(service.nextRunDefaults()),
+    setOptionalDefault: (input: unknown) => boundedControlOutput(service.setOptionalDefault(input as SetOptionalCheckpointDefaultInput)),
+    decide: async (input: unknown, context: CheckpointControlContext) => boundedControlOutput(await service.decide(input as DecideCheckpointApprovalInput, context)),
+  });
+}

--- a/src/artifacts/checkpoints.ts
+++ b/src/artifacts/checkpoints.ts
@@ -1,0 +1,218 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+import { boundedId, boundedJson, deepFreeze, exactKeys, plainRecord } from "../workflows/values";
+import { isArtifactHash, type ArtifactWorkspaceHashesV1 } from "./hashes";
+
+export const CHECKPOINT_DESCRIPTOR_FORMAT_VERSION = 1 as const;
+export const CHECKPOINT_DIGEST_LIMITS = Object.freeze({
+  contributors: 512,
+  dataBytes: 65_536,
+  dataDepth: 16,
+  dataNodes: 4_096,
+  pathBytes: 4_096,
+  descriptorBytes: 131_072,
+});
+
+export type CheckpointContributorV1 =
+  | Readonly<{ kind: "file"; path: string }>
+  | Readonly<{ kind: "data"; id: string; value: JsonValue }>
+  | Readonly<{ kind: "hash"; id: string; digest: string }>;
+
+export interface CheckpointDescriptorV1 {
+  readonly formatVersion: 1;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  /** Adapter-profile schema that defines the contributor contract. */
+  readonly profileSchemaVersion: string;
+  readonly checkpointId: string;
+  readonly checkpointVersion: string;
+  readonly contributors: readonly CheckpointContributorV1[];
+}
+
+export type ResolvedCheckpointContributorV1 =
+  | Readonly<{ kind: "file"; path: string; bytes: number; digest: string }>
+  | Readonly<{ kind: "data"; id: string; digest: string }>
+  | Readonly<{ kind: "hash"; id: string; digest: string }>;
+
+export interface ResolvedCheckpointDigestV1 {
+  readonly formatVersion: 1;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  readonly profileSchemaVersion: string;
+  readonly checkpointId: string;
+  readonly checkpointVersion: string;
+  readonly digest: string;
+  /** Redacted contributor proofs: data values are represented only by hashes. */
+  readonly contributors: readonly ResolvedCheckpointContributorV1[];
+}
+
+export type CheckpointPolicy = "required" | "optional" | "none";
+export interface EffectiveCheckpointV1 {
+  readonly checkpointId: string;
+  readonly policy: CheckpointPolicy;
+  readonly enabled: boolean;
+}
+export interface RunCheckpointSnapshotV1 {
+  readonly formatVersion: 1;
+  readonly runId: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly profileId: string;
+  readonly profileVersion: string;
+  readonly profileSchemaVersion: string;
+  /** Journal sequence of the last optional-default update observed at creation. */
+  readonly defaultsRevision: number;
+  readonly checkpoints: readonly EffectiveCheckpointV1[];
+  readonly enabledCheckpointIds: readonly string[];
+}
+
+function digest(domain: string, value: unknown): string {
+  return `sha256:${createHash("sha256").update(`${domain}\0`).update(canonicalJson(value)).digest("hex")}`;
+}
+function identifier(value: unknown, label: string): string {
+  const result = boundedId(value, label);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(result)) throw new Error(`${label} is invalid`);
+  return result;
+}
+function contributorPath(value: unknown): string {
+  if (typeof value !== "string" || !value || Buffer.byteLength(value, "utf8") > CHECKPOINT_DIGEST_LIMITS.pathBytes
+    || value.includes("\\") || value.includes("\0") || value.startsWith("/") || /^[A-Za-z]:\//u.test(value)
+    || posix.normalize(value) !== value || value === "." || value.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error("Checkpoint contributor path must be a normalized workspace-relative path");
+  }
+  return value;
+}
+function validateDescriptorIdentity(value: CheckpointDescriptorV1): Omit<CheckpointDescriptorV1, "contributors"> {
+  if (!plainRecord(value)) throw new Error("Checkpoint descriptor is invalid");
+  exactKeys(value, ["formatVersion", "adapterId", "adapterVersion", "profileId", "profileVersion", "profileSchemaVersion", "checkpointId", "checkpointVersion", "contributors"], [], "Checkpoint descriptor");
+  if (value.formatVersion !== CHECKPOINT_DESCRIPTOR_FORMAT_VERSION || !Array.isArray(value.contributors)
+    || value.contributors.length > CHECKPOINT_DIGEST_LIMITS.contributors) throw new Error("Checkpoint descriptor format or contributor count is invalid");
+  return Object.freeze({
+    formatVersion: CHECKPOINT_DESCRIPTOR_FORMAT_VERSION,
+    adapterId: identifier(value.adapterId, "Checkpoint adapter ID"),
+    adapterVersion: identifier(value.adapterVersion, "Checkpoint adapter version"),
+    profileId: identifier(value.profileId, "Checkpoint profile ID"),
+    profileVersion: identifier(value.profileVersion, "Checkpoint profile version"),
+    profileSchemaVersion: identifier(value.profileSchemaVersion, "Checkpoint profile schema version"),
+    checkpointId: identifier(value.checkpointId, "Checkpoint ID"),
+    checkpointVersion: identifier(value.checkpointVersion, "Checkpoint version"),
+  });
+}
+function resolveContributor(value: unknown, hashes: ArtifactWorkspaceHashesV1): ResolvedCheckpointContributorV1 {
+  if (!plainRecord(value) || typeof value.kind !== "string") throw new Error("Checkpoint contributor is invalid");
+  if (value.kind === "file") {
+    exactKeys(value, ["kind", "path"], [], "Checkpoint file contributor");
+    const path = contributorPath(value.path);
+    const entry = hashes.entries.find((candidate) => candidate.path === path);
+    if (!entry || entry.kind !== "file") throw new Error(`Checkpoint file contributor is missing or not a file: ${path}`);
+    return Object.freeze({ kind: "file", path, bytes: entry.bytes, digest: entry.hash });
+  }
+  if (value.kind === "data") {
+    exactKeys(value, ["kind", "id", "value"], [], "Checkpoint data contributor");
+    const id = identifier(value.id, "Checkpoint data contributor ID");
+    const data = boundedJson(value.value, "Checkpoint data contributor", {
+      bytes: CHECKPOINT_DIGEST_LIMITS.dataBytes,
+      depth: CHECKPOINT_DIGEST_LIMITS.dataDepth,
+      nodes: CHECKPOINT_DIGEST_LIMITS.dataNodes,
+    });
+    return Object.freeze({ kind: "data", id, digest: digest("pi-hive-checkpoint-data-v1", data) });
+  }
+  if (value.kind === "hash") {
+    exactKeys(value, ["kind", "id", "digest"], [], "Checkpoint hash contributor");
+    const id = identifier(value.id, "Checkpoint hash contributor ID");
+    if (!isArtifactHash(value.digest)) throw new Error("Checkpoint hash contributor digest is invalid");
+    return Object.freeze({ kind: "hash", id, digest: value.digest });
+  }
+  throw new Error("Checkpoint contributor kind is unsupported");
+}
+function contributorKey(value: ResolvedCheckpointContributorV1): string {
+  return `${value.kind}\0${value.kind === "file" ? value.path : value.id}`;
+}
+function jsonNodeCount(value: JsonValue): number {
+  const pending: JsonValue[] = [value];
+  let nodes = 0;
+  while (pending.length) {
+    const current = pending.pop()!;
+    nodes++;
+    if (Array.isArray(current)) pending.push(...current);
+    else if (current !== null && typeof current === "object") pending.push(...Object.values(current));
+  }
+  return nodes;
+}
+function validateAggregateRawDataBounds(descriptor: CheckpointDescriptorV1): void {
+  let bytes = 0;
+  let nodes = 0;
+  for (const contributor of descriptor.contributors) {
+    if (!plainRecord(contributor) || contributor.kind !== "data") continue;
+    exactKeys(contributor, ["kind", "id", "value"], [], "Checkpoint data contributor");
+    identifier(contributor.id, "Checkpoint data contributor ID");
+    const data = boundedJson(contributor.value, "Checkpoint data contributor", {
+      bytes: CHECKPOINT_DIGEST_LIMITS.dataBytes,
+      depth: CHECKPOINT_DIGEST_LIMITS.dataDepth,
+      nodes: CHECKPOINT_DIGEST_LIMITS.dataNodes,
+    });
+    bytes += Buffer.byteLength(canonicalJson(data), "utf8");
+    nodes += jsonNodeCount(data);
+    if (bytes > CHECKPOINT_DIGEST_LIMITS.dataBytes || nodes > CHECKPOINT_DIGEST_LIMITS.dataNodes) {
+      throw new Error("Checkpoint aggregate raw data contributors exceed their byte or node limit");
+    }
+  }
+}
+function compareCanonical(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Resolve a deterministic exact digest from only the adapter-declared contributors. */
+export function resolveCheckpointDigest(descriptor: CheckpointDescriptorV1, hashes: ArtifactWorkspaceHashesV1): ResolvedCheckpointDigestV1 {
+  if (hashes.schemaVersion !== 1 || hashes.algorithm !== "sha256" || !isArtifactHash(hashes.workspaceHash) || !Array.isArray(hashes.entries)) {
+    throw new Error("Checkpoint workspace hash snapshot is invalid");
+  }
+  const identity = validateDescriptorIdentity(descriptor);
+  validateAggregateRawDataBounds(descriptor);
+  const contributors = descriptor.contributors.map((entry) => resolveContributor(entry, hashes))
+    .sort((a, b) => compareCanonical(contributorKey(a), contributorKey(b)));
+  for (let index = 1; index < contributors.length; index++) {
+    if (contributorKey(contributors[index - 1]) === contributorKey(contributors[index])) throw new Error("Checkpoint descriptor contains a duplicate contributor");
+  }
+  const digestIdentity = { ...identity, contributors };
+  if (Buffer.byteLength(canonicalJson(digestIdentity), "utf8") > CHECKPOINT_DIGEST_LIMITS.descriptorBytes) throw new Error("Checkpoint descriptor exceeds its byte limit");
+  return deepFreeze({ ...identity, digest: digest("pi-hive-checkpoint-digest-v1", digestIdentity), contributors });
+}
+
+export function validateRunCheckpointSnapshot(value: unknown): RunCheckpointSnapshotV1 {
+  if (!plainRecord(value)) throw new Error("Run checkpoint snapshot is invalid");
+  exactKeys(value, ["formatVersion", "runId", "adapterId", "adapterVersion", "profileId", "profileVersion", "profileSchemaVersion", "defaultsRevision", "checkpoints", "enabledCheckpointIds"], [], "Run checkpoint snapshot");
+  if (value.formatVersion !== 1 || !Number.isSafeInteger(value.defaultsRevision) || (value.defaultsRevision as number) < 0
+    || !Array.isArray(value.checkpoints) || value.checkpoints.length > CHECKPOINT_DIGEST_LIMITS.contributors
+    || !Array.isArray(value.enabledCheckpointIds)) throw new Error("Run checkpoint snapshot format is invalid");
+  const checkpoints = value.checkpoints.map((entry): EffectiveCheckpointV1 => {
+    if (!plainRecord(entry)) throw new Error("Run checkpoint entry is invalid");
+    exactKeys(entry, ["checkpointId", "policy", "enabled"], [], "Run checkpoint entry");
+    const checkpointId = identifier(entry.checkpointId, "Run checkpoint ID");
+    if (entry.policy !== "required" && entry.policy !== "optional" && entry.policy !== "none") throw new Error("Run checkpoint policy is invalid");
+    if (typeof entry.enabled !== "boolean" || (entry.policy === "required" && !entry.enabled) || (entry.policy === "none" && entry.enabled)) throw new Error("Run checkpoint enabled state violates its policy");
+    return Object.freeze({ checkpointId, policy: entry.policy, enabled: entry.enabled });
+  }).sort((a, b) => compareCanonical(a.checkpointId, b.checkpointId));
+  if (new Set(checkpoints.map((entry) => entry.checkpointId)).size !== checkpoints.length) throw new Error("Run checkpoint IDs are duplicated");
+  const enabledCheckpointIds = value.enabledCheckpointIds.map((entry) => identifier(entry, "Enabled checkpoint ID"));
+  const expectedEnabled = checkpoints.filter((entry) => entry.enabled).map((entry) => entry.checkpointId);
+  if (canonicalJson(enabledCheckpointIds) !== canonicalJson(expectedEnabled)) throw new Error("Run enabled checkpoint set does not match its frozen policy");
+  return deepFreeze({
+    formatVersion: 1,
+    runId: identifier(value.runId, "Checkpoint snapshot run ID"),
+    adapterId: identifier(value.adapterId, "Checkpoint snapshot adapter ID"),
+    adapterVersion: identifier(value.adapterVersion, "Checkpoint snapshot adapter version"),
+    profileId: identifier(value.profileId, "Checkpoint snapshot profile ID"),
+    profileVersion: identifier(value.profileVersion, "Checkpoint snapshot profile version"),
+    profileSchemaVersion: identifier(value.profileSchemaVersion, "Checkpoint snapshot profile schema version"),
+    defaultsRevision: value.defaultsRevision as number,
+    checkpoints,
+    enabledCheckpointIds,
+  });
+}

--- a/src/artifacts/leases.ts
+++ b/src/artifacts/leases.ts
@@ -60,6 +60,10 @@ export type WorkspaceLeaseAcquireResult =
 export type WorkspaceLeaseView =
   | Readonly<{ state: "available" }>
   | Readonly<{ state: "owned"; runId: string; heartbeatAt: string; expiresAt: string }>;
+export interface WorkspaceLeaseRunIdentity {
+  readonly sessionId: string;
+  readonly runId: string;
+}
 
 function id(value: string, label: string): string {
   if (!value || Buffer.byteLength(value, "utf8") > 256 || value.includes("/") || value.includes("\\") || value.includes("\0")) throw new Error(`${label} is invalid`);
@@ -157,6 +161,36 @@ export function inspectWorkspaceLease(projectRoot: string, adapterId: string, wo
   if (!owner) return Object.freeze({ state: "available" });
   // Expiry alone does not publish availability: acquisition must also prove death.
   return Object.freeze({ state: "owned", runId: owner.runId, heartbeatAt: owner.heartbeatAt, expiresAt: owner.expiresAt });
+}
+
+function assertRunLeaseOwner(path: string, identity: WorkspaceLeaseRunIdentity, now: number): void {
+  const owner = readLease(path);
+  if (!owner || owner.sessionId !== identity.sessionId || owner.runId !== identity.runId || now >= Date.parse(owner.expiresAt)) {
+    throw new Error("Current run does not own the fresh artifact writer lease");
+  }
+}
+
+/**
+ * Serialize an approval/hash validation with artifact mutations, while proving
+ * that the exact session/run still owns a fresh writer lease. This intentionally
+ * reveals no owner nonce to dashboard/control callers.
+ */
+export async function withWorkspaceLeaseRunValidation<T>(
+  projectRoot: string,
+  adapterId: string,
+  workspaceId: string,
+  identity: WorkspaceLeaseRunIdentity,
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  id(adapterId, "Artifact lease adapter ID"); id(workspaceId, "Artifact lease workspace ID");
+  id(identity.sessionId, "Artifact lease session ID"); id(identity.runId, "Artifact lease run ID");
+  const path = leasePath(projectRoot, adapterId, workspaceId);
+  return withCrossProcessFileLockAsync(`${path}.mutation`, async () => {
+    withLeaseLock(path, () => assertRunLeaseOwner(path, identity, Date.now()));
+    const result = await callback();
+    withLeaseLock(path, () => assertRunLeaseOwner(path, identity, Date.now()));
+    return result;
+  }, { timeoutMs: WORKSPACE_LEASE_TIMING.lockTimeoutMs, staleMs: WORKSPACE_LEASE_TIMING.lockStaleMs });
 }
 
 export class WorkspaceLeaseRuntime {

--- a/src/workflows/runs.ts
+++ b/src/workflows/runs.ts
@@ -9,6 +9,7 @@ import { replayWorkflowJournal } from "./replay";
 import { restoreHandoffState } from "./handoff";
 import { validateArtifactWorkspaceBinding } from "../artifacts/contracts";
 import type { ArtifactWorkspaceBinding } from "../artifacts/types";
+import { validateRunCheckpointSnapshot, type RunCheckpointSnapshotV1 } from "../artifacts/checkpoints";
 
 export const RUN_LIFECYCLE_FORMAT_VERSION = 1 as const;
 export const CANCELLATION_TIMING = Object.freeze({ settleGraceMs: 2_000, killSettleMs: 1_000, coordinatorStepMs: 2_000 });
@@ -99,6 +100,8 @@ export interface WorkflowRunRecord {
   readonly handoffPacketHash?: string;
   /** Trusted adapter workspace selected once and durably bound by run.started. */
   readonly artifactWorkspace?: ArtifactWorkspaceBinding;
+  /** Effective required/optional set frozen atomically into run.started. */
+  readonly checkpointSnapshot?: RunCheckpointSnapshotV1;
   readonly inputs: readonly RunInputRecord[];
   readonly deliveredThrough: number;
   readonly pendingDelivery?: PendingInputDelivery;
@@ -151,6 +154,12 @@ export interface CompletionValidationHooks {
   readonly settleTerminal?: (settlement: TerminalSettlementRequest) => void | Promise<void>;
 }
 
+export interface RunCheckpointSnapshotProvider {
+  create(runId: string, startedAt: string): RunCheckpointSnapshotV1;
+  /** Recheck remembered defaults under the run.started journal append lock. */
+  validate(snapshot: RunCheckpointSnapshotV1, events: readonly WorkflowEventEnvelope[]): void;
+}
+
 export interface WorkflowRunLifecycleOptions {
   readonly projectRoot: string;
   readonly projectId: string;
@@ -166,6 +175,8 @@ export interface WorkflowRunLifecycleOptions {
   readonly onRunStarted?: (runId: string, startedAt: string) => void;
   /** Synchronous, side-effect-free binding factory; W16 uses it for none's logical record. */
   readonly createArtifactWorkspace?: (runId: string, startedAt: string) => ArtifactWorkspaceBinding;
+  /** Generic checkpoint policy snapshot frozen by the same event that creates the run. */
+  readonly checkpointSnapshots?: RunCheckpointSnapshotProvider;
   /** Synchronous projection hook after durable open-state transitions. */
   readonly onRunStatusChanged?: (runId: string, status: OpenRunStatus, timestamp: string) => void;
   /** Fault-injection seam used to verify durable journal publication recovery. */
@@ -314,17 +325,34 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
     const handoffPacketHash = payload.handoffPacketHash;
     if (handoffPacketHash !== undefined && (typeof handoffPacketHash !== "string" || !/^[0-9a-f]{64}$/u.test(handoffPacketHash))) throw new Error("Run handoff packet hash is invalid");
     const artifactWorkspace = payload.artifactWorkspace === undefined ? undefined : validateArtifactWorkspaceBinding(payload.artifactWorkspace);
+    const checkpointSnapshot = payload.checkpointSnapshot === undefined ? undefined : validateRunCheckpointSnapshot(payload.checkpointSnapshot);
+    if (checkpointSnapshot && checkpointSnapshot.runId !== event.runId) throw new Error("Run checkpoint snapshot identity mismatch");
     const run: WorkflowRunRecord = {
       runId: event.runId,
       status: "running",
       startedAt: event.timestamp,
       ...(handoffPacketHash === undefined ? {} : { handoffPacketHash }),
       ...(artifactWorkspace === undefined ? {} : { artifactWorkspace }),
+      ...(checkpointSnapshot === undefined ? {} : { checkpointSnapshot }),
       inputs: [input],
       deliveredThrough: 0,
       cancellationRequested: false,
     };
     return freezeRun(state, run, { inputId: input.inputId, runId: event.runId, input });
+  }
+
+  if (event.type === "approval.recorded" && payload.subsystem === "checkpoint-approval" && (payload.operation === "request" || payload.operation === "decision")) {
+    const run = requireCurrentRun(state, event);
+    if (!isOpenRunStatus(run.status) || run.cancellationRequested || run.pendingTerminal) throw new Error("Checkpoint approval cannot change a terminal, cancelling, or finalizing run");
+    if (payload.operation === "request") {
+      if (event.producer !== "harness" || run.status !== "running") throw new Error("Checkpoint approval request lacks harness authority or a running run");
+      return freezeRun(state, { ...run, status: "waiting_for_human" });
+    }
+    if (payload.operation === "decision") {
+      if ((event.producer !== "dashboard" && event.producer !== "harness") || run.status !== "waiting_for_human") throw new Error("Checkpoint decision lacks human control authority or a waiting run");
+      return freezeRun(state, { ...run, status: "running" });
+    }
+    throw new Error("Checkpoint approval operation is unsupported");
   }
 
   if (event.type === "artifact.recorded" && payload.subsystem === "workspace" && payload.operation === "bind") {
@@ -734,13 +762,15 @@ export class WorkflowRunLifecycle {
       const stagedHandoff = restoreHandoffState(eventsAtInput).staged;
       const artifactWorkspace = this.options.createArtifactWorkspace?.(runId, now);
       if (artifactWorkspace) validateArtifactWorkspaceBinding(artifactWorkspace);
+      const checkpointSnapshot = this.options.checkpointSnapshots?.create(runId, now);
+      if (checkpointSnapshot) validateRunCheckpointSnapshot(checkpointSnapshot);
       try {
         appendWorkflowEventChecked(this.options.projectRoot, createWorkflowEvent({
           projectId: this.options.projectId,
           sessionId: this.options.sessionId,
           runId,
           type: "run.started",
-          payload: asJson({ formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, input: record, ...(stagedHandoff ? { handoffPacketHash: stagedHandoff.packetHash } : {}), ...(artifactWorkspace ? { artifactWorkspace } : {}) }),
+          payload: asJson({ formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, input: record, ...(stagedHandoff ? { handoffPacketHash: stagedHandoff.packetHash } : {}), ...(artifactWorkspace ? { artifactWorkspace } : {}), ...(checkpointSnapshot ? { checkpointSnapshot } : {}) }),
           producer: "runtime",
           timestamp: now,
         }), (existing) => {
@@ -749,6 +779,7 @@ export class WorkflowRunLifecycle {
           if (locked.latestRun && isOpenRunStatus(locked.latestRun.status)) throw new Error("Workflow session already has an open run");
           const lockedHandoff = restoreHandoffState(existing).staged;
           if (lockedHandoff?.packetHash !== stagedHandoff?.packetHash) throw new Error("Staged handoff changed before atomic run creation");
+          if (checkpointSnapshot) this.options.checkpointSnapshots?.validate(checkpointSnapshot, existing);
         });
       } catch (error) {
         const concurrent = this.restore().inputAssignments?.[input.inputId];

--- a/tests/artifacts/artifact-approvals-policy.test.ts
+++ b/tests/artifacts/artifact-approvals-policy.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  CheckpointApprovalService,
+  type CheckpointApprovalServiceOptions,
+} from "../../src/artifacts/approvals.ts";
+import { ARTIFACT_CONTRACT_VERSION, ARTIFACT_PROFILE_VERSION } from "../../src/artifacts/contracts.ts";
+import { hashArtifactWorkspace } from "../../src/artifacts/hashes.ts";
+import { WorkspaceLeaseRuntime } from "../../src/artifacts/leases.ts";
+import type { ArtifactWorkspaceBinding } from "../../src/artifacts/types.ts";
+import { createWorkflowEvent } from "../../src/workflows/events.ts";
+import { appendWorkflowEvent, readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { WorkflowRunLifecycle, type FinishResult } from "../../src/workflows/runs.ts";
+
+const POLICIES = { required: "required", optional: "optional", skipped: "none" } as const;
+const rootBatch = { callerNodeId: "root", toolBatch: ["workflow_finish"] } as const;
+const issues = (result: FinishResult) => result.ok ? "" : result.issues.join("\n");
+
+function fixture(label: string, overrides: Partial<CheckpointApprovalServiceOptions> = {}) {
+  const projectRoot = mkdtempSync(join(tmpdir(), `hive-approvals-${label}-`));
+  const workspacePath = join(projectRoot, "workspace");
+  mkdirSync(workspacePath);
+  writeFileSync(join(workspacePath, "artifact.md"), "# Artifact\n\ninitial\n");
+  const workspaceHash = hashArtifactWorkspace(workspacePath).workspaceHash;
+  const binding: ArtifactWorkspaceBinding = Object.freeze({
+    schemaVersion: 1,
+    contractVersion: ARTIFACT_CONTRACT_VERSION,
+    adapterId: "fixture",
+    adapterVersion: "1",
+    profileId: "author",
+    profileVersion: ARTIFACT_PROFILE_VERSION,
+    binding: "existing",
+    selection: "existing",
+    workspace: Object.freeze({ id: "work", kind: "physical" as const }),
+    path: workspacePath,
+    workspaceHash,
+    writerLease: Object.freeze({ required: true }),
+    checkpointIds: Object.freeze(Object.keys(POLICIES)),
+    actionIds: Object.freeze([]),
+  });
+  let requestNumber = 0;
+  let decisionNumber = 0;
+  let clock = 0;
+  const options: CheckpointApprovalServiceOptions = {
+    projectRoot,
+    projectId: "project-1",
+    sessionId: `session-${label}`,
+    adapterId: "fixture",
+    adapterVersion: "1",
+    profileId: "author",
+    profileVersion: "1",
+    profileSchemaVersion: "1",
+    checkpointPolicies: POLICIES,
+    resolveDescriptor: ({ checkpointId }) => ({
+      formatVersion: 1,
+      adapterId: "fixture",
+      adapterVersion: "1",
+      profileId: "author",
+      profileVersion: "1",
+      profileSchemaVersion: "1",
+      checkpointId,
+      checkpointVersion: "1",
+      contributors: [{ kind: "file", path: "artifact.md" }],
+    }),
+    authenticateControl: ({ credential, channel }) => credential === `${channel}-secret`
+      ? { approverId: "human-1", authenticationId: `auth-${channel}`, mechanism: channel === "dashboard" ? "bearer" : "explicit-tui" }
+      : undefined,
+    createRequestId: () => `request-${++requestNumber}`,
+    createDecisionId: () => `decision-${++decisionNumber}`,
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, clock++)).toISOString(),
+    ...overrides,
+  };
+  const service = new CheckpointApprovalService(options);
+  let runNumber = 0;
+  const lifecycle = new WorkflowRunLifecycle({
+    projectRoot,
+    projectId: "project-1",
+    sessionId: `session-${label}`,
+    snapshotId: "snapshot-1",
+    rootNodeId: "root",
+    createRunId: () => `run-${++runNumber}`,
+    createArtifactWorkspace: () => binding,
+    checkpointSnapshots: service.runSnapshotProvider(),
+    completion: {
+      approvals: () => service.completionGate({ expectedWorkspaceHash: hashArtifactWorkspace(workspacePath).workspaceHash }),
+      evidence: (refs) => ({ state: refs.length ? "satisfied" : "not-present" }),
+      artifacts: () => ({ state: "satisfied" }),
+      projectState: () => ({ state: "satisfied", fileChanges: [], changeCoverage: "recorded" }),
+      settleTerminal: () => {},
+    },
+  });
+  const start = (inputId = `input-${runNumber + 1}`) => lifecycle.recordUserInput({ inputId, text: "work", source: "interactive" });
+  const deliver = (id = `delivery-${runNumber}`) => { lifecycle.prepareInputDelivery(id); lifecycle.confirmInputDelivery(id); };
+  const lease = (runId = lifecycle.restore().latestRun!.runId) => new WorkspaceLeaseRuntime({
+    projectRoot, adapterId: "fixture", workspaceId: "work", sessionId: `session-${label}`, runId,
+  });
+  return { projectRoot, workspacePath, binding, service, lifecycle, start, deliver, lease };
+}
+
+async function approve(f: ReturnType<typeof fixture>, checkpointId: string, operation = checkpointId) {
+  const currentHash = hashArtifactWorkspace(f.workspacePath).workspaceHash;
+  const lease = f.lease();
+  assert.equal(lease.acquire().ok, true);
+  const request = await f.service.requestApproval({ operationId: `request-op-${operation}`, checkpointId, expectedWorkspaceHash: currentHash });
+  const decision = await f.service.decide({
+    operationId: `decision-op-${operation}`,
+    requestId: request.requestId,
+    expectedRequestSequence: request.requestSequence,
+    digest: request.digest,
+    expectedWorkspaceHash: currentHash,
+    decision: "approved",
+  }, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential: "dashboard-secret" });
+  lease.release();
+  return { request, decision };
+}
+
+test("required/optional/none defaults are explicit, idle-only, and frozen independently into each run", async () => {
+  const initial = fixture("policy-initial-on");
+  const initialRun = initial.start();
+  assert.deepEqual(initial.lifecycle.restore().latestRun!.checkpointSnapshot!.enabledCheckpointIds, ["optional", "required"], "optional checkpoints fail safe to on until an idle default event disables them");
+  assert.equal(initial.lifecycle.restore().latestRun!.checkpointSnapshot!.runId, initialRun.runId);
+
+  const f = fixture("policy");
+  assert.deepEqual(f.service.nextRunDefaults().map(({ checkpointId, policy, enabled }) => ({ checkpointId, policy, enabled })), [
+    { checkpointId: "optional", policy: "optional", enabled: true },
+    { checkpointId: "required", policy: "required", enabled: true },
+    { checkpointId: "skipped", policy: "none", enabled: false },
+  ]);
+  assert.throws(() => f.service.setOptionalDefault({ operationId: "default-required", checkpointId: "required", enabled: false, expectedDefaultsRevision: 0 }), /required|optional/i);
+  assert.throws(() => f.service.setOptionalDefault({ operationId: "default-none", checkpointId: "skipped", enabled: true, expectedDefaultsRevision: 0 }), /none|optional/i);
+  const disabled = f.service.setOptionalDefault({ operationId: "default-disable", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  assert.equal(disabled.enabled, false);
+  assert.equal(disabled.defaultsRevision, f.service.restore().defaultsRevision);
+
+  const first = f.start();
+  const firstSnapshot = f.lifecycle.restore().latestRun!.checkpointSnapshot!;
+  assert.deepEqual(firstSnapshot.enabledCheckpointIds, ["required"]);
+  assert.equal(firstSnapshot.runId, first.runId);
+  assert.throws(() => f.service.setOptionalDefault({ operationId: "default-during-run", checkpointId: "optional", enabled: true, expectedDefaultsRevision: disabled.defaultsRevision }), /idle|open run/i);
+  await assert.rejects(() => f.service.requestApproval({ operationId: "none-op", checkpointId: "skipped", expectedWorkspaceHash: hashArtifactWorkspace(f.workspacePath).workspaceHash }), /disabled|no human gate|enabled/i);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-policy").filter((event) => event.type === "approval.recorded" && (event.payload as any).operation === "request").length, 0);
+
+  await approve(f, "required", "first-required");
+  f.deliver();
+  const completed = await f.lifecycle.finish({ status: "completed", summary: "first complete" }, rootBatch);
+  assert.equal(completed.ok, true, issues(completed));
+
+  f.service.setOptionalDefault({ operationId: "default-enable", checkpointId: "optional", enabled: true, expectedDefaultsRevision: f.service.restore().defaultsRevision });
+  const second = f.start("second-input");
+  const secondSnapshot = f.lifecycle.restore().latestRun!.checkpointSnapshot!;
+  assert.deepEqual(secondSnapshot.enabledCheckpointIds, ["optional", "required"]);
+  assert.equal(secondSnapshot.runId, second.runId);
+  assert.deepEqual(firstSnapshot.enabledCheckpointIds, ["required"], "later defaults cannot mutate a prior frozen snapshot");
+});
+
+test("optional-default control uses caller operation CAS and lost-response replay never overwrites a later change", () => {
+  let injected = false;
+  const f = fixture("default-cas", {
+    fault(operation, stage) {
+      if (!injected && operation === "default" && stage === "afterRename") {
+        injected = true;
+        throw new Error("simulated lost default response");
+      }
+    },
+  });
+  const first = f.service.setOptionalDefault({ operationId: "default-first", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  assert.equal(first.enabled, false);
+  assert.ok(first.defaultsRevision > 0);
+  assert.throws(() => f.service.setOptionalDefault({ operationId: "default-stale", checkpointId: "optional", enabled: true, expectedDefaultsRevision: 0 }), /revision|CAS|stale/i);
+
+  const later = f.service.setOptionalDefault({ operationId: "default-later", checkpointId: "optional", enabled: true, expectedDefaultsRevision: first.defaultsRevision });
+  assert.equal(later.enabled, true);
+  const replay = f.service.setOptionalDefault({ operationId: "default-first", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  assert.deepEqual(replay, first, "the original bounded result is replayed instead of reapplying the old value");
+  assert.equal(f.service.nextRunDefaults().find((entry) => entry.checkpointId === "optional")?.enabled, true);
+  assert.throws(() => f.service.setOptionalDefault({ operationId: "default-first", checkpointId: "optional", enabled: true, expectedDefaultsRevision: later.defaultsRevision }), /operation.*reuse|different input/i);
+  const defaults = readWorkflowJournal(f.projectRoot, "session-default-cas")
+    .filter((event) => event.type === "approval.recorded" && (event.payload as any).operation === "default-set");
+  assert.equal(defaults.length, 2);
+});
+
+test("checkpoint replay ignores approval events owned by another subsystem", () => {
+  const f = fixture("unrelated-approval");
+  appendWorkflowEvent(f.projectRoot, createWorkflowEvent({
+    projectId: "project-1",
+    sessionId: "session-unrelated-approval",
+    type: "approval.recorded",
+    producer: "harness",
+    payload: { formatVersion: 99, subsystem: "future-approval", operation: "record" },
+  }));
+  assert.deepEqual(f.service.nextRunDefaults().map(({ checkpointId, enabled }) => ({ checkpointId, enabled })), [
+    { checkpointId: "optional", enabled: true },
+    { checkpointId: "required", enabled: true },
+    { checkpointId: "skipped", enabled: false },
+  ]);
+});
+
+test("a run with no enabled human gates has a neutral completion result without workspace-hash authority", async () => {
+  const f = fixture("no-gates", { checkpointPolicies: { required: "none", optional: "none", skipped: "none" } });
+  f.start();
+  assert.deepEqual(await f.service.completionGate({}), { state: "not-present" });
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-no-gates").some((event) => event.type === "approval.recorded" && (event.payload as any).operation === "request"), false);
+});
+
+test("completion requires every enabled exact-digest decision while blocked/failed persist unsatisfied checkpoint evidence", async () => {
+  const completed = fixture("completion");
+  completed.service.setOptionalDefault({ operationId: "default-completion", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  completed.start();
+  completed.deliver();
+  const missing = await completed.lifecycle.finish({ status: "completed", summary: "not actually complete" }, rootBatch);
+  assert.equal(missing.ok, false);
+  assert.match(issues(missing), /required.*missing|checkpoint|approval/i);
+  await approve(completed, "required", "completion-required");
+  const success = await completed.lifecycle.finish({ status: "completed", summary: "complete now" }, rootBatch);
+  assert.equal(success.ok, true, issues(success));
+
+  for (const status of ["blocked", "failed"] as const) {
+    const f = fixture(`terminal-${status}`);
+    f.service.setOptionalDefault({ operationId: `default-${status}`, checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+    f.start();
+    f.deliver();
+    const result = await f.lifecycle.finish({
+      status,
+      summary: `${status} due to external dependency`,
+      evidenceRefs: [{ kind: "tool-result", claim: "dependency unavailable" }],
+    }, rootBatch);
+    assert.equal(result.ok, true, issues(result));
+    if (!result.ok) continue;
+    assert.ok(result.envelope.unsatisfiedGates.some((gate) => /required|checkpoint|approval/i.test(gate)));
+  }
+});
+
+test("handoff approval references remain evidence only and never satisfy a target run", async () => {
+  const source = fixture("handoff-source");
+  source.service.setOptionalDefault({ operationId: "default-source", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  source.start();
+  const { request } = await approve(source, "required", "source");
+
+  const target = fixture("handoff-target");
+  target.service.setOptionalDefault({ operationId: "default-target", checkpointId: "optional", enabled: false, expectedDefaultsRevision: 0 });
+  target.start();
+  target.deliver();
+  const denied = await target.lifecycle.finish({
+    status: "completed",
+    summary: "forged carryover",
+    artifactRefs: [{ workspaceId: "work", checkpoint: "required", digest: request.digest }],
+  }, rootBatch);
+  assert.equal(denied.ok, false);
+  assert.match(issues(denied), /required|checkpoint|approval/i);
+});

--- a/tests/artifacts/artifact-approvals-security-race-fault.test.ts
+++ b/tests/artifacts/artifact-approvals-security-race-fault.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { CheckpointApprovalService, createCheckpointControlHandlers } from "../../src/artifacts/approvals.ts";
+import { ARTIFACT_CONTRACT_VERSION, ARTIFACT_PROFILE_VERSION } from "../../src/artifacts/contracts.ts";
+import { hashArtifactWorkspace } from "../../src/artifacts/hashes.ts";
+import { WorkspaceLeaseRuntime } from "../../src/artifacts/leases.ts";
+import type { ArtifactWorkspaceBinding } from "../../src/artifacts/types.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+
+function fixture(
+  label: string,
+  fault?: (operation: "default" | "request" | "decision", stage: string) => void,
+  createDecisionId?: () => string,
+  onRunStatusChanged?: (runId: string, status: "running" | "waiting_for_human" | "paused", timestamp: string) => void,
+) {
+  const projectRoot = mkdtempSync(join(tmpdir(), `hive-approval-security-${label}-`));
+  const workspacePath = join(projectRoot, "workspace");
+  mkdirSync(workspacePath);
+  writeFileSync(join(workspacePath, "declared.md"), "declared-v1\n");
+  writeFileSync(join(workspacePath, "unrelated.md"), "unrelated-v1\n");
+  const binding: ArtifactWorkspaceBinding = Object.freeze({
+    schemaVersion: 1, contractVersion: ARTIFACT_CONTRACT_VERSION, adapterId: "fixture", adapterVersion: "1",
+    profileId: "author", profileVersion: ARTIFACT_PROFILE_VERSION, binding: "existing", selection: "existing",
+    workspace: Object.freeze({ id: "workspace", kind: "physical" as const }), path: workspacePath,
+    workspaceHash: hashArtifactWorkspace(workspacePath).workspaceHash, writerLease: Object.freeze({ required: true }),
+    checkpointIds: Object.freeze(["plan"]), actionIds: Object.freeze([]),
+  });
+  let requestId = 0;
+  let decisionId = 0;
+  const service = new CheckpointApprovalService({
+    projectRoot, projectId: "project", sessionId: `session-${label}`,
+    adapterId: "fixture", adapterVersion: "1", profileId: "author", profileVersion: "1", profileSchemaVersion: "1",
+    checkpointPolicies: { plan: "required" },
+    resolveDescriptor: () => ({
+      formatVersion: 1, adapterId: "fixture", adapterVersion: "1", profileId: "author", profileVersion: "1", profileSchemaVersion: "1",
+      checkpointId: "plan", checkpointVersion: "1", contributors: [{ kind: "file", path: "declared.md" }],
+    }),
+    authenticateControl: ({ credential, channel }) => credential === `${channel}:valid`
+      ? { approverId: "human", authenticationId: `${channel}-auth`, mechanism: channel === "dashboard" ? "bearer" : "tui-confirmation" }
+      : undefined,
+    createRequestId: () => `request-${++requestId}`,
+    createDecisionId: createDecisionId ?? (() => `decision-${++decisionId}`),
+    fault: fault as any,
+    onRunStatusChanged,
+  });
+  const lifecycle = new WorkflowRunLifecycle({
+    projectRoot, projectId: "project", sessionId: `session-${label}`, snapshotId: "snapshot", rootNodeId: "root",
+    createRunId: () => "run-1", createArtifactWorkspace: () => binding, checkpointSnapshots: service.runSnapshotProvider(),
+  });
+  lifecycle.recordUserInput({ inputId: "input", text: "prepare checkpoint", source: "interactive" });
+  const lease = new WorkspaceLeaseRuntime({ projectRoot, adapterId: "fixture", workspaceId: "workspace", sessionId: `session-${label}`, runId: "run-1" });
+  const currentHash = () => hashArtifactWorkspace(workspacePath).workspaceHash;
+  const request = async (operationId = "request-op") => {
+    let acquired = false;
+    try { lease.assertOwned(); }
+    catch {
+      if (!lease.acquire().ok) throw new Error("Fixture could not acquire its request lease");
+      acquired = true;
+    }
+    try { return await service.requestApproval({ operationId, checkpointId: "plan", expectedWorkspaceHash: currentHash() }); }
+    finally { if (acquired) lease.release(); }
+  };
+  const decide = (approvalRequest: Awaited<ReturnType<typeof request>>, decision: "approved" | "denied", input: Partial<Parameters<typeof service.decide>[0]> = {}, context: Partial<Parameters<typeof service.decide>[1]> = {}) => service.decide({
+    operationId: `${decision}-op`, requestId: approvalRequest.requestId, expectedRequestSequence: approvalRequest.requestSequence,
+    digest: approvalRequest.digest, expectedWorkspaceHash: currentHash(), decision, ...input,
+  }, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential: "dashboard:valid", ...context });
+  return { projectRoot, workspacePath, service, lifecycle, lease, currentHash, request, decide };
+}
+
+test("only authenticated dashboard or dashboard-unavailable TUI human actions can decide an exact digest", async () => {
+  const f = fixture("channels");
+  const request = await f.request();
+  assert.equal(f.lifecycle.restore().latestRun?.status, "waiting_for_human");
+
+  for (const attempt of [
+    f.decide(request, "approved", {}, { credential: "forged model text" }),
+    f.decide(request, "approved", {}, { channel: "model" as any, credential: "dashboard:valid" }),
+    f.decide(request, "approved", {}, { channel: "tool" as any, credential: "dashboard:valid" }),
+    f.decide(request, "approved", {}, { channel: "tui", mode: "headless", dashboardAvailable: false, credential: "tui:valid" }),
+    f.decide(request, "approved", {}, { channel: "tui", mode: "tui", dashboardAvailable: true, credential: "tui:valid" }),
+    f.decide(request, "approved", {}, { channel: "dashboard", mode: "headless", dashboardAvailable: false, credential: "dashboard:valid" }),
+  ]) await assert.rejects(attempt, /authenticated|channel|dashboard|tui|headless|unavailable/i);
+  assert.equal(f.service.restore().requests[request.requestId].decision, undefined);
+
+  assert.equal(f.lease.acquire().ok, true);
+  const tuiDecision = await f.decide(request, "approved", {}, { channel: "tui", mode: "tui", dashboardAvailable: false, credential: "tui:valid" });
+  assert.equal(tuiDecision.channel, "tui");
+  assert.equal(tuiDecision.approverId, "human");
+  assert.deepEqual(tuiDecision.provenance, { authenticationId: "tui-auth", mechanism: "tui-confirmation" });
+  assert.deepEqual({
+    projectId: tuiDecision.projectId, sessionId: tuiDecision.sessionId, runId: tuiDecision.runId,
+    workspaceId: tuiDecision.workspaceId, adapterId: tuiDecision.adapterId, profileId: tuiDecision.profileId,
+    checkpointId: tuiDecision.checkpointId, checkpointVersion: tuiDecision.checkpointVersion,
+  }, {
+    projectId: "project", sessionId: "session-channels", runId: "run-1", workspaceId: "workspace",
+    adapterId: "fixture", profileId: "author", checkpointId: "plan", checkpointVersion: "1",
+  });
+  assert.equal(JSON.stringify(tuiDecision).includes("tui:valid"), false, "credentials are never returned or persisted");
+  assert.equal(f.lifecycle.restore().latestRun?.status, "running");
+  f.lease.release();
+
+  const dashboard = fixture("dashboard-channel");
+  const dashboardRequest = await dashboard.request();
+  assert.equal(dashboard.lease.acquire().ok, true);
+  const dashboardDecision = await dashboard.decide(dashboardRequest, "approved");
+  assert.equal(dashboardDecision.channel, "dashboard");
+  dashboard.lease.release();
+});
+
+test("request and decision validate current lease; decision also validates workspace hash, exact digest, and declared contributors", async () => {
+  const f = fixture("validation");
+  await assert.rejects(() => f.service.requestApproval({
+    operationId: "request-without-lease",
+    checkpointId: "plan",
+    expectedWorkspaceHash: f.currentHash(),
+  }), /lease|owner/i);
+  const request = await f.request();
+  await assert.rejects(() => f.decide(request, "approved"), /lease|owner/i);
+  assert.equal(f.lease.acquire().ok, true);
+  await assert.rejects(() => f.decide(request, "approved", { expectedWorkspaceHash: `sha256:${"0".repeat(64)}` }), /hash|conflict/i);
+  await assert.rejects(() => f.decide(request, "approved", { digest: `sha256:${"f".repeat(64)}` }), /digest|exact|stale/i);
+
+  writeFileSync(join(f.workspacePath, "unrelated.md"), "unrelated-v2\n");
+  const unrelatedDecision = await f.decide(request, "approved");
+  assert.equal(unrelatedDecision.digest, request.digest);
+  f.lease.release();
+
+  const changed = fixture("declared-change");
+  const stale = await changed.request();
+  assert.equal(changed.lease.acquire().ok, true);
+  writeFileSync(join(changed.workspacePath, "declared.md"), "declared-v2\n");
+  await assert.rejects(() => changed.decide(stale, "approved"), /digest|stale|changed/i);
+  assert.equal(changed.service.restore().requests[stale.requestId].decision, undefined);
+  changed.lease.release();
+});
+
+test("first valid approve/deny wins exact-state CAS; replay is idempotent and conflicting reuse/late decisions fail", async () => {
+  const f = fixture("race");
+  const request = await f.request();
+  assert.equal(f.lease.acquire().ok, true);
+  const settled = await Promise.allSettled([
+    f.decide(request, "approved", { operationId: "race-approve" }),
+    f.decide(request, "denied", { operationId: "race-deny" }),
+  ]);
+  assert.equal(settled.filter((item) => item.status === "fulfilled").length, 1);
+  assert.equal(settled.filter((item) => item.status === "rejected").length, 1);
+  const decision = f.service.restore().requests[request.requestId].decision!;
+  assert.ok(decision.decision === "approved" || decision.decision === "denied");
+  const replayed = await f.decide(request, decision.decision, { operationId: decision.operationId });
+  assert.equal(replayed.decisionId, decision.decisionId);
+  await assert.rejects(() => f.decide(request, decision.decision === "approved" ? "denied" : "approved", { operationId: decision.operationId }), /operation.*reuse|different|conflict/i);
+  await assert.rejects(() => f.decide(request, decision.decision, { operationId: "late-operation" }), /already decided|first.*wins|immutable/i);
+  const decisionEvents = readWorkflowJournal(f.projectRoot, "session-race").filter((event) => event.type === "approval.recorded" && (event.payload as any).operation === "decision");
+  assert.equal(decisionEvents.length, 1);
+  f.lease.release();
+});
+
+test("decision IDs remain globally unique across digest revisions", async () => {
+  const f = fixture("decision-id", undefined, () => "decision-shared");
+  const first = await f.request("first-request");
+  assert.equal(f.lease.acquire().ok, true);
+  await f.decide(first, "denied", { operationId: "first-denial" });
+  writeFileSync(join(f.workspacePath, "declared.md"), "declared-v2\n");
+  const second = await f.request("second-request");
+  await assert.rejects(() => f.decide(second, "approved", { operationId: "second-approval" }), /decision ID.*duplicated|duplicate.*decision ID/i);
+  assert.equal(f.service.restore().requests[second.requestId].decision, undefined);
+  f.lease.release();
+});
+
+test("denial is immutable for one digest, reopens revision, and changed contributors create a fresh request", async () => {
+  const f = fixture("revision");
+  const first = await f.request("request-first");
+  assert.equal(f.lease.acquire().ok, true);
+  const denied = await f.decide(first, "denied", { operationId: "deny-first", feedback: "revise the declared artifact" });
+  assert.equal(denied.decision, "denied");
+  assert.equal(f.lifecycle.restore().latestRun?.status, "running");
+
+  const exactAgain = await f.request("request-exact-again");
+  assert.equal(exactAgain.requestId, first.requestId);
+  assert.equal(exactAgain.decision?.decision, "denied");
+  await assert.rejects(() => f.decide(first, "approved", { operationId: "overwrite-denial" }), /already decided|immutable|first.*wins/i);
+
+  writeFileSync(join(f.workspacePath, "declared.md"), "declared-v2\n");
+  const revised = await f.request("request-revision");
+  assert.notEqual(revised.requestId, first.requestId);
+  assert.notEqual(revised.digest, first.digest);
+  assert.equal(revised.decision, undefined);
+  const approved = await f.decide(revised, "approved", { operationId: "approve-revision" });
+  assert.equal(approved.decision, "approved");
+  f.lease.release();
+});
+
+test("request/decision publication faults recover replay-safely without duplicate authority records", async () => {
+  const thrown = new Set<string>();
+  const statuses: string[] = [];
+  const f = fixture("fault", (operation, stage) => {
+    if ((operation === "request" || operation === "decision") && stage === "afterRename" && !thrown.has(operation)) {
+      thrown.add(operation);
+      throw new Error(`crash after ${operation} rename`);
+    }
+  }, undefined, (_runId, status) => statuses.push(status));
+  const request = await f.request("fault-request");
+  assert.equal(request.requestId, "request-1");
+  assert.equal(f.lease.acquire().ok, true);
+  const decision = await f.decide(request, "approved", { operationId: "fault-decision" });
+  assert.equal(decision.decision, "approved");
+  assert.equal((await f.request("fault-request")).requestId, request.requestId);
+  assert.equal((await f.decide(request, "approved", { operationId: "fault-decision" })).decisionId, decision.decisionId);
+  assert.deepEqual(statuses, ["waiting_for_human", "running"], "durable status projection callbacks run exactly once, including after-rename recovery");
+  const events = readWorkflowJournal(f.projectRoot, "session-fault").filter((event) => event.type === "approval.recorded");
+  assert.equal(events.filter((event) => (event.payload as any).operation === "request").length, 1);
+  assert.equal(events.filter((event) => (event.payload as any).operation === "decision").length, 1);
+  f.lease.release();
+});
+
+test("an exact-existing request durably binds every caller operation and rejects differing reuse", async () => {
+  const f = fixture("exact-binding");
+  const first = await f.request("exact-first");
+  assert.equal(f.lease.acquire().ok, true);
+  const exact = await f.service.requestApproval({ operationId: "exact-second", checkpointId: "plan", expectedWorkspaceHash: f.currentHash() });
+  assert.equal(exact.requestId, first.requestId);
+  const operation = f.service.restore().operations["exact-second"];
+  assert.equal(operation?.kind, "request");
+  assert.equal(operation?.requestId, first.requestId);
+  await assert.rejects(() => f.service.requestApproval({
+    operationId: "exact-second", checkpointId: "plan", expectedWorkspaceHash: `sha256:${"0".repeat(64)}`,
+  }), /operation.*reuse|different input/i);
+  const bindings = readWorkflowJournal(f.projectRoot, "session-exact-binding")
+    .filter((event) => event.type === "approval.recorded" && (event.payload as any).operation === "request-bind");
+  assert.equal(bindings.length, 1);
+  f.lease.release();
+});
+
+test("bounded control service handlers expose decisions/defaults without routes or credentials", async () => {
+  const f = fixture("handlers");
+  const handlers = createCheckpointControlHandlers(f.service);
+  assert.deepEqual(handlers.listDefaults(), [{ checkpointId: "plan", policy: "required", enabled: true, defaultsRevision: 0 }]);
+  const request = await f.request();
+  assert.equal(f.lease.acquire().ok, true);
+  const decision = await handlers.decide({
+    operationId: "handler-decision", requestId: request.requestId, expectedRequestSequence: request.requestSequence,
+    digest: request.digest, expectedWorkspaceHash: f.currentHash(), decision: "approved",
+  }, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential: "dashboard:valid" });
+  assert.equal(decision.decision, "approved");
+  assert.ok(Buffer.byteLength(JSON.stringify(decision), "utf8") <= 65_536);
+  assert.equal(JSON.stringify(decision).includes("dashboard:valid"), false);
+  f.lease.release();
+});
+
+test("control request fields and feedback are strict and bounded", async () => {
+  const f = fixture("bounds");
+  const request = await f.request();
+  assert.equal(f.lease.acquire().ok, true);
+  await assert.rejects(() => f.service.decide({
+    operationId: "oversized", requestId: request.requestId, expectedRequestSequence: request.requestSequence,
+    digest: request.digest, expectedWorkspaceHash: f.currentHash(), decision: "denied", feedback: "x".repeat(9_000), extra: "forged",
+  } as any, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential: "dashboard:valid" }), /field|feedback|limit|unsupported/i);
+  assert.equal(f.service.restore().requests[request.requestId].decision, undefined);
+  f.lease.release();
+});

--- a/tests/artifacts/artifact-checkpoint-digests.test.ts
+++ b/tests/artifacts/artifact-checkpoint-digests.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { hashArtifactWorkspace } from "../../src/artifacts/hashes.ts";
+import {
+  resolveCheckpointDigest,
+  validateRunCheckpointSnapshot,
+  type CheckpointDescriptorV1,
+} from "../../src/artifacts/checkpoints.ts";
+
+function fixture() {
+  const workspace = mkdtempSync(join(tmpdir(), "hive-checkpoint-digest-"));
+  mkdirSync(join(workspace, "nested"));
+  writeFileSync(join(workspace, "plan.md"), "# Plan\n\nVersion one.\n");
+  writeFileSync(join(workspace, "nested", "evidence.json"), "{\"passed\":true}\n");
+  writeFileSync(join(workspace, "unrelated.txt"), "unrelated one\n");
+  const descriptor = (overrides: Partial<CheckpointDescriptorV1> = {}): CheckpointDescriptorV1 => ({
+    formatVersion: 1,
+    adapterId: "fixture",
+    adapterVersion: "1",
+    profileId: "author",
+    profileVersion: "1",
+    profileSchemaVersion: "1",
+    checkpointId: "plan",
+    checkpointVersion: "1",
+    contributors: [
+      { kind: "file", path: "plan.md" },
+      { kind: "data", id: "validation", value: { passed: true, count: 2 } },
+      { kind: "hash", id: "external", digest: `sha256:${"a".repeat(64)}` },
+    ],
+    ...overrides,
+  });
+  return { workspace, descriptor };
+}
+
+test("checkpoint digests bind every declared contributor and profile/schema version but ignore unrelated content", () => {
+  const f = fixture();
+  const initialHashes = hashArtifactWorkspace(f.workspace);
+  const initial = resolveCheckpointDigest(f.descriptor(), initialHashes);
+  assert.match(initial.digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(initial.contributors.length, 3);
+  assert.ok(Object.isFrozen(initial));
+  assert.ok(Object.isFrozen(initial.contributors));
+
+  writeFileSync(join(f.workspace, "unrelated.txt"), "unrelated changed\n");
+  const unrelated = resolveCheckpointDigest(f.descriptor(), hashArtifactWorkspace(f.workspace));
+  assert.equal(unrelated.digest, initial.digest, "whole-workspace changes do not contribute implicitly");
+
+  writeFileSync(join(f.workspace, "plan.md"), "# Plan\n\nVersion two.\n");
+  const fileChanged = resolveCheckpointDigest(f.descriptor(), hashArtifactWorkspace(f.workspace));
+  assert.notEqual(fileChanged.digest, initial.digest);
+
+  const dataChanged = resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "file", path: "plan.md" },
+    { kind: "data", id: "validation", value: { passed: false, count: 2 } },
+    { kind: "hash", id: "external", digest: `sha256:${"a".repeat(64)}` },
+  ] }), hashArtifactWorkspace(f.workspace));
+  assert.notEqual(dataChanged.digest, fileChanged.digest);
+
+  const hashChanged = resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "file", path: "plan.md" },
+    { kind: "data", id: "validation", value: { passed: true, count: 2 } },
+    { kind: "hash", id: "external", digest: `sha256:${"b".repeat(64)}` },
+  ] }), hashArtifactWorkspace(f.workspace));
+  assert.notEqual(hashChanged.digest, fileChanged.digest);
+
+  for (const overrides of [
+    { adapterVersion: "2" },
+    { profileVersion: "2" },
+    { profileSchemaVersion: "2" },
+    { checkpointVersion: "2" },
+  ] satisfies Array<Partial<CheckpointDescriptorV1>>) {
+    assert.notEqual(resolveCheckpointDigest(f.descriptor(overrides), hashArtifactWorkspace(f.workspace)).digest, fileChanged.digest);
+  }
+});
+
+test("checkpoint contributor ordering is canonical while duplicate, missing, escaping, and oversized declarations fail closed", () => {
+  const f = fixture();
+  const hashes = hashArtifactWorkspace(f.workspace);
+  const descriptor = f.descriptor();
+  const reversed = { ...descriptor, contributors: [...descriptor.contributors].reverse() };
+  assert.equal(resolveCheckpointDigest(descriptor, hashes).digest, resolveCheckpointDigest(reversed, hashes).digest);
+
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "file", path: "plan.md" },
+    { kind: "file", path: "plan.md" },
+  ] }), hashes), /duplicate/i);
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [{ kind: "file", path: "missing.md" }] }), hashes), /missing|contributor/i);
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [{ kind: "file", path: "../escape" }] }), hashes), /path|normalized|escape/i);
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [{ kind: "hash", id: "external", digest: "forged" }] }), hashes), /digest|hash/i);
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [{ kind: "data", id: "huge", value: "x".repeat(70_000) }] }), hashes), /limit|large|bytes/i);
+});
+
+test("aggregate raw data contributor budgets reject N+1 bytes and nodes before digest resolution", () => {
+  const f = fixture();
+  const hashes = hashArtifactWorkspace(f.workspace);
+  const atNodeLimit = Array.from({ length: 4_095 }, () => null);
+  assert.doesNotThrow(() => resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "data", id: "nodes-at-limit", value: atNodeLimit },
+  ] }), hashes));
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "data", id: "nodes-at-limit", value: atNodeLimit },
+    { kind: "data", id: "nodes-n-plus-one", value: null },
+  ] }), hashes), /aggregate|structural|nodes|limit/i);
+
+  const atByteLimit = "x".repeat(65_534);
+  assert.doesNotThrow(() => resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "data", id: "bytes-at-limit", value: atByteLimit },
+  ] }), hashes));
+  assert.throws(() => resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "data", id: "bytes-at-limit", value: atByteLimit },
+    { kind: "data", id: "bytes-n-plus-one", value: null },
+  ] }), hashes), /aggregate|bytes|limit|large/i);
+});
+
+test("checkpoint canonical ordering uses stable code-unit order for legal mixed-case IDs", () => {
+  const f = fixture();
+  const resolved = resolveCheckpointDigest(f.descriptor({ contributors: [
+    { kind: "hash", id: "a", digest: `sha256:${"a".repeat(64)}` },
+    { kind: "hash", id: "B", digest: `sha256:${"b".repeat(64)}` },
+  ] }), hashArtifactWorkspace(f.workspace));
+  assert.deepEqual(resolved.contributors.map((entry) => entry.kind === "file" ? entry.path : entry.id), ["B", "a"]);
+
+  const snapshot = validateRunCheckpointSnapshot({
+    formatVersion: 1,
+    runId: "run-1",
+    adapterId: "fixture",
+    adapterVersion: "1",
+    profileId: "author",
+    profileVersion: "1",
+    profileSchemaVersion: "1",
+    defaultsRevision: 0,
+    checkpoints: [
+      { checkpointId: "B", policy: "required", enabled: true },
+      { checkpointId: "a", policy: "optional", enabled: true },
+    ],
+    enabledCheckpointIds: ["B", "a"],
+  });
+  assert.deepEqual(snapshot.enabledCheckpointIds, ["B", "a"]);
+});


### PR DESCRIPTION
## Summary
- add generic exact-digest checkpoint descriptors and approval policies
- persist authenticated human request/decision CAS with replay-safe controls
- integrate approval waits, revisions, and completion gates with run lifecycle

## Validation
- checkpoint digest, policy, security, race, and fault tests
- `just coverage-core`
- `just verify`