### PR TITLE
feat(artifacts): add Markdown plan adapter

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -311,6 +311,8 @@ test-node-compat:
     tests/artifacts/artifact-facade.test.ts \
     tests/artifacts/artifact-leases-cross-process.test.ts \
     tests/artifacts/artifact-lifecycle-integration.test.ts \
+    tests/artifacts/artifact-markdown-plan.test.ts \
+    tests/artifacts/artifact-markdown-plan-e2e.test.ts \
     tests/artifacts/artifact-none-run.test.ts \
     tests/artifacts/artifact-operations-fault.test.ts \
     tests/artifacts/artifact-registry-none.test.ts \

--- a/src/artifacts/adapters/markdown-plan.ts
+++ b/src/artifacts/adapters/markdown-plan.ts
@@ -1,0 +1,607 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { Type } from "typebox";
+import { Value } from "typebox/value";
+import type { ProtectedPathRoot } from "../../capabilities/reserved-paths";
+import { canonicalJson } from "../../config/snapshot-canonical";
+import type { JsonValue } from "../../config/types";
+import { resolveCanonicalPath, resolveContainedPath } from "../../core/safe-path";
+import { boundedJson, boundedText, plainRecord, utf8Prefix } from "../../workflows/values";
+import {
+  ARTIFACT_ACTION_VERSION,
+  ARTIFACT_CONTRACT_LIMITS,
+  ARTIFACT_CONTRACT_VERSION,
+  ARTIFACT_PROFILE_VERSION,
+  ARTIFACT_VIEW_VERSION,
+} from "../contracts";
+import { resolveCheckpointDigest, type CheckpointContributorV1, type CheckpointDescriptorV1 } from "../checkpoints";
+import { hashArtifactWorkspace, type ArtifactWorkspaceHashesV1 } from "../hashes";
+import type {
+  ArtifactActionContext,
+  ArtifactActionContract,
+  ArtifactActionResultV1,
+  ArtifactAdapter,
+  ArtifactCheckpointDescriptorInput,
+  ArtifactCompletionResult,
+  ArtifactEvidenceReferenceV1,
+  ArtifactRuntimeProfile,
+  ArtifactStatusContext,
+  ArtifactStatusPageRequest,
+  ArtifactStatusViewV1,
+  ArtifactWorkspaceBinding,
+  VerifiedArtifactEvidenceV1,
+} from "../types";
+
+export const MARKDOWN_PLAN_ADAPTER_VERSION = "1" as const;
+export const MARKDOWN_PLAN_PROFILE_SCHEMA_VERSION = "1" as const;
+export const MARKDOWN_PLAN_DEFAULT_ROOT = "plans" as const;
+export const MARKDOWN_PLAN_CHECKPOINT_IDS = Object.freeze(["plan", "execution", "review"] as const);
+export const MARKDOWN_PLAN_ACTION_IDS = Object.freeze([
+  "markdown-plan.plan.read",
+  "markdown-plan.plan.author",
+  "markdown-plan.plan.update",
+  "markdown-plan.validate",
+  "markdown-plan.tasks.list",
+  "markdown-plan.tasks.complete",
+  "markdown-plan.review.inspect",
+] as const);
+export const MARKDOWN_PLAN_LIMITS = Object.freeze({
+  planBytes: 48_000,
+  titleBytes: 512,
+  summaryBytes: 24_000,
+  taskTextBytes: 2_048,
+  tasks: 256,
+  evidenceRefsPerTask: 32,
+  evidencePathBytes: 1_024,
+  // Compact JSON at this bound accommodates 256 tasks with 32 worst-case
+  // adapter-bounded verified references each, including JSON escaping.
+  sidecarBytes: 67_108_864,
+  sidecarNodes: 65_536,
+  readPageJsonBytes: 48_000,
+  rootBytes: 512,
+  rootSegments: 16,
+  validationIssues: 32,
+});
+
+export type MarkdownPlanAdapterErrorCode = "invalid-options" | "invalid-workspace" | "invalid-plan" | "output-limit";
+export class MarkdownPlanAdapterError extends Error {
+  readonly code: MarkdownPlanAdapterErrorCode;
+  constructor(code: MarkdownPlanAdapterErrorCode, message: string) {
+    super(message.slice(0, 2_048));
+    this.name = "MarkdownPlanAdapterError";
+    this.code = code;
+  }
+}
+
+const strict = { additionalProperties: false } as const;
+const ROOT_PATTERN = "^[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*){0,15}$";
+const ID_PATTERN = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const CONTRACT_ID_PATTERN = "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$";
+const DIGEST_PATTERN = "^sha256:[0-9a-f]{64}$";
+const OPTIONS_SCHEMA = Type.Object({ root: Type.Optional(Type.String({ pattern: ROOT_PATTERN, maxLength: MARKDOWN_PLAN_LIMITS.rootBytes })) }, strict);
+const TaskInput = Type.Object({
+  id: Type.String({ pattern: ID_PATTERN, maxLength: 64 }),
+  text: Type.String({ minLength: 1, maxLength: MARKDOWN_PLAN_LIMITS.taskTextBytes }),
+}, strict);
+const PlanInput = Type.Object({
+  title: Type.String({ minLength: 1, maxLength: MARKDOWN_PLAN_LIMITS.titleBytes }),
+  summary: Type.String({ minLength: 1, maxLength: MARKDOWN_PLAN_LIMITS.summaryBytes }),
+  tasks: Type.Array(TaskInput, { minItems: 1, maxItems: MARKDOWN_PLAN_LIMITS.tasks }),
+}, strict);
+const EvidenceReference = Type.Union([
+  Type.Object({ kind: Type.Literal("tool"), attemptId: Type.String({ pattern: CONTRACT_ID_PATTERN, maxLength: 256 }) }, strict),
+  Type.Object({ kind: Type.Literal("command"), attemptId: Type.String({ pattern: CONTRACT_ID_PATTERN, maxLength: 256 }) }, strict),
+  Type.Object({ kind: Type.Literal("repository"), path: Type.String({ minLength: 1, maxLength: MARKDOWN_PLAN_LIMITS.evidencePathBytes }), digest: Type.String({ pattern: DIGEST_PATTERN, maxLength: 71 }) }, strict),
+]);
+const VERIFIED_EVIDENCE_SCHEMA = Type.Union([
+  Type.Object({ kind: Type.Literal("tool"), attemptId: Type.String({ minLength: 1, maxLength: 256 }), operation: Type.String({ minLength: 1, maxLength: 1_024 }), inputHash: Type.String({ pattern: "^[0-9a-f]{64}$" }), resultHash: Type.String({ pattern: "^[0-9a-f]{64}$" }) }, strict),
+  Type.Object({ kind: Type.Literal("command"), attemptId: Type.String({ minLength: 1, maxLength: 256 }), effect: Type.Union([Type.Literal("shell"), Type.Literal("git")]), operation: Type.String({ minLength: 1, maxLength: 1_024 }), inputHash: Type.String({ pattern: "^[0-9a-f]{64}$" }), resultHash: Type.String({ pattern: "^[0-9a-f]{64}$" }) }, strict),
+  Type.Object({ kind: Type.Literal("repository"), path: Type.String({ minLength: 1, maxLength: MARKDOWN_PLAN_LIMITS.evidencePathBytes }), digest: Type.String({ pattern: DIGEST_PATTERN }), bytes: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }) }, strict),
+]);
+
+function action(input: Omit<ArtifactActionContract, "version" | "argumentsSchemaVersion">): ArtifactActionContract {
+  return Object.freeze({ version: ARTIFACT_ACTION_VERSION, argumentsSchemaVersion: "1", ...input });
+}
+const READ_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[0], label: "Read Markdown plan", argumentsSchema: Type.Object({ cursor: Type.Optional(Type.String({ pattern: "^markdown-plan-read-v1:(0|[1-9][0-9]{0,8})$", maxLength: 40 })) }, strict), requiredCapabilities: Object.freeze(["read"] as const), completion: "optional", mutability: "read-only", idempotency: "idempotent" });
+const AUTHOR_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[1], label: "Author Markdown plan", argumentsSchema: PlanInput, requiredCapabilities: Object.freeze(["write"] as const), completion: "mandatory", mutability: "mutating", idempotency: "operation-bound" });
+const UPDATE_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[2], label: "Revise Markdown plan", argumentsSchema: PlanInput, requiredCapabilities: Object.freeze(["write"] as const), completion: "mandatory", mutability: "mutating", idempotency: "operation-bound" });
+const VALIDATE_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[3], label: "Validate Markdown plan", argumentsSchema: Type.Object({}, strict), requiredCapabilities: Object.freeze(["read"] as const), completion: "optional", mutability: "read-only", idempotency: "idempotent" });
+const TASK_LIST_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[4], label: "List Markdown plan tasks", argumentsSchema: Type.Object({ limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })), cursor: Type.Optional(Type.String({ pattern: "^markdown-plan-tasks-v1:(0|[1-9][0-9]{0,8})$", maxLength: 40 })) }, strict), requiredCapabilities: Object.freeze(["read"] as const), completion: "optional", mutability: "read-only", idempotency: "idempotent" });
+const TASK_COMPLETE_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[5], label: "Record Markdown plan task evidence", argumentsSchema: Type.Object({ taskId: Type.String({ pattern: ID_PATTERN, maxLength: 64 }), evidenceRefs: Type.Array(EvidenceReference, { minItems: 1, maxItems: MARKDOWN_PLAN_LIMITS.evidenceRefsPerTask }) }, strict), requiredCapabilities: Object.freeze(["write"] as const), completion: "mandatory", mutability: "mutating", idempotency: "operation-bound" });
+const REVIEW_ACTION = action({ id: MARKDOWN_PLAN_ACTION_IDS[6], label: "Inspect Markdown plan review evidence", argumentsSchema: Type.Object({}, strict), requiredCapabilities: Object.freeze(["review"] as const), completion: "optional", mutability: "read-only", idempotency: "idempotent" });
+const AUTHOR_ACTIONS = Object.freeze([READ_ACTION, AUTHOR_ACTION, UPDATE_ACTION, VALIDATE_ACTION]);
+const EXECUTE_ACTIONS = Object.freeze([READ_ACTION, VALIDATE_ACTION, TASK_LIST_ACTION, TASK_COMPLETE_ACTION]);
+const REVIEW_ACTIONS = Object.freeze([READ_ACTION, VALIDATE_ACTION, TASK_LIST_ACTION, REVIEW_ACTION]);
+const LIFECYCLE_ACTIONS = Object.freeze([READ_ACTION, AUTHOR_ACTION, UPDATE_ACTION, VALIDATE_ACTION, TASK_LIST_ACTION, TASK_COMPLETE_ACTION, REVIEW_ACTION]);
+function runtimeProfile(id: "author" | "execute" | "review" | "lifecycle", bindings: readonly ("new" | "existing" | "either")[], checkpoints: readonly string[], actions: readonly ArtifactActionContract[]): ArtifactRuntimeProfile {
+  return Object.freeze({
+    contractVersion: ARTIFACT_CONTRACT_VERSION, version: ARTIFACT_PROFILE_VERSION, adapterId: "markdown-plan", adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION,
+    id, optionsSchemaVersion: MARKDOWN_PLAN_PROFILE_SCHEMA_VERSION, optionsSchema: OPTIONS_SCHEMA, bindings: Object.freeze([...bindings]),
+    checkpointIds: Object.freeze([...checkpoints]), actions, viewVersion: ARTIFACT_VIEW_VERSION,
+  });
+}
+export const MARKDOWN_PLAN_PROFILES = Object.freeze({
+  author: runtimeProfile("author", ["new", "existing", "either"], ["plan"], AUTHOR_ACTIONS),
+  execute: runtimeProfile("execute", ["existing"], ["plan", "execution"], EXECUTE_ACTIONS),
+  review: runtimeProfile("review", ["existing"], ["execution", "review"], REVIEW_ACTIONS),
+  lifecycle: runtimeProfile("lifecycle", ["new", "existing", "either"], MARKDOWN_PLAN_CHECKPOINT_IDS, LIFECYCLE_ACTIONS),
+});
+const PROFILE_LIST = Object.freeze([MARKDOWN_PLAN_PROFILES.author, MARKDOWN_PLAN_PROFILES.execute, MARKDOWN_PLAN_PROFILES.review, MARKDOWN_PLAN_PROFILES.lifecycle]);
+
+const WORKSPACE_METADATA_PATH = ".pi-hive/workspace-v1.json";
+const EVIDENCE_PATH = ".pi-hive/evidence-v1.json";
+const PLAN_PATH = "plan.md";
+const PLAN_ID_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
+const ROOT_RE = /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*){0,15}$/u;
+const TASK_ID_RE = PLAN_ID_RE;
+
+function planRootOptions(options: Readonly<Record<string, JsonValue>>): string {
+  if (!Value.Check(OPTIONS_SCHEMA, options)) throw new MarkdownPlanAdapterError("invalid-options", "Markdown plan options contain unknown or invalid fields");
+  const value = options.root === undefined ? MARKDOWN_PLAN_DEFAULT_ROOT : String(options.root);
+  if (!ROOT_RE.test(value) || value.split("/").length > MARKDOWN_PLAN_LIMITS.rootSegments || Buffer.byteLength(value, "utf8") > MARKDOWN_PLAN_LIMITS.rootBytes
+    || value.split("/").some((part) => part === ".git" || part === ".pi" || part === "openspec")) {
+    throw new MarkdownPlanAdapterError("invalid-options", "Markdown plan root must be a bounded project-relative POSIX path outside protected subsystem roots");
+  }
+  return value;
+}
+export function markdownPlanProtectedRoots(options: Readonly<Record<string, JsonValue>>): readonly ProtectedPathRoot[] {
+  return Object.freeze([Object.freeze({ path: planRootOptions(options), kind: "artifact" as const })]);
+}
+function planId(value: unknown): string {
+  if (typeof value !== "string" || !PLAN_ID_RE.test(value) || value.length > 128 || Buffer.byteLength(value, "utf8") > 128) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace ID is invalid");
+  return value;
+}
+function canonicalProjectRoot(value: string): string {
+  const root = resolveCanonicalPath(value);
+  if (!root?.exists || !lstatSync(root.canonicalPath).isDirectory() || lstatSync(root.canonicalPath).isSymbolicLink()) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan project root is unavailable");
+  return root.canonicalPath;
+}
+function candidateRoot(projectRoot: string, options: Readonly<Record<string, JsonValue>>, allowMissing: boolean): Readonly<{ root: string; planRoot: string }> {
+  const root = canonicalProjectRoot(projectRoot);
+  const planRoot = planRootOptions(options);
+  const candidate = resolveContainedPath(root, join(root, ...planRoot.split("/")), { allowMissing });
+  if (!candidate) throw new MarkdownPlanAdapterError("invalid-options", "Markdown plan root escapes project containment");
+  if (candidate.exists && (!lstatSync(candidate.canonicalPath).isDirectory() || lstatSync(candidate.canonicalPath).isSymbolicLink())) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan root must be a physical directory");
+  return Object.freeze({ root: candidate.canonicalPath, planRoot });
+}
+function safeRead(path: string, maxBytes: number): string | undefined {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > maxBytes) return undefined;
+    const value = readFileSync(path, "utf8");
+    return Buffer.byteLength(value, "utf8") <= maxBytes ? value : undefined;
+  } catch { return undefined; }
+}
+function atomicWrite(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    renameSync(temporary, path); chmodSync(path, 0o600);
+  } catch (error) {
+    try { unlinkSync(temporary); } catch { /* best effort */ }
+    throw error;
+  }
+}
+interface WorkspaceMetadata { readonly schemaVersion: 1; readonly adapterVersion: "1"; readonly planId: string; readonly planRoot: string }
+function metadata(id: string, root: string): WorkspaceMetadata { return Object.freeze({ schemaVersion: 1, adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION, planId: id, planRoot: root }); }
+function readMetadata(path: string, expectedId: string): WorkspaceMetadata | undefined {
+  const source = safeRead(join(path, WORKSPACE_METADATA_PATH), 4_096);
+  if (!source) return undefined;
+  try {
+    const raw: unknown = JSON.parse(source);
+    if (!plainRecord(raw) || Object.keys(raw).sort().join(",") !== "adapterVersion,planId,planRoot,schemaVersion" || raw.schemaVersion !== 1
+      || raw.adapterVersion !== MARKDOWN_PLAN_ADAPTER_VERSION || raw.planId !== expectedId || !PLAN_ID_RE.test(String(raw.planId)) || !ROOT_RE.test(String(raw.planRoot))) return undefined;
+    return metadata(String(raw.planId), String(raw.planRoot));
+  } catch { return undefined; }
+}
+function candidateWorkspace(projectRoot: string, options: Readonly<Record<string, JsonValue>>, idValue: string): string | undefined {
+  const id = planId(idValue);
+  const resolvedRoot = candidateRoot(projectRoot, options, true);
+  const candidate = resolveContainedPath(resolvedRoot.root, join(resolvedRoot.root, id), { allowMissing: true });
+  if (!candidate || relative(resolvedRoot.root, candidate.canonicalPath).split("/").length !== 1 || !candidate.exists) return undefined;
+  const stat = lstatSync(candidate.canonicalPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return undefined;
+  const meta = readMetadata(candidate.canonicalPath, id);
+  return meta?.planRoot === resolvedRoot.planRoot ? candidate.canonicalPath : undefined;
+}
+interface Workspace { readonly projectRoot: string; readonly path: string; readonly planId: string; readonly planRoot: string }
+function workspaceRoot(binding: ArtifactWorkspaceBinding): Workspace {
+  if (binding.adapterId !== "markdown-plan" || binding.adapterVersion !== MARKDOWN_PLAN_ADAPTER_VERSION || binding.workspace.kind !== "physical" || !binding.path) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace binding is incompatible");
+  const path = resolveCanonicalPath(binding.path);
+  if (!path?.exists || !lstatSync(path.canonicalPath).isDirectory() || lstatSync(path.canonicalPath).isSymbolicLink() || basename(path.canonicalPath) !== binding.workspace.id) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace is unavailable or mismatched");
+  const id = planId(binding.workspace.id);
+  const meta = readMetadata(path.canonicalPath, id);
+  if (!meta) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace metadata is invalid");
+  let projectRoot = dirname(path.canonicalPath);
+  for (const _segment of meta.planRoot.split("/")) projectRoot = dirname(projectRoot);
+  const canonicalProject = canonicalProjectRoot(projectRoot);
+  const expected = resolveContainedPath(canonicalProject, join(canonicalProject, ...meta.planRoot.split("/"), id));
+  if (!expected || expected.canonicalPath !== path.canonicalPath) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace path does not match its metadata mapping");
+  return Object.freeze({ projectRoot: canonicalProject, path: path.canonicalPath, planId: id, planRoot: meta.planRoot });
+}
+function decodeListCursor(value: string | undefined): number {
+  if (value === undefined) return 0;
+  const match = /^markdown-plan-v1:(0|[1-9][0-9]{0,8})$/u.exec(value);
+  if (!match) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace cursor is invalid");
+  return Number(match[1]);
+}
+
+interface PlanTask { readonly id: string; readonly text: string }
+interface ParsedPlan { readonly id: string; readonly title: string; readonly summary: string; readonly revision: number; readonly lastOperationId: string; readonly tasks: readonly PlanTask[]; readonly source: string }
+interface PlanValidation { readonly valid: boolean; readonly issues: readonly string[]; readonly plan?: ParsedPlan }
+function normalizedBlock(value: unknown, label: string, bytes: number): string {
+  const text = boundedText(value, label, bytes).replace(/\r\n?|\r/gu, "\n").trim();
+  if (!text || text.includes("\0")) throw new MarkdownPlanAdapterError("invalid-plan", `${label} is empty or invalid`);
+  return text;
+}
+function planInput(value: Readonly<Record<string, JsonValue>>): Readonly<{ title: string; summary: string; tasks: readonly PlanTask[] }> {
+  if (!Value.Check(PlanInput, value)) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan author/update input is invalid");
+  const title = normalizedBlock(value.title, "Markdown plan title", MARKDOWN_PLAN_LIMITS.titleBytes);
+  const summary = normalizedBlock(value.summary, "Markdown plan summary", MARKDOWN_PLAN_LIMITS.summaryBytes);
+  if (title.includes("\n") || summary.split("\n").some((line) => line === "---" || line === "# Tasks")) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan title/summary would make the canonical structure ambiguous");
+  const rawTasks = value.tasks as unknown as readonly { id: string; text: string }[];
+  const tasks = rawTasks.map((entry): PlanTask => {
+    const id = String(entry.id); const text = normalizedBlock(entry.text, `Markdown plan task ${id}`, MARKDOWN_PLAN_LIMITS.taskTextBytes);
+    if (!TASK_ID_RE.test(id) || id.length > 64 || text.includes("\n")) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan tasks require stable lowercase IDs and single-line text");
+    return Object.freeze({ id, text });
+  });
+  if (new Set(tasks.map((entry) => entry.id)).size !== tasks.length) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan task IDs must be unique and stable");
+  return Object.freeze({ title, summary, tasks: Object.freeze(tasks) });
+}
+function renderPlan(id: string, input: Readonly<{ title: string; summary: string; tasks: readonly PlanTask[] }>, revision: number, operationId: string): string {
+  const value = `---\nschema-version: 1\nplan-id: ${id}\ntitle: ${JSON.stringify(input.title)}\nrevision: ${revision}\nlast-operation-id: ${operationId}\n---\n\n# Summary\n\n${input.summary}\n\n# Tasks\n\n${input.tasks.map((entry) => `- [ ] ${entry.id}: ${entry.text}`).join("\n")}\n`;
+  if (Buffer.byteLength(value, "utf8") > MARKDOWN_PLAN_LIMITS.planBytes) throw new MarkdownPlanAdapterError("output-limit", "Canonical Markdown plan exceeds its byte limit");
+  return value;
+}
+function validatePlan(path: string, expectedId: string): PlanValidation {
+  const source = safeRead(join(path, PLAN_PATH), MARKDOWN_PLAN_LIMITS.planBytes);
+  if (!source) return Object.freeze({ valid: false, issues: Object.freeze(["plan.md is missing, unsupported, or exceeds its byte limit"]) });
+  try {
+    if (source.includes("\r")) throw new Error("plan.md must use LF line endings");
+    const lines = source.split("\n");
+    if (lines.length < 15 || lines[0] !== "---" || lines[1] !== "schema-version: 1" || lines[2] !== `plan-id: ${expectedId}` || !lines[3].startsWith("title: ")
+      || !/^revision: [1-9][0-9]*$/u.test(lines[4]) || !/^last-operation-id: [A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(lines[5]) || lines[6] !== "---"
+      || lines[7] !== "" || lines[8] !== "# Summary" || lines[9] !== "") throw new Error("canonical frontmatter or Summary structure is invalid");
+    const titleRaw: unknown = JSON.parse(lines[3].slice("title: ".length));
+    if (typeof titleRaw !== "string") throw new Error("title must be a canonical quoted string");
+    const tasksHeading = lines.indexOf("# Tasks", 10);
+    if (tasksHeading < 12 || lines[tasksHeading - 1] !== "" || lines[tasksHeading + 1] !== "") throw new Error("canonical Tasks structure is invalid");
+    const summary = lines.slice(10, tasksHeading - 1).join("\n");
+    const taskLines = lines.slice(tasksHeading + 2, lines.at(-1) === "" ? -1 : undefined);
+    if (!taskLines.length || taskLines.length > MARKDOWN_PLAN_LIMITS.tasks) throw new Error("plan must contain a bounded non-empty task list");
+    const tasks = taskLines.map((line): PlanTask => {
+      const match = /^- \[ \] ([a-z][a-z0-9]*(?:-[a-z0-9]+)*): (.+)$/u.exec(line);
+      if (!match || match[1].length > 64 || Buffer.byteLength(match[2], "utf8") > MARKDOWN_PLAN_LIMITS.taskTextBytes) throw new Error("task lines must use canonical stable IDs");
+      return Object.freeze({ id: match[1], text: match[2] });
+    });
+    if (new Set(tasks.map((entry) => entry.id)).size !== tasks.length) throw new Error("task IDs are duplicated");
+    const parsed: ParsedPlan = Object.freeze({ id: expectedId, title: titleRaw, summary, revision: Number(lines[4].slice("revision: ".length)), lastOperationId: lines[5].slice("last-operation-id: ".length), tasks: Object.freeze(tasks), source });
+    const canonicalInput = planInput({ title: parsed.title, summary: parsed.summary, tasks: parsed.tasks as unknown as JsonValue });
+    if (renderPlan(expectedId, canonicalInput, parsed.revision, parsed.lastOperationId) !== source) throw new Error("plan.md is not in canonical form");
+    return Object.freeze({ valid: true, issues: Object.freeze([]), plan: parsed });
+  } catch (error) {
+    return Object.freeze({ valid: false, issues: Object.freeze([String(error instanceof Error ? error.message : error).slice(0, 2_048)]) });
+  }
+}
+function requirePlan(workspace: Workspace): ParsedPlan {
+  const result = validatePlan(workspace.path, workspace.planId);
+  if (!result.valid || !result.plan) throw new MarkdownPlanAdapterError("invalid-plan", `Markdown plan is invalid: ${result.issues.join("; ")}`);
+  return result.plan;
+}
+function planContentIdentity(hashes: ArtifactWorkspaceHashesV1): string {
+  const entry = hashes.entries.find((candidate) => candidate.path === PLAN_PATH && candidate.kind === "file");
+  if (!entry) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan content identity requires plan.md");
+  return `sha256:${createHash("sha256").update("pi-hive-markdown-plan-content-v1\0").update(JSON.stringify({ path: entry.path, bytes: entry.bytes, digest: entry.hash })).digest("hex")}`;
+}
+
+interface EvidenceEntry { readonly taskId: string; readonly taskText: string; readonly operationId: string; readonly evidenceRefs: readonly VerifiedArtifactEvidenceV1[]; readonly completedAt: string }
+interface EvidenceState { readonly schemaVersion: 1; readonly adapterVersion: "1"; readonly planId: string; readonly planRevision: number; readonly planContentIdentity: string; readonly tasks: Readonly<Record<string, EvidenceEntry>> }
+function emptyEvidence(planIdValue: string): EvidenceState { return Object.freeze({ schemaVersion: 1, adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION, planId: planIdValue, planRevision: 0, planContentIdentity: "", tasks: Object.freeze({}) }); }
+function artifactHash(value: unknown): value is string { return typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value); }
+function verifiedEvidence(value: unknown): VerifiedArtifactEvidenceV1 | undefined {
+  if (!Value.Check(VERIFIED_EVIDENCE_SCHEMA, value) || !plainRecord(value)) return undefined;
+  if ((value.kind === "tool" || value.kind === "command") && Buffer.byteLength(value.operation, "utf8") > 1_024) return undefined;
+  if (value.kind === "repository" && Buffer.byteLength(value.path, "utf8") > MARKDOWN_PLAN_LIMITS.evidencePathBytes) return undefined;
+  return Object.freeze(structuredClone(value)) as VerifiedArtifactEvidenceV1;
+}
+function invalidEvidence(message: string): never { throw new MarkdownPlanAdapterError("invalid-plan", `Markdown plan execution evidence is invalid: ${message}`); }
+function readEvidence(path: string, id: string): EvidenceState {
+  const evidencePath = join(path, EVIDENCE_PATH);
+  if (!existsSync(evidencePath)) return emptyEvidence(id);
+  let source: string;
+  try {
+    const stat = lstatSync(evidencePath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0 || stat.size > MARKDOWN_PLAN_LIMITS.sidecarBytes) invalidEvidence("sidecar is not a bounded physical file");
+    source = readFileSync(evidencePath, "utf8");
+    if (Buffer.byteLength(source, "utf8") !== stat.size) invalidEvidence("sidecar encoding or size is inconsistent");
+  } catch (error) {
+    if (error instanceof MarkdownPlanAdapterError) throw error;
+    return invalidEvidence(String(error instanceof Error ? error.message : error));
+  }
+  try {
+    const raw: unknown = JSON.parse(source);
+    boundedJson(raw, "Markdown plan execution evidence", { bytes: MARKDOWN_PLAN_LIMITS.sidecarBytes, depth: 12, nodes: MARKDOWN_PLAN_LIMITS.sidecarNodes, rootRecord: true });
+    if (!plainRecord(raw) || Object.keys(raw).sort().join(",") !== "adapterVersion,planContentIdentity,planId,planRevision,schemaVersion,tasks" || raw.schemaVersion !== 1
+      || raw.adapterVersion !== MARKDOWN_PLAN_ADAPTER_VERSION || raw.planId !== id || !Number.isSafeInteger(raw.planRevision) || Number(raw.planRevision) < 1
+      || !artifactHash(raw.planContentIdentity) || !plainRecord(raw.tasks) || Object.keys(raw.tasks).length > MARKDOWN_PLAN_LIMITS.tasks) invalidEvidence("sidecar identity or task collection is inconsistent");
+    const tasks: Record<string, EvidenceEntry> = {};
+    for (const [taskId, value] of Object.entries(raw.tasks)) {
+      if (!TASK_ID_RE.test(taskId) || !plainRecord(value) || Object.keys(value).sort().join(",") !== "completedAt,evidenceRefs,operationId,taskId,taskText" || value.taskId !== taskId
+        || typeof value.taskText !== "string" || !value.taskText || Buffer.byteLength(value.taskText, "utf8") > MARKDOWN_PLAN_LIMITS.taskTextBytes
+        || typeof value.operationId !== "string" || !new RegExp(CONTRACT_ID_PATTERN, "u").test(value.operationId)
+        || !Array.isArray(value.evidenceRefs) || !value.evidenceRefs.length || value.evidenceRefs.length > MARKDOWN_PLAN_LIMITS.evidenceRefsPerTask
+        || typeof value.completedAt !== "string" || Buffer.byteLength(value.completedAt, "utf8") > 256 || !Number.isFinite(Date.parse(value.completedAt))) invalidEvidence(`task ${taskId} is inconsistent`);
+      const refs = value.evidenceRefs.map(verifiedEvidence);
+      if (refs.some((entry) => !entry) || !refs.some((entry) => entry?.kind === "repository") || !refs.some((entry) => entry?.kind === "tool" || entry?.kind === "command")) invalidEvidence(`task ${taskId} has incomplete or malformed verified references`);
+      tasks[taskId] = Object.freeze({ taskId, taskText: value.taskText, operationId: value.operationId, evidenceRefs: Object.freeze(refs as VerifiedArtifactEvidenceV1[]), completedAt: value.completedAt });
+    }
+    return Object.freeze({ schemaVersion: 1, adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION, planId: id, planRevision: Number(raw.planRevision), planContentIdentity: raw.planContentIdentity, tasks: Object.freeze(tasks) });
+  } catch (error) {
+    if (error instanceof MarkdownPlanAdapterError) throw error;
+    return invalidEvidence(String(error instanceof Error ? error.message : error));
+  }
+}
+function normalizedEvidence(value: EvidenceState): JsonValue {
+  return { schemaVersion: value.schemaVersion, adapterVersion: value.adapterVersion, planId: value.planId, planRevision: value.planRevision, planContentIdentity: value.planContentIdentity,
+    tasks: Object.fromEntries(Object.entries(value.tasks).sort(([a], [b]) => a.localeCompare(b)).map(([id, entry]) => [id, { ...entry, evidenceRefs: [...entry.evidenceRefs] }])) };
+}
+function serializeEvidence(value: EvidenceState): string {
+  const normalized = boundedJson(normalizedEvidence(value), "Markdown plan execution evidence", { bytes: MARKDOWN_PLAN_LIMITS.sidecarBytes, depth: 12, nodes: MARKDOWN_PLAN_LIMITS.sidecarNodes, rootRecord: true });
+  const serialized = `${JSON.stringify(normalized)}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MARKDOWN_PLAN_LIMITS.sidecarBytes) throw new MarkdownPlanAdapterError("output-limit", "Markdown plan execution evidence exceeds its physical sidecar byte limit");
+  return serialized;
+}
+function evidenceDigest(value: EvidenceState): string {
+  return `sha256:${createHash("sha256").update("pi-hive-markdown-plan-evidence-v1\0").update(canonicalJson(normalizedEvidence(value))).digest("hex")}`;
+}
+function repositoryEvidenceCurrent(root: string, reference: Extract<VerifiedArtifactEvidenceV1, { kind: "repository" }>): boolean {
+  try {
+    if (!reference.path || reference.path.includes("\\") || reference.path.startsWith("/") || reference.path.split("/").some((part) => !part || part === "." || part === "..")) return false;
+    const candidate = resolveContainedPath(root, join(root, ...reference.path.split("/")));
+    if (!candidate?.exists || relative(root, candidate.canonicalPath).split("\\").join("/") !== reference.path) return false;
+    const stat = lstatSync(candidate.canonicalPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== reference.bytes || stat.size > 33_554_432) return false;
+    return `sha256:${createHash("sha256").update(readFileSync(candidate.canonicalPath)).digest("hex")}` === reference.digest;
+  } catch { return false; }
+}
+function entryCurrent(workspace: Workspace, entry: EvidenceEntry): boolean {
+  return entry.evidenceRefs.some((reference) => reference.kind === "repository") && entry.evidenceRefs.some((reference) => reference.kind === "tool" || reference.kind === "command")
+    && entry.evidenceRefs.every((reference) => reference.kind !== "repository" || repositoryEvidenceCurrent(workspace.projectRoot, reference));
+}
+function completedTaskIds(workspace: Workspace, plan: ParsedPlan, hashes: ArtifactWorkspaceHashesV1, evidence = readEvidence(workspace.path, workspace.planId)): readonly string[] {
+  const identity = planContentIdentity(hashes);
+  if (evidence.planContentIdentity !== identity || evidence.planRevision !== plan.revision) return Object.freeze([]);
+  return Object.freeze(plan.tasks.filter((task) => evidence.tasks[task.id]?.taskText === task.text && entryCurrent(workspace, evidence.tasks[task.id])).map((task) => task.id));
+}
+
+function descriptor(input: ArtifactCheckpointDescriptorInput): CheckpointDescriptorV1 {
+  const workspace = workspaceRoot(input.binding); requirePlan(workspace);
+  if (!input.binding.checkpointIds.includes(input.checkpointId) || !MARKDOWN_PLAN_CHECKPOINT_IDS.includes(input.checkpointId as never)) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan checkpoint is not published by the bound profile");
+  const contributors: CheckpointContributorV1[] = [Object.freeze({ kind: "file", path: PLAN_PATH })];
+  if (input.checkpointId !== "plan") contributors.push(Object.freeze({ kind: "hash", id: "execution-evidence-v1", digest: evidenceDigest(readEvidence(workspace.path, workspace.planId)) }));
+  return Object.freeze({ formatVersion: 1, adapterId: "markdown-plan", adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION, profileId: input.binding.profileId,
+    profileVersion: input.binding.profileVersion, profileSchemaVersion: MARKDOWN_PLAN_PROFILE_SCHEMA_VERSION, checkpointId: input.checkpointId, checkpointVersion: "1", contributors: Object.freeze(contributors) });
+}
+function actionResult(context: ArtifactActionContext | { binding: ArtifactWorkspaceBinding; operationId: string }, actionId: string, summary: string, changed: boolean, data: Readonly<Record<string, JsonValue>>, refs: ArtifactActionResultV1["refs"] = Object.freeze([])): ArtifactActionResultV1 {
+  const hash = context.binding.path ? hashArtifactWorkspace(context.binding.path).workspaceHash : context.binding.workspaceHash;
+  return Object.freeze({ schemaVersion: ARTIFACT_ACTION_VERSION, operationId: context.operationId, actionId, status: "completed", summary, changed, ...(hash ? { workspaceHash: hash } : {}), data: Object.freeze(data), refs });
+}
+function display(value: string, bytes = 512): string { return utf8Prefix(value.replaceAll("<", "‹").replaceAll(">", "›"), bytes); }
+function actionAvailable(value: ArtifactActionContract, capabilities: ArtifactStatusContext["capabilities"]): boolean { return value.requiredCapabilities.every((capability) => capabilities.includes(capability)); }
+function statusCursor(value: string | undefined): number {
+  if (value === undefined) return 0;
+  const match = /^markdown-plan-status-v1:(0|[1-9][0-9]{0,8})$/u.exec(value);
+  if (!match) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan status cursor is invalid");
+  return Number(match[1]);
+}
+function taskCursor(value: unknown): number {
+  if (value === undefined) return 0;
+  const match = /^markdown-plan-tasks-v1:(0|[1-9][0-9]{0,8})$/u.exec(String(value));
+  if (!match) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan task cursor is invalid");
+  return Number(match[1]);
+}
+function readCursor(value: unknown): number {
+  if (value === undefined) return 0;
+  const match = /^markdown-plan-read-v1:(0|[1-9][0-9]{0,8})$/u.exec(String(value));
+  if (!match) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan read cursor is invalid");
+  return Number(match[1]);
+}
+function sourcePage(source: string, cursor: unknown): Readonly<{ source: string; offset: number; count: number; total: number; nextCursor?: string }> {
+  const characters = Array.from(source);
+  const offset = readCursor(cursor);
+  if (offset > characters.length) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan read cursor is stale");
+  let low = offset;
+  let high = characters.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = characters.slice(offset, middle).join("");
+    if (Buffer.byteLength(JSON.stringify(candidate), "utf8") - 2 <= MARKDOWN_PLAN_LIMITS.readPageJsonBytes) low = middle;
+    else high = middle - 1;
+  }
+  if (offset < characters.length && low === offset) throw new MarkdownPlanAdapterError("output-limit", "One Markdown plan character cannot fit the bounded read DTO");
+  const value = characters.slice(offset, low).join("");
+  return Object.freeze({ source: value, offset, count: low - offset, total: characters.length, ...(low < characters.length ? { nextCursor: `markdown-plan-read-v1:${low}` } : {}) });
+}
+
+export function createMarkdownPlanAdapter(input: Readonly<{ now?: () => string }> = {}): ArtifactAdapter & { readonly profiles: typeof PROFILE_LIST } {
+  const now = input.now ?? (() => new Date().toISOString());
+  const adapter: ArtifactAdapter & { readonly profiles: typeof PROFILE_LIST } = {
+    contractVersion: ARTIFACT_CONTRACT_VERSION, id: "markdown-plan", version: MARKDOWN_PLAN_ADAPTER_VERSION, profiles: PROFILE_LIST,
+    protectedWorkspaceRoots(request) {
+      canonicalProjectRoot(request.projectRoot);
+      if (!PROFILE_LIST.includes(request.profile as never)) throw new MarkdownPlanAdapterError("invalid-options", "Markdown plan protected roots require an active built-in profile");
+      return markdownPlanProtectedRoots(request.options);
+    },
+    workspaceLifecycle: {
+      create(request) {
+        const root = candidateRoot(request.projectRoot, request.options, true); const id = planId(request.workspaceId);
+        mkdirSync(root.root, { recursive: true, mode: 0o700 });
+        const verifiedRoot = candidateRoot(request.projectRoot, request.options, false);
+        const target = join(verifiedRoot.root, id);
+        if (existsSync(target)) throw new MarkdownPlanAdapterError("invalid-workspace", `Markdown plan ${id} already exists`);
+        mkdirSync(target, { mode: 0o700 });
+        atomicWrite(join(target, WORKSPACE_METADATA_PATH), `${JSON.stringify(metadata(id, verifiedRoot.planRoot), null, 2)}\n`);
+        const resolved = candidateWorkspace(request.projectRoot, request.options, id);
+        if (!resolved) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan scaffold did not produce one exact contained workspace");
+        return Object.freeze({ id, path: resolved });
+      },
+      resolve(request) {
+        const id = planId(request.workspaceId); const path = candidateWorkspace(request.projectRoot, request.options, id);
+        return path ? Object.freeze({ id, path }) : undefined;
+      },
+      list(request) {
+        const root = candidateRoot(request.projectRoot, request.options, true);
+        if (!existsSync(root.root)) return Object.freeze({ items: Object.freeze([]) });
+        const ids = readdirSync(root.root, { withFileTypes: true }).filter((entry) => entry.isDirectory() && !entry.isSymbolicLink() && PLAN_ID_RE.test(entry.name) && candidateWorkspace(request.projectRoot, request.options, entry.name)).map((entry) => entry.name).sort();
+        const offset = decodeListCursor(request.cursor);
+        if (offset > ids.length) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan workspace cursor is stale");
+        const selected = ids.slice(offset, offset + request.limit);
+        return Object.freeze({ items: Object.freeze(selected.map((id) => Object.freeze({ id, label: id, summary: "Exact Markdown plan workspace" }))), ...(offset + selected.length < ids.length ? { nextCursor: `markdown-plan-v1:${offset + selected.length}` } : {}) });
+      },
+      validateHandoffReference(request) {
+        try {
+          if (request.reference.workspaceId !== request.workspace.id || !MARKDOWN_PLAN_CHECKPOINT_IDS.includes(request.reference.checkpoint as never)) return Object.freeze({ state: "incompatible" as const, reason: "handoff identity/checkpoint is incompatible with Markdown plan" });
+          const target = PROFILE_LIST.find((entry) => entry.id === request.profileId);
+          if (!target?.checkpointIds.includes(request.reference.checkpoint)) return Object.freeze({ state: "incompatible" as const, reason: "target Markdown plan profile does not publish the handoff checkpoint" });
+          const digests = PROFILE_LIST.filter((entry) => entry.checkpointIds.includes(request.reference.checkpoint)).map((sourceProfile) => {
+            const binding: ArtifactWorkspaceBinding = Object.freeze({ schemaVersion: 1, contractVersion: ARTIFACT_CONTRACT_VERSION, adapterId: "markdown-plan", adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION,
+              profileId: sourceProfile.id, profileVersion: sourceProfile.version, binding: "existing", selection: "existing", workspace: Object.freeze({ id: request.workspace.id, kind: "physical" as const }), path: request.workspace.path,
+              workspaceHash: request.hashes.workspaceHash, writerLease: Object.freeze({ required: true }), checkpointIds: sourceProfile.checkpointIds, actionIds: Object.freeze(sourceProfile.actions.map((entry) => entry.id)) });
+            return resolveCheckpointDigest(descriptor({ binding, checkpointId: request.reference.checkpoint, hashes: request.hashes }), request.hashes).digest;
+          });
+          return digests.includes(request.reference.digest) ? Object.freeze({ state: "valid" as const }) : Object.freeze({ state: "stale" as const, reason: "Markdown plan checkpoint digest changed" });
+        } catch (error) { return Object.freeze({ state: "stale" as const, reason: String(error instanceof Error ? error.message : error).slice(0, 2_048) }); }
+      },
+    },
+    bind() { throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan physical workspaces bind through the common workspace lifecycle"); },
+    status(context: ArtifactStatusContext, page: ArtifactStatusPageRequest): ArtifactStatusViewV1 {
+      const workspace = workspaceRoot(context.binding); const profile = PROFILE_LIST.find((entry) => entry.id === context.binding.profileId);
+      if (!profile || !context.hashes) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan status requires its active profile and fresh workspace hash");
+      const validation = validatePlan(workspace.path, workspace.planId); const plan = validation.plan; const evidence = readEvidence(workspace.path, workspace.planId);
+      const completed = plan ? new Set(completedTaskIds(workspace, plan, context.hashes, evidence)) : new Set<string>();
+      const allItems = plan ? plan.tasks.map((task) => Object.freeze({ id: `task:${task.id}`, kind: "execution-task", label: display(task.text, MARKDOWN_PLAN_LIMITS.taskTextBytes), state: completed.has(task.id) ? "complete" : "pending", summary: completed.has(task.id) ? `${evidence.tasks[task.id].evidenceRefs.length} verified evidence reference(s)` : "Current verified execution evidence required", ref: `markdown-plan-task:${task.id}` }))
+        : validation.issues.map((issue, index) => Object.freeze({ id: `validation:${index}`, kind: "validation", label: "Plan validation issue", state: "blocked", summary: display(issue, 2_048), ref: `markdown-plan-validation:${index}` }));
+      const offset = statusCursor(page.cursor); if (offset > allItems.length) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan status cursor is stale");
+      const checkpoints = Object.freeze(profile.checkpointIds.map((checkpointId) => {
+        try { const resolved = resolveCheckpointDigest(descriptor({ binding: context.binding, checkpointId, hashes: context.hashes! }), context.hashes!); return Object.freeze({ id: checkpointId, state: "ready" as const, digest: resolved.digest }); }
+        catch { return Object.freeze({ id: checkpointId, state: "pending" as const }); }
+      }));
+      const authorDone = Boolean(plan); const executionDone = Boolean(plan?.tasks.length && completed.size === plan.tasks.length);
+      const complete = profile.id === "author" ? authorDone : profile.id === "lifecycle" ? authorDone && executionDone : executionDone;
+      const actions = Object.freeze(profile.actions.map((entry) => Object.freeze({ id: entry.id, label: entry.label, available: actionAvailable(entry, context.capabilities), ...(!actionAvailable(entry, context.capabilities) ? { reason: `Requires artifact.${entry.requiredCapabilities.join("+")}` } : {}) })));
+      const refs = Object.freeze(checkpoints.filter((entry): entry is Readonly<{ id: string; state: "ready"; digest: string }> => "digest" in entry).map((entry) => Object.freeze({ id: entry.id, kind: "checkpoint", digest: entry.digest })));
+      const selected = allItems.slice(offset, offset + page.limit);
+      const build = (items: readonly (typeof allItems)[number][]) => ({ schemaVersion: ARTIFACT_VIEW_VERSION, contractVersion: ARTIFACT_CONTRACT_VERSION, adapter: { id: "markdown-plan", version: MARKDOWN_PLAN_ADAPTER_VERSION },
+        profile: { id: profile.id, version: profile.version }, workspace: { id: workspace.planId, kind: "physical" as const, binding: context.binding.binding, path: workspace.path, hash: context.hashes!.workspaceHash },
+        status: complete ? "complete" as const : validation.valid ? "ready" as const : "blocked" as const,
+        summary: complete ? "Markdown plan profile completion requirements are satisfied." : validation.valid ? `Markdown plan revision ${plan!.revision} is canonical; current evidence is required for incomplete tasks.` : `Markdown plan validation reports ${validation.issues.length} issue(s).`,
+        checkpoints, actions, items, page: { limit: page.limit, ...(page.cursor ? { cursor: page.cursor } : {}), ...(offset + items.length < allItems.length ? { nextCursor: `markdown-plan-status-v1:${offset + items.length}` } : {}) }, refs });
+      while (selected.length && Buffer.byteLength(JSON.stringify(build(selected)), "utf8") > ARTIFACT_CONTRACT_LIMITS.viewBytes) selected.pop();
+      if (!selected.length && offset < allItems.length) throw new MarkdownPlanAdapterError("output-limit", "One Markdown plan status item cannot fit the bounded view DTO");
+      return Object.freeze(build(Object.freeze(selected))) as ArtifactStatusViewV1;
+    },
+    async executeAction(context: ArtifactActionContext, selected: ArtifactActionContract, argumentsValue: Readonly<Record<string, JsonValue>>): Promise<ArtifactActionResultV1> {
+      const workspace = workspaceRoot(context.binding); const profile = PROFILE_LIST.find((entry) => entry.id === context.binding.profileId);
+      if (!profile?.actions.includes(selected)) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan action is not published by the active profile");
+      const validation = validatePlan(workspace.path, workspace.planId);
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[0]) {
+        if (!validation.plan) return actionResult(context, selected.id, "Markdown plan is not yet canonical.", false, { issues: validation.issues as unknown as JsonValue });
+        const page = sourcePage(validation.plan.source, argumentsValue.cursor);
+        const hashes = hashArtifactWorkspace(workspace.path);
+        const planEntry = hashes.entries.find((entry) => entry.path === PLAN_PATH && entry.kind === "file")!;
+        const result = actionResult(context, selected.id, `Read canonical Markdown plan revision ${validation.plan.revision}.`, false,
+          { title: validation.plan.title, revision: validation.plan.revision, taskCount: validation.plan.tasks.length, source: page.source, page: { offset: page.offset, count: page.count, total: page.total, ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}) } },
+          Object.freeze([Object.freeze({ id: PLAN_PATH, kind: "file", digest: planEntry.hash, bytes: planEntry.bytes })]));
+        if (Buffer.byteLength(JSON.stringify(result), "utf8") > ARTIFACT_CONTRACT_LIMITS.resultBytes) throw new MarkdownPlanAdapterError("output-limit", "Markdown plan read page exceeds the artifact facade result limit");
+        return result;
+      }
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[1] || selected.id === MARKDOWN_PLAN_ACTION_IDS[2]) {
+        if (selected.id === MARKDOWN_PLAN_ACTION_IDS[1] && existsSync(join(workspace.path, PLAN_PATH))) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan is already authored; use the update action for an explicit revision");
+        if (selected.id === MARKDOWN_PLAN_ACTION_IDS[2] && !validation.plan) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan update requires a current canonical plan");
+        const next = planInput(argumentsValue); const revision = selected.id === MARKDOWN_PLAN_ACTION_IDS[1] ? 1 : validation.plan!.revision + 1;
+        const content = renderPlan(workspace.planId, next, revision, context.operationId);
+        await context.enqueueMutation(PLAN_PATH, () => atomicWrite(join(workspace.path, PLAN_PATH), content));
+        return actionResult(context, selected.id, `${selected.id === MARKDOWN_PLAN_ACTION_IDS[1] ? "Authored" : "Revised"} canonical Markdown plan revision ${revision}.`, true, { revision, taskCount: next.tasks.length });
+      }
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[3]) {
+        return actionResult(context, selected.id, validation.valid ? "Markdown plan validation passed." : `Markdown plan validation found ${validation.issues.length} issue(s).`, false,
+          { valid: validation.valid, ...(validation.plan ? { revision: validation.plan.revision, taskCount: validation.plan.tasks.length } : {}), issues: validation.issues as unknown as JsonValue });
+      }
+      const plan = requirePlan(workspace); const hashes = hashArtifactWorkspace(workspace.path); const evidence = readEvidence(workspace.path, workspace.planId); const completed = new Set(completedTaskIds(workspace, plan, hashes, evidence));
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[4]) {
+        const offset = taskCursor(argumentsValue.cursor); if (offset > plan.tasks.length) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan task cursor is stale");
+        const limit = argumentsValue.limit === undefined ? 20 : Number(argumentsValue.limit);
+        const tasks = plan.tasks.slice(offset, offset + limit).map((task) => ({ taskId: task.id, text: task.text, completed: completed.has(task.id), ...(evidence.tasks[task.id] ? { evidenceRefCount: evidence.tasks[task.id].evidenceRefs.length } : {}) }));
+        const build = () => actionResult(context, selected.id, `${completed.size}/${plan.tasks.length} Markdown plan tasks have current evidence.`, false, { tasks, total: plan.tasks.length, ...(offset + tasks.length < plan.tasks.length ? { nextCursor: `markdown-plan-tasks-v1:${offset + tasks.length}` } : {}) });
+        let result = build();
+        while (tasks.length && Buffer.byteLength(JSON.stringify(result), "utf8") > ARTIFACT_CONTRACT_LIMITS.resultBytes) { tasks.pop(); result = build(); }
+        if (!tasks.length && offset < plan.tasks.length) throw new MarkdownPlanAdapterError("output-limit", "One Markdown plan task cannot fit the bounded list DTO");
+        return result;
+      }
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[5]) {
+        const taskId = String(argumentsValue.taskId); const task = plan.tasks.find((entry) => entry.id === taskId);
+        if (!task) throw new MarkdownPlanAdapterError("invalid-plan", `Markdown plan task ${taskId} does not exist in the exact current plan`);
+        if (!context.verifyEvidence || !Array.isArray(argumentsValue.evidenceRefs)) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan task completion requires package-issued evidence verification");
+        const refs = Object.freeze([...context.verifyEvidence(argumentsValue.evidenceRefs as unknown as readonly ArtifactEvidenceReferenceV1[])]);
+        if (!refs.length || !refs.some((entry) => entry.kind === "repository") || !refs.some((entry) => entry.kind === "tool" || entry.kind === "command") || refs.some((entry) => !verifiedEvidence(entry))) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan task completion requires verified W13 tool/command evidence and current repository hashes");
+        const identity = planContentIdentity(hashes); const retained = evidence.planContentIdentity === identity && evidence.planRevision === plan.revision ? evidence.tasks : {};
+        const completedAt = boundedText(now(), "Markdown plan evidence completion timestamp", 256);
+        if (!Number.isFinite(Date.parse(completedAt))) throw new MarkdownPlanAdapterError("invalid-plan", "Markdown plan evidence completion timestamp is invalid");
+        const next: EvidenceState = Object.freeze({ schemaVersion: 1, adapterVersion: MARKDOWN_PLAN_ADAPTER_VERSION, planId: workspace.planId, planRevision: plan.revision, planContentIdentity: identity,
+          tasks: Object.freeze({ ...retained, [taskId]: Object.freeze({ taskId, taskText: task.text, operationId: context.operationId, evidenceRefs: refs, completedAt }) }) });
+        const serialized = serializeEvidence(next);
+        await context.enqueueMutation(EVIDENCE_PATH, () => atomicWrite(join(workspace.path, EVIDENCE_PATH), serialized));
+        return actionResult(context, selected.id, `Recorded current verified execution evidence for Markdown plan task ${taskId}.`, true, { taskId, planContentIdentity: identity, evidenceRefCount: refs.length });
+      }
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[6]) {
+        const review = resolveCheckpointDigest(descriptor({ binding: context.binding, checkpointId: "review", hashes }), hashes);
+        return actionResult(context, selected.id, "Inspected adapter-owned review evidence; human checkpoint decisions remain outside this action.", false,
+          { reviewDigest: review.digest, revision: plan.revision, taskCount: plan.tasks.length, completedTaskIds: [...completed] },
+          Object.freeze(review.contributors.map((entry, index) => Object.freeze({ id: `review:${index}`, kind: entry.kind, digest: entry.digest, ...(entry.kind === "file" ? { bytes: entry.bytes } : {}) }))));
+      }
+      throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan action is unsupported");
+    },
+    checkpointDescriptor: descriptor,
+    reconcileAction(context, selected) {
+      const workspace = workspaceRoot(context.binding); const validation = validatePlan(workspace.path, workspace.planId);
+      if ((selected.id === MARKDOWN_PLAN_ACTION_IDS[1] || selected.id === MARKDOWN_PLAN_ACTION_IDS[2]) && validation.plan?.lastOperationId === context.operation.operationId) {
+        return Object.freeze({ state: "applied" as const, result: actionResult({ binding: context.binding, operationId: context.operation.operationId }, selected.id, `${selected.id === MARKDOWN_PLAN_ACTION_IDS[1] ? "Authored" : "Revised"} canonical Markdown plan revision ${validation.plan.revision}.`, true, { revision: validation.plan.revision, taskCount: validation.plan.tasks.length }) });
+      }
+      if (selected.id === MARKDOWN_PLAN_ACTION_IDS[5]) {
+        const entry = Object.values(readEvidence(workspace.path, workspace.planId).tasks).find((candidate) => candidate.operationId === context.operation.operationId);
+        if (entry) return Object.freeze({ state: "applied" as const, result: actionResult({ binding: context.binding, operationId: context.operation.operationId }, selected.id, `Recorded current verified execution evidence for Markdown plan task ${entry.taskId}.`, true, { taskId: entry.taskId, evidenceRefCount: entry.evidenceRefs.length }) });
+      }
+      return Object.freeze({ state: "unknown" as const, diagnostic: `Markdown plan cannot prove interrupted ${selected.id} from current adapter-owned state` });
+    },
+    validateCompletion(binding: ArtifactWorkspaceBinding): ArtifactCompletionResult {
+      try {
+        const workspace = workspaceRoot(binding); const profile = PROFILE_LIST.find((entry) => entry.id === binding.profileId);
+        if (!profile) throw new MarkdownPlanAdapterError("invalid-workspace", "Markdown plan completion profile is unknown");
+        const validation = validatePlan(workspace.path, workspace.planId); const issues = [...validation.issues];
+        if (validation.plan && profile.id !== "author") {
+          const hashes = hashArtifactWorkspace(workspace.path); const evidence = readEvidence(workspace.path, workspace.planId); const identity = planContentIdentity(hashes);
+          if (evidence.planContentIdentity !== identity || evidence.planRevision !== validation.plan.revision) issues.push("Markdown plan execution evidence is stale because the exact plan content/revision changed");
+          const completed = new Set(completedTaskIds(workspace, validation.plan, hashes, evidence));
+          const incomplete = validation.plan.tasks.filter((entry) => !completed.has(entry.id)).map((entry) => entry.id);
+          if (incomplete.length) issues.push(`Markdown plan execution evidence or current repository hashes are missing/stale for tasks: ${incomplete.join(", ")}`);
+        }
+        return issues.length ? Object.freeze({ state: "unsatisfied" as const, issues: Object.freeze(issues.slice(0, 128)) }) : Object.freeze({ state: "satisfied" as const });
+      } catch (error) { return Object.freeze({ state: "unsatisfied" as const, issues: Object.freeze([String(error instanceof Error ? error.message : error).slice(0, 2_048)]) }); }
+    },
+  };
+  return Object.freeze(adapter);
+}
+
+export const MARKDOWN_PLAN_ARTIFACT_ADAPTER = createMarkdownPlanAdapter();

--- a/src/artifacts/contracts.ts
+++ b/src/artifacts/contracts.ts
@@ -50,14 +50,16 @@ const contract = (adapter: string, profile: string, bindings: readonly ArtifactB
   actionIds: Object.freeze([...actionIds]),
   viewVersion: ARTIFACT_VIEW_VERSION,
 });
+const markdownRead = "markdown-plan.plan.read", markdownAuthor = "markdown-plan.plan.author", markdownUpdate = "markdown-plan.plan.update", markdownValidate = "markdown-plan.validate";
+const markdownTaskList = "markdown-plan.tasks.list", markdownTaskComplete = "markdown-plan.tasks.complete", markdownReviewInspect = "markdown-plan.review.inspect";
 const openspecRead = "openspec.artifact.read", openspecWrite = "openspec.artifact.write", openspecValidate = "openspec.validate";
 const openspecTaskList = "openspec.tasks.list", openspecTaskComplete = "openspec.tasks.complete", openspecReviewInspect = "openspec.review.inspect";
 export const BUILTIN_ARTIFACT_PROFILES: readonly ArtifactProfileContract[] = Object.freeze([
   contract("none", "default", ["none"], []),
-  contract("markdown-plan", "author", author, ["plan"]),
-  contract("markdown-plan", "execute", existing, ["plan", "execution"]),
-  contract("markdown-plan", "review", existing, ["execution", "review"]),
-  contract("markdown-plan", "lifecycle", author, ["plan", "execution", "review"]),
+  contract("markdown-plan", "author", author, ["plan"], [markdownRead, markdownAuthor, markdownUpdate, markdownValidate]),
+  contract("markdown-plan", "execute", existing, ["plan", "execution"], [markdownRead, markdownValidate, markdownTaskList, markdownTaskComplete]),
+  contract("markdown-plan", "review", existing, ["execution", "review"], [markdownRead, markdownValidate, markdownTaskList, markdownReviewInspect]),
+  contract("markdown-plan", "lifecycle", author, ["plan", "execution", "review"], [markdownRead, markdownAuthor, markdownUpdate, markdownValidate, markdownTaskList, markdownTaskComplete, markdownReviewInspect]),
   contract("openspec", "author", author, ["proposal", "design", "specs", "tasks"], [openspecRead, openspecWrite, openspecValidate]),
   contract("openspec", "execute", existing, ["tasks", "implementation"], [openspecRead, openspecValidate, openspecTaskList, openspecTaskComplete]),
   contract("openspec", "review", existing, ["implementation", "review"], [openspecRead, openspecValidate, openspecTaskList, openspecReviewInspect]),
@@ -126,7 +128,15 @@ export function validateArtifactDeclaration(
   const selected = artifactProfileContract(artifact.adapter, artifact.profile);
   if (!selected) return { codes: ["ARTIFACT_PROFILE_UNKNOWN"] };
   if (!selected.bindings.includes(artifact.binding as ArtifactBinding)) codes.push("ARTIFACT_BINDING_INVALID");
-  if (artifact.options && (Object.keys(artifact.options).length > 0 || Buffer.byteLength(JSON.stringify(artifact.options), "utf8") > ARTIFACT_CONTRACT_LIMITS.optionsBytes)) codes.push("ARTIFACT_OPTIONS_UNKNOWN");
+  if (artifact.options) {
+    const optionsBytes = Buffer.byteLength(JSON.stringify(artifact.options), "utf8");
+    const keys = Object.keys(artifact.options);
+    const markdownRoot = artifact.options.root;
+    const markdownOptionsValid = selected.adapter === "markdown-plan" && keys.every((key) => key === "root")
+      && (markdownRoot === undefined || (typeof markdownRoot === "string" && markdownRoot.length <= 512 && /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*){0,15}$/u.test(markdownRoot)
+        && !markdownRoot.split("/").some((part) => part === ".git" || part === ".pi" || part === "openspec")));
+    if (optionsBytes > ARTIFACT_CONTRACT_LIMITS.optionsBytes || (selected.adapter === "markdown-plan" ? !markdownOptionsValid : keys.length > 0)) codes.push("ARTIFACT_OPTIONS_UNKNOWN");
+  }
   const actual = new Set(Object.keys(approvals ?? {}));
   for (const id of selected.checkpoints) if (!actual.has(id)) codes.push("WORKFLOW_CHECKPOINT_MISSING");
   for (const id of actual) if (!selected.checkpoints.includes(id)) codes.push("WORKFLOW_CHECKPOINT_UNKNOWN");

--- a/src/artifacts/hashes.ts
+++ b/src/artifacts/hashes.ts
@@ -16,8 +16,8 @@ export const ARTIFACT_HASH_VERSION = 1 as const;
 export const ARTIFACT_HASH_LIMITS = Object.freeze({
   files: 2_048,
   pathBytes: 262_144,
-  fileBytes: 33_554_432,
-  aggregateBytes: 67_108_864,
+  fileBytes: 67_108_864,
+  aggregateBytes: 134_217_728,
   depth: 128,
 });
 

--- a/src/artifacts/registry.ts
+++ b/src/artifacts/registry.ts
@@ -10,7 +10,9 @@ import {
   type ArtifactBinding,
 } from "./contracts";
 import { NONE_ARTIFACT_ADAPTER, NONE_PROFILE } from "./adapters/none";
+import { MARKDOWN_PLAN_ARTIFACT_ADAPTER, MARKDOWN_PLAN_PROFILES } from "./adapters/markdown-plan";
 import { OPEN_SPEC_ARTIFACT_ADAPTER, OPEN_SPEC_PROFILES } from "./adapters/openspec";
+import type { JsonValue } from "../config/types";
 import type {
   ArtifactAdapter,
   ArtifactBindRequest,
@@ -53,6 +55,7 @@ const strict = { additionalProperties: false } as const;
 const EMPTY_OPTIONS = Type.Object({}, strict);
 const runtimeProfiles: readonly ArtifactRuntimeProfile[] = Object.freeze(BUILTIN_ARTIFACT_PROFILES.map((metadata) => {
   if (metadata.adapter === "none" && metadata.profile === "default") return NONE_PROFILE;
+  if (metadata.adapter === "markdown-plan") return MARKDOWN_PLAN_PROFILES[metadata.profile as keyof typeof MARKDOWN_PLAN_PROFILES];
   if (metadata.adapter === "openspec") return OPEN_SPEC_PROFILES[metadata.profile as keyof typeof OPEN_SPEC_PROFILES];
   return Object.freeze({
     contractVersion: ARTIFACT_CONTRACT_VERSION,
@@ -75,6 +78,7 @@ class BuiltinArtifactRegistry {
 
   private implementation(adapterId: string): ArtifactAdapter | undefined {
     if (adapterId === "none") return NONE_ARTIFACT_ADAPTER;
+    if (adapterId === "markdown-plan") return MARKDOWN_PLAN_ARTIFACT_ADAPTER;
     if (adapterId === "openspec") return OPEN_SPEC_ARTIFACT_ADAPTER;
     return undefined;
   }
@@ -96,7 +100,7 @@ class BuiltinArtifactRegistry {
     return Object.freeze({ profile, adapter });
   }
 
-  validateOptions(profile: ArtifactRuntimeProfile, raw: unknown): Readonly<Record<string, never>> {
+  validateOptions(profile: ArtifactRuntimeProfile, raw: unknown): Readonly<Record<string, JsonValue>> {
     try {
       boundedJson(raw, "Artifact options", {
         bytes: ARTIFACT_CONTRACT_LIMITS.optionsBytes,
@@ -108,7 +112,7 @@ class BuiltinArtifactRegistry {
       throw new ArtifactRegistryError("OPTIONS_INVALID", String(error instanceof Error ? error.message : error));
     }
     if (!Value.Check(profile.optionsSchema, raw)) throw new ArtifactRegistryError("OPTIONS_INVALID", `Artifact options for ${profile.adapterId}/${profile.id} contain unknown or invalid fields`);
-    return Object.freeze({});
+    return Object.freeze(structuredClone(raw)) as Readonly<Record<string, JsonValue>>;
   }
 
   bind(resolved: ResolvedArtifactProfile, request: { readonly runId: string; readonly binding: string; readonly options: unknown }): ArtifactWorkspaceBinding {

--- a/src/artifacts/types.ts
+++ b/src/artifacts/types.ts
@@ -1,6 +1,7 @@
 import type { TSchema } from "typebox";
 import type { JsonValue } from "../config/types";
 import type { ArtifactCapability } from "../capabilities/types";
+import type { ProtectedPathRoot } from "../capabilities/reserved-paths";
 import type { ArtifactReference } from "../workflows/runs";
 import type { ArtifactWorkspaceHashesV1 } from "./hashes";
 import type { CheckpointDescriptorV1 } from "./checkpoints";
@@ -196,6 +197,8 @@ export interface ArtifactAdapter {
   readonly id: string;
   readonly version: string;
   readonly profiles: readonly ArtifactRuntimeProfile[];
+  /** Adapter-owned roots automatically incorporated into generic filesystem policy. */
+  protectedWorkspaceRoots?(input: Readonly<{ projectRoot: string; profile: ArtifactRuntimeProfile; options: Readonly<Record<string, JsonValue>> }>): readonly ProtectedPathRoot[];
   readonly workspaceLifecycle?: ArtifactWorkspaceLifecycle;
   bind(profile: ArtifactRuntimeProfile, request: ArtifactBindRequest): ArtifactWorkspaceBinding;
   status(context: ArtifactStatusContext, page: ArtifactStatusPageRequest): ArtifactStatusViewV1 | Promise<ArtifactStatusViewV1>;

--- a/src/capabilities/filesystem.ts
+++ b/src/capabilities/filesystem.ts
@@ -7,6 +7,7 @@ import { checkProtectedPath, type ProtectedPathRoot } from "./reserved-paths";
 import type { EffectiveNodePolicy, FilesystemOperation, NormalizedFilesystemGrant } from "./types";
 import type { MutationAccountingRecorder, MutationIntent } from "../workflows/change-accounting";
 import type { AttemptRuntime } from "../workflows/attempts";
+import { BUILTIN_ARTIFACT_REGISTRY, type ResolvedArtifactProfile } from "../artifacts/registry";
 
 const MAX_TOOL_PATHS = 32;
 const MAX_DIAGNOSTIC_BYTES = 2_048;
@@ -35,6 +36,8 @@ export interface CompileFilesystemPolicyInput {
   readonly effectivePolicy: EffectiveNodePolicy;
   readonly secretPaths?: readonly string[];
   readonly additionalProtectedRoots?: readonly ProtectedPathRoot[];
+  /** Resolved activation/runtime selection; its adapter roots cannot be omitted by callers. */
+  readonly artifact?: Readonly<{ resolved: ResolvedArtifactProfile; options: unknown }>;
   readonly platform?: NodeJS.Platform;
 }
 
@@ -84,6 +87,12 @@ export function compileFilesystemPolicy(input: CompileFilesystemPolicyInput): Co
   const canonical = resolveCanonicalPath(lexicalProjectRoot);
   if (!canonical || !canonical.exists || !statSync(canonical.canonicalPath).isDirectory()) throw new Error("FILESYSTEM_PROJECT_ROOT_INVALID");
   const grants = input.effectivePolicy.capabilities.filesystem.map((grant) => canonicalGrant(lexicalProjectRoot, grant));
+  const artifactRoots = (() => {
+    if (!input.artifact) return Object.freeze([]) as readonly ProtectedPathRoot[];
+    const { resolved } = input.artifact;
+    const options = BUILTIN_ARTIFACT_REGISTRY.validateOptions(resolved.profile, input.artifact.options);
+    return Object.freeze([...(resolved.adapter.protectedWorkspaceRoots?.({ projectRoot: canonical.canonicalPath, profile: resolved.profile, options }) ?? [])]);
+  })();
   return Object.freeze({
     projectRoot: canonical.canonicalPath,
     lexicalProjectRoot,
@@ -91,7 +100,7 @@ export function compileFilesystemPolicy(input: CompileFilesystemPolicyInput): Co
     nodeId: input.effectivePolicy.nodeId,
     grants: Object.freeze(grants),
     secretPaths: Object.freeze([...(input.secretPaths ?? [])]),
-    additionalProtectedRoots: Object.freeze([...(input.additionalProtectedRoots ?? [])]),
+    additionalProtectedRoots: Object.freeze([...(input.additionalProtectedRoots ?? []), ...artifactRoots]),
   });
 }
 

--- a/src/capabilities/reserved-paths.ts
+++ b/src/capabilities/reserved-paths.ts
@@ -27,6 +27,7 @@ export const DEFAULT_PROTECTED_PATHS: readonly ProtectedPathRoot[] = Object.free
   // directory has not yet been added to the specific registry above.
   Object.freeze({ path: ".pi/hive", kind: "authority-config" }),
   Object.freeze({ path: "openspec", kind: "artifact" }),
+  Object.freeze({ path: "plans", kind: "artifact" }),
   Object.freeze({ path: ".git", kind: "git-metadata" }),
 ]);
 

--- a/src/workflows/orchestration.ts
+++ b/src/workflows/orchestration.ts
@@ -524,10 +524,22 @@ export class RunOrchestrationService {
     });
   }
 
+  private artifactProtectedWorkspaceRoots() {
+    if (!this.selectedArtifact) return Object.freeze([]);
+    const configured = this.artifactSelection();
+    return this.selectedArtifact.adapter.protectedWorkspaceRoots?.({
+      projectRoot: this.options.projectRoot,
+      profile: this.selectedArtifact.profile,
+      options: configured.options,
+    }) ?? Object.freeze([]);
+  }
+
   private changeAccountingFor(runId: string): ChangeAccountingRuntime {
+    const configured = this.options.changeAccounting;
     return new ChangeAccountingRuntime({
       projectRoot: this.options.projectRoot, projectId: this.options.projectId, sessionId: this.options.sessionId, runId,
-      now: this.options.now, ...this.options.changeAccounting,
+      now: this.options.now, ...configured,
+      protectedRoots: Object.freeze([...(configured?.protectedRoots ?? []), ...this.artifactProtectedWorkspaceRoots()]),
     });
   }
 

--- a/tests/artifacts/artifact-contract-harness.test.ts
+++ b/tests/artifacts/artifact-contract-harness.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
+import { MARKDOWN_PLAN_ARTIFACT_ADAPTER } from "../../src/artifacts/adapters/markdown-plan.ts";
 import { NONE_ARTIFACT_ADAPTER } from "../../src/artifacts/adapters/none.ts";
 import { OPEN_SPEC_ARTIFACT_ADAPTER } from "../../src/artifacts/adapters/openspec.ts";
 import {
@@ -13,6 +14,7 @@ import {
 
 test("built-in implemented adapters pass the reusable lifecycle contract", () => {
   assertArtifactAdapterContract(NONE_ARTIFACT_ADAPTER);
+  assertArtifactAdapterContract(MARKDOWN_PLAN_ARTIFACT_ADAPTER);
   assertArtifactAdapterContract(OPEN_SPEC_ARTIFACT_ADAPTER);
 });
 
@@ -53,6 +55,7 @@ test("artifact modules have no model, delegation, routing, Pi runtime, or workfl
     "src/artifacts/workspaces.ts",
     "src/artifacts/internal/caller.ts",
     "src/artifacts/adapters/none.ts",
+    "src/artifacts/adapters/markdown-plan.ts",
     "src/artifacts/adapters/openspec.ts",
   ].map((path) => resolve(path)));
 });

--- a/tests/artifacts/artifact-markdown-plan-e2e.test.ts
+++ b/tests/artifacts/artifact-markdown-plan-e2e.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createMarkdownPlanAdapter, MARKDOWN_PLAN_PROFILES } from "../../src/artifacts/adapters/markdown-plan.ts";
+import { CheckpointApprovalService } from "../../src/artifacts/approvals.ts";
+import { resolveCheckpointDigest } from "../../src/artifacts/checkpoints.ts";
+import { ArtifactFacade } from "../../src/artifacts/facade.ts";
+import { hashArtifactWorkspace } from "../../src/artifacts/hashes.ts";
+import { createRunOrchestrationArtifactCallerIssuer } from "../../src/artifacts/internal/caller.ts";
+import { WorkspaceLeaseRuntime } from "../../src/artifacts/leases.ts";
+import { ArtifactOperationRuntime } from "../../src/artifacts/operations.ts";
+import { bindPhysicalArtifactWorkspace } from "../../src/artifacts/workspaces.ts";
+import type { ArtifactActionContext, ArtifactEvidenceReferenceV1, ArtifactWorkspaceBinding, VerifiedArtifactEvidenceV1 } from "../../src/artifacts/types.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+
+function fixture(label: string) {
+  const projectRoot = mkdtempSync(join(tmpdir(), `hive-markdown-plan-e2e-${label}-`));
+  return { projectRoot, adapter: createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:00.000Z" }) };
+}
+function live(value: ArtifactWorkspaceBinding): ArtifactWorkspaceBinding { return Object.freeze({ ...value, workspaceHash: hashArtifactWorkspace(value.path!).workspaceHash }); }
+function repositoryRef(root: string, path: string) { return { kind: "repository" as const, path, digest: `sha256:${createHash("sha256").update(readFileSync(join(root, path))).digest("hex")}` }; }
+const toolRef = { kind: "tool" as const, attemptId: "tool-test" };
+async function action(adapter: ReturnType<typeof createMarkdownPlanAdapter>, value: ArtifactWorkspaceBinding, actionId: string, argumentsValue: Record<string, unknown>, operationId: string) {
+  const profile = adapter.profiles.find((entry) => entry.id === value.profileId)!;
+  const contract = profile.actions.find((entry) => entry.id === actionId)!;
+  const current = live(value);
+  const context: ArtifactActionContext = Object.freeze({
+    binding: current, capabilities: Object.freeze(["read", "write", "review"] as const), hashes: hashArtifactWorkspace(current.path!), operationId,
+    expectedWorkspaceHash: current.workspaceHash, enqueueMutation: async <T>(_path: string, callback: () => T | Promise<T>): Promise<T> => callback(),
+    verifyEvidence: (references: readonly ArtifactEvidenceReferenceV1[]): readonly VerifiedArtifactEvidenceV1[] => references.map((reference) => {
+      if (reference.kind === "tool") return { kind: "tool" as const, attemptId: reference.attemptId, operation: "tool.test", inputHash: "a".repeat(64), resultHash: "b".repeat(64) };
+      if (reference.kind !== "repository") throw new Error("command evidence is unused");
+      const root = join(current.path!, "..", ".."); const content = readFileSync(join(root, reference.path));
+      return { kind: "repository" as const, path: reference.path, digest: reference.digest, bytes: content.byteLength };
+    }),
+  });
+  return adapter.executeAction!(context, contract, argumentsValue as never);
+}
+const plan = { title: "Deliver feature", summary: "Implement and review the requested feature.", tasks: [{ id: "deliver", text: "Deliver the feature" }] };
+
+async function facadeAction(input: Readonly<{
+  projectRoot: string;
+  adapter: ReturnType<typeof createMarkdownPlanAdapter>;
+  binding: ArtifactWorkspaceBinding;
+  sessionId: string;
+  runId: string;
+  actionId: string;
+  arguments: Record<string, unknown>;
+  operationId: string;
+}>) {
+  const current = live(input.binding);
+  const lease = new WorkspaceLeaseRuntime({ projectRoot: input.projectRoot, adapterId: "markdown-plan", workspaceId: current.workspace.id, sessionId: input.sessionId, runId: input.runId });
+  const facade = new ArtifactFacade({ adapter: input.adapter, profile: input.adapter.profiles.find((entry) => entry.id === current.profileId)!, binding: current,
+    mutationQueue: async (_target, _operationId, callback) => callback(), workspaceAuthority: {
+      readHashes: () => hashArtifactWorkspace(current.path!), lease,
+      operations: new ArtifactOperationRuntime({ projectRoot: input.projectRoot, projectId: "project", sessionId: input.sessionId, runId: input.runId }),
+    },
+  });
+  const caller = createRunOrchestrationArtifactCallerIssuer({ payload: { authority: { nodes: [{ nodeId: "root", capabilities: { effective: { artifact: ["read", "review", "write"] } }, tools: ["artifact_action", "artifact_status"] }] } } } as never).issue("root", current);
+  try {
+    return await facade.action(caller, { actionId: input.actionId, arguments: input.arguments, ...(input.adapter.profiles.find((entry) => entry.id === current.profileId)!.actions.find((entry) => entry.id === input.actionId)!.mutability === "mutating" ? { expectedWorkspaceHash: current.workspaceHash } : {}) }, {
+      attemptId: input.operationId,
+      verifyEvidence: (references) => references.map((reference) => {
+        if (reference.kind === "tool") return { kind: "tool" as const, attemptId: reference.attemptId, operation: "tool.test", inputHash: "a".repeat(64), resultHash: "b".repeat(64) };
+        if (reference.kind !== "repository") throw new Error("command evidence is unused");
+        const content = readFileSync(join(input.projectRoot, reference.path));
+        return { kind: "repository" as const, path: reference.path, digest: reference.digest, bytes: content.byteLength };
+      }),
+    });
+  } finally { lease.release(); }
+}
+
+test("split Markdown author handoff execute review revalidates exact current evidence without carrying approval authority", async () => {
+  const f = fixture("split"); mkdirSync(join(f.projectRoot, "src")); writeFileSync(join(f.projectRoot, "src", "delivery.ts"), "export const delivered = true;\n");
+  const author = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.author, runId: "author-run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "split-plan" } });
+  await facadeAction({ projectRoot: f.projectRoot, adapter: f.adapter, binding: author, sessionId: "author-session", runId: "author-run", actionId: "markdown-plan.plan.author", arguments: plan, operationId: "author-plan" });
+  const authorHashes = hashArtifactWorkspace(author.path!);
+  const authorPlan = resolveCheckpointDigest(f.adapter.checkpointDescriptor!({ binding: live(author), checkpointId: "plan", hashes: authorHashes }), authorHashes);
+  const execute = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.execute, runId: "execute-run", configuredBinding: "existing", options: {}, selection: { mode: "existing", workspaceId: "split-plan" }, handoffReference: { workspaceId: "split-plan", checkpoint: "plan", digest: authorPlan.digest } });
+  const executeHashes = hashArtifactWorkspace(execute.path!);
+  assert.notEqual(resolveCheckpointDigest(f.adapter.checkpointDescriptor!({ binding: live(execute), checkpointId: "plan", hashes: executeHashes }), executeHashes).digest, authorPlan.digest);
+  await facadeAction({ projectRoot: f.projectRoot, adapter: f.adapter, binding: execute, sessionId: "execute-session", runId: "execute-run", actionId: "markdown-plan.tasks.complete", arguments: { taskId: "deliver", evidenceRefs: [toolRef, repositoryRef(f.projectRoot, "src/delivery.ts")] }, operationId: "execute-task" });
+  assert.equal((await f.adapter.validateCompletion(live(execute))).state, "satisfied");
+  const implementationHashes = hashArtifactWorkspace(execute.path!);
+  const execution = resolveCheckpointDigest(f.adapter.checkpointDescriptor!({ binding: live(execute), checkpointId: "execution", hashes: implementationHashes }), implementationHashes);
+  const review = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.review, runId: "review-run", configuredBinding: "existing", options: {}, selection: { mode: "existing", workspaceId: "split-plan" }, handoffReference: { workspaceId: "split-plan", checkpoint: "execution", digest: execution.digest } });
+  assert.equal(MARKDOWN_PLAN_PROFILES.review.actions.some((entry) => entry.id === "markdown-plan.tasks.complete"), false);
+  assert.equal((await f.adapter.validateCompletion(live(review))).state, "satisfied");
+  const reviewData = await facadeAction({ projectRoot: f.projectRoot, adapter: f.adapter, binding: review, sessionId: "review-session", runId: "review-run", actionId: "markdown-plan.review.inspect", arguments: {}, operationId: "inspect-review" });
+  assert.deepEqual(reviewData.data.completedTaskIds, ["deliver"]);
+  writeFileSync(join(author.path!, "plan.md"), readFileSync(join(author.path!, "plan.md"), "utf8").replace("Deliver the feature", "Deliver the revised feature"));
+  assert.throws(() => bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.execute, runId: "stale-run", configuredBinding: "existing", options: {}, selection: { mode: "existing", workspaceId: "split-plan" }, handoffReference: { workspaceId: "split-plan", checkpoint: "plan", digest: authorPlan.digest } }), /stale/i);
+});
+
+test("a real W18 denial is immutable for one Markdown plan digest and revision creates a fresh request", async () => {
+  const f = fixture("approval-revision");
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.author, runId: "approval-run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "approval-plan" } });
+  await action(f.adapter, created, "markdown-plan.plan.author", plan, "approval-author");
+  const current = live(created);
+  let requestId = 0; let decisionId = 0;
+  const service = new CheckpointApprovalService({
+    projectRoot: f.projectRoot, projectId: "project", sessionId: "approval-session", adapterId: "markdown-plan", adapterVersion: "1", profileId: "author", profileVersion: "1", profileSchemaVersion: "1",
+    checkpointPolicies: { plan: "required" }, resolveDescriptor: ({ checkpointId, binding }) => f.adapter.checkpointDescriptor!({ binding, checkpointId, hashes: hashArtifactWorkspace(binding.path!) }),
+    authenticateControl: ({ credential }) => credential === "human-secret" ? { approverId: "human", authenticationId: "auth", mechanism: "bearer" } : undefined,
+    createRequestId: () => `request-${++requestId}`, createDecisionId: () => `decision-${++decisionId}`,
+  });
+  const lifecycle = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project", sessionId: "approval-session", snapshotId: "snapshot", rootNodeId: "root", createRunId: () => "approval-run", createArtifactWorkspace: () => current, checkpointSnapshots: service.runSnapshotProvider() });
+  lifecycle.recordUserInput({ inputId: "input", text: "review plan", source: "interactive" });
+  const lease = new WorkspaceLeaseRuntime({ projectRoot: f.projectRoot, adapterId: "markdown-plan", workspaceId: "approval-plan", sessionId: "approval-session", runId: "approval-run" });
+  assert.equal(lease.acquire().ok, true);
+  const firstHash = hashArtifactWorkspace(current.path!).workspaceHash;
+  const first = await service.requestApproval({ operationId: "request-first", checkpointId: "plan", expectedWorkspaceHash: firstHash });
+  const denied = await service.decide({ operationId: "deny-first", requestId: first.requestId, expectedRequestSequence: first.requestSequence, digest: first.digest, expectedWorkspaceHash: firstHash, decision: "denied", feedback: "revise" }, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential: "human-secret" });
+  assert.equal(denied.decision, "denied");
+  assert.equal((await service.requestApproval({ operationId: "request-again", checkpointId: "plan", expectedWorkspaceHash: firstHash })).requestId, first.requestId);
+  await action(f.adapter, current, "markdown-plan.plan.update", { ...plan, summary: "Revised after human denial." }, "approval-revise");
+  const revisedHash = hashArtifactWorkspace(current.path!).workspaceHash;
+  const revised = await service.requestApproval({ operationId: "request-revised", checkpointId: "plan", expectedWorkspaceHash: revisedHash });
+  assert.notEqual(revised.requestId, first.requestId);
+  assert.notEqual(revised.digest, first.digest);
+  assert.equal(lease.release(), true);
+});
+
+test("combined Markdown lifecycle uses the generic facade, lease, operation, evidence, and completion contracts", async () => {
+  const f = fixture("lifecycle"); mkdirSync(join(f.projectRoot, "src")); writeFileSync(join(f.projectRoot, "src", "combined.ts"), "export const combined = true;\n");
+  const lifecycle = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.lifecycle, runId: "run", configuredBinding: "either", options: {}, selection: { mode: "new", workspaceId: "combined-plan" } });
+  await action(f.adapter, lifecycle, "markdown-plan.plan.author", plan, "author-plan");
+  const current = live(lifecycle);
+  const facade = new ArtifactFacade({ adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.lifecycle, binding: current,
+    mutationQueue: async (_target, _operationId, callback) => callback(), workspaceAuthority: {
+      readHashes: () => hashArtifactWorkspace(current.path!),
+      lease: new WorkspaceLeaseRuntime({ projectRoot: f.projectRoot, adapterId: "markdown-plan", workspaceId: "combined-plan", sessionId: "session", runId: "run" }),
+      operations: new ArtifactOperationRuntime({ projectRoot: f.projectRoot, projectId: "project", sessionId: "session", runId: "run" }),
+    },
+  });
+  const caller = createRunOrchestrationArtifactCallerIssuer({ payload: { authority: { nodes: [{ nodeId: "root", capabilities: { effective: { artifact: ["read", "review", "write"] } }, tools: ["artifact_action", "artifact_status"] }] } } } as never).issue("root", current);
+  const ref = repositoryRef(f.projectRoot, "src/combined.ts");
+  await facade.action(caller, { actionId: "markdown-plan.tasks.complete", arguments: { taskId: "deliver", evidenceRefs: [toolRef, ref] }, expectedWorkspaceHash: current.workspaceHash }, { attemptId: "complete", verifyEvidence: (references) => references.map((reference) => {
+    if (reference.kind === "tool") return { kind: "tool" as const, attemptId: reference.attemptId, operation: "tool.test", inputHash: "a".repeat(64), resultHash: "b".repeat(64) };
+    if (reference.kind !== "repository") throw new Error("command evidence is unused");
+    return { kind: "repository" as const, path: reference.path, digest: reference.digest, bytes: readFileSync(join(f.projectRoot, reference.path)).byteLength };
+  }) });
+  assert.equal((await f.adapter.validateCompletion(live(lifecycle))).state, "satisfied");
+  const status = await facade.status(caller, { limit: 20 });
+  assert.equal(status.status, "complete");
+  assert.deepEqual(status.checkpoints.map((entry) => entry.id), ["plan", "execution", "review"]);
+});
+
+test("Markdown facade serializes concurrent writers, rejects stale hashes, and reconciles an applied crash intent", async () => {
+  const f = fixture("writer-recovery");
+  const value = bindPhysicalArtifactWorkspace({ projectRoot: f.projectRoot, adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.lifecycle, runId: "writer-run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "writer-plan" } });
+  const initial = live(value);
+  const lease = new WorkspaceLeaseRuntime({ projectRoot: f.projectRoot, adapterId: "markdown-plan", workspaceId: "writer-plan", sessionId: "writer-session", runId: "writer-run" });
+  const operations = new ArtifactOperationRuntime({ projectRoot: f.projectRoot, projectId: "project", sessionId: "writer-session", runId: "writer-run" });
+  const facade = new ArtifactFacade({ adapter: f.adapter, profile: MARKDOWN_PLAN_PROFILES.lifecycle, binding: initial, mutationQueue: async (_target, _operationId, callback) => callback(), workspaceAuthority: { readHashes: () => hashArtifactWorkspace(initial.path!), lease, operations } });
+  const caller = createRunOrchestrationArtifactCallerIssuer({ payload: { authority: { nodes: [{ nodeId: "root", capabilities: { effective: { artifact: ["read", "review", "write"] } }, tools: ["artifact_action", "artifact_status"] }] } } } as never).issue("root", initial);
+  await facade.action(caller, { actionId: "markdown-plan.plan.author", arguments: plan, expectedWorkspaceHash: initial.workspaceHash }, { attemptId: "writer-author" });
+  const beforeConcurrent = hashArtifactWorkspace(initial.path!).workspaceHash;
+  const settled = await Promise.allSettled([
+    facade.action(caller, { actionId: "markdown-plan.plan.update", arguments: { ...plan, summary: "Concurrent first." }, expectedWorkspaceHash: beforeConcurrent }, { attemptId: "writer-first" }),
+    facade.action(caller, { actionId: "markdown-plan.plan.update", arguments: { ...plan, summary: "Concurrent second." }, expectedWorkspaceHash: beforeConcurrent }, { attemptId: "writer-second" }),
+  ]);
+  assert.equal(settled.filter((entry) => entry.status === "fulfilled").length, 1);
+  assert.equal(settled.filter((entry) => entry.status === "rejected").length, 1);
+
+  const stale = hashArtifactWorkspace(initial.path!).workspaceHash;
+  writeFileSync(join(initial.path!, "external.txt"), "external\n");
+  await assert.rejects(() => facade.action(caller, { actionId: "markdown-plan.plan.update", arguments: { ...plan, summary: "Must conflict." }, expectedWorkspaceHash: stale }, { attemptId: "writer-stale" }), /hash conflict|changed/i);
+
+  const crashExpected = hashArtifactWorkspace(initial.path!).workspaceHash;
+  const crashArguments = { ...plan, summary: "Applied before process crash." };
+  operations.begin({ operationId: "writer-crash", actionId: "markdown-plan.plan.update", arguments: crashArguments, expectedWorkspaceHash: crashExpected });
+  await action(f.adapter, initial, "markdown-plan.plan.update", crashArguments, "writer-crash");
+  assert.deepEqual(facade.recoverUnresolvedOperations().recovered, ["writer-crash"]);
+  assert.equal(operations.restore().operations["writer-crash"].reconciliation, "applied");
+  assert.equal(lease.release(), true);
+});

--- a/tests/artifacts/artifact-markdown-plan.test.ts
+++ b/tests/artifacts/artifact-markdown-plan.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { Value } from "typebox/value";
+import {
+  MARKDOWN_PLAN_ACTION_IDS,
+  MARKDOWN_PLAN_ARTIFACT_ADAPTER,
+  MARKDOWN_PLAN_CHECKPOINT_IDS,
+  MARKDOWN_PLAN_DEFAULT_ROOT,
+  MARKDOWN_PLAN_LIMITS,
+  MARKDOWN_PLAN_PROFILES,
+  createMarkdownPlanAdapter,
+  markdownPlanProtectedRoots,
+} from "../../src/artifacts/adapters/markdown-plan.ts";
+import { resolveCheckpointDigest } from "../../src/artifacts/checkpoints.ts";
+import { ARTIFACT_CONTRACT_VERSION } from "../../src/artifacts/contracts.ts";
+import { ARTIFACT_HASH_LIMITS, hashArtifactWorkspace } from "../../src/artifacts/hashes.ts";
+import { BUILTIN_ARTIFACT_REGISTRY } from "../../src/artifacts/registry.ts";
+import { bindPhysicalArtifactWorkspace, listPhysicalArtifactWorkspaces } from "../../src/artifacts/workspaces.ts";
+import type { ArtifactActionContext, ArtifactEvidenceReferenceV1, ArtifactWorkspaceBinding, VerifiedArtifactEvidenceV1 } from "../../src/artifacts/types.ts";
+import { compileFilesystemPolicy, authorizeFilesystemOperation } from "../../src/capabilities/filesystem.ts";
+import { normalizeCapabilities } from "../../src/capabilities/policy.ts";
+import type { EffectiveNodePolicy } from "../../src/capabilities/types.ts";
+import { boundedJson } from "../../src/workflows/values.ts";
+import { assertArtifactActionFilesystemContained, assertArtifactAdapterContract } from "../helpers/artifact-adapter-contract.ts";
+
+function project(label: string): string { return mkdtempSync(join(tmpdir(), `hive-markdown-plan-${label}-`)); }
+function profile(id: keyof typeof MARKDOWN_PLAN_PROFILES) { return MARKDOWN_PLAN_PROFILES[id]; }
+function binding(root: string, profileId: keyof typeof MARKDOWN_PLAN_PROFILES, id = "add-auth", planRoot = MARKDOWN_PLAN_DEFAULT_ROOT): ArtifactWorkspaceBinding {
+  const selected = profile(profileId);
+  const path = join(root, ...planRoot.split("/"), id);
+  return Object.freeze({
+    schemaVersion: 1 as const, contractVersion: ARTIFACT_CONTRACT_VERSION, adapterId: "markdown-plan", adapterVersion: "1",
+    profileId, profileVersion: "1" as const, binding: profileId === "execute" || profileId === "review" ? "existing" as const : "either" as const,
+    selection: "existing" as const, workspace: Object.freeze({ id, kind: "physical" as const }), path,
+    workspaceHash: hashArtifactWorkspace(path).workspaceHash, writerLease: Object.freeze({ required: true }), checkpointIds: selected.checkpointIds,
+    actionIds: selected.actions.map((action) => action.id),
+  });
+}
+function context(value: ArtifactWorkspaceBinding, operationId: string): ArtifactActionContext {
+  return Object.freeze({
+    binding: Object.freeze({ ...value, workspaceHash: hashArtifactWorkspace(value.path!).workspaceHash }),
+    capabilities: Object.freeze(["read", "write", "review"] as const), hashes: hashArtifactWorkspace(value.path!), operationId,
+    expectedWorkspaceHash: hashArtifactWorkspace(value.path!).workspaceHash,
+    enqueueMutation: async <T>(_path: string, callback: () => T | Promise<T>): Promise<T> => callback(),
+    verifyEvidence: (references: readonly ArtifactEvidenceReferenceV1[]): readonly VerifiedArtifactEvidenceV1[] => references.map((reference) => {
+      if (reference.kind === "tool") return { kind: "tool" as const, attemptId: reference.attemptId, operation: "tool.test", inputHash: "a".repeat(64), resultHash: "b".repeat(64) };
+      if (reference.kind === "command") return { kind: "command" as const, attemptId: reference.attemptId, effect: "shell", operation: "command.test", inputHash: "a".repeat(64), resultHash: "b".repeat(64) };
+      const workspace = value.path!;
+      const metadata = JSON.parse(readFileSync(join(workspace, ".pi-hive", "workspace-v1.json"), "utf8")) as { planRoot: string };
+      let projectRoot = workspace;
+      for (let count = 0; count <= metadata.planRoot.split("/").length; count++) projectRoot = join(projectRoot, "..");
+      const content = readFileSync(join(projectRoot, reference.path));
+      const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+      if (digest !== reference.digest) throw new Error("Repository evidence hash is stale");
+      return { kind: "repository" as const, path: reference.path, digest, bytes: content.byteLength };
+    }),
+  });
+}
+async function invoke(adapter: ReturnType<typeof createMarkdownPlanAdapter>, value: ArtifactWorkspaceBinding, actionId: string, args: Record<string, unknown>, operationId: string) {
+  const selected = adapter.profiles.find((entry) => entry.id === value.profileId)!;
+  const action = selected.actions.find((entry) => entry.id === actionId)!;
+  assert.ok(action, `${actionId} is published by ${selected.id}`);
+  return adapter.executeAction!(context(value, operationId), action, args as never);
+}
+const planInput = {
+  title: "Add authentication",
+  summary: "Add bounded session authentication without changing unrelated APIs.",
+  tasks: [{ id: "session-store", text: "Implement the session store" }, { id: "auth-tests", text: "Add authentication tests" }],
+};
+
+test("Markdown plan finalizes the exact options/profile/checkpoint/action contract", () => {
+  assertArtifactAdapterContract(MARKDOWN_PLAN_ARTIFACT_ADAPTER);
+  assert.equal(MARKDOWN_PLAN_DEFAULT_ROOT, "plans");
+  assert.deepEqual(MARKDOWN_PLAN_CHECKPOINT_IDS, ["plan", "execution", "review"]);
+  assert.deepEqual(MARKDOWN_PLAN_ACTION_IDS, [
+    "markdown-plan.plan.read", "markdown-plan.plan.author", "markdown-plan.plan.update", "markdown-plan.validate",
+    "markdown-plan.tasks.list", "markdown-plan.tasks.complete", "markdown-plan.review.inspect",
+  ]);
+  const rows = {
+    author: { bindings: ["new", "existing", "either"], checkpoints: ["plan"], actions: MARKDOWN_PLAN_ACTION_IDS.slice(0, 4), mandatory: ["markdown-plan.plan.author", "markdown-plan.plan.update"] },
+    execute: { bindings: ["existing"], checkpoints: ["plan", "execution"], actions: [MARKDOWN_PLAN_ACTION_IDS[0], MARKDOWN_PLAN_ACTION_IDS[3], MARKDOWN_PLAN_ACTION_IDS[4], MARKDOWN_PLAN_ACTION_IDS[5]], mandatory: ["markdown-plan.tasks.complete"] },
+    review: { bindings: ["existing"], checkpoints: ["execution", "review"], actions: [MARKDOWN_PLAN_ACTION_IDS[0], MARKDOWN_PLAN_ACTION_IDS[3], MARKDOWN_PLAN_ACTION_IDS[4], MARKDOWN_PLAN_ACTION_IDS[6]], mandatory: [] },
+    lifecycle: { bindings: ["new", "existing", "either"], checkpoints: MARKDOWN_PLAN_CHECKPOINT_IDS, actions: MARKDOWN_PLAN_ACTION_IDS, mandatory: ["markdown-plan.plan.author", "markdown-plan.plan.update", "markdown-plan.tasks.complete"] },
+  } as const;
+  for (const [id, expected] of Object.entries(rows)) {
+    const actual = MARKDOWN_PLAN_PROFILES[id as keyof typeof MARKDOWN_PLAN_PROFILES];
+    assert.deepEqual(actual.bindings, expected.bindings);
+    assert.deepEqual(actual.checkpointIds, expected.checkpoints);
+    assert.deepEqual(actual.actions.map((action) => action.id), expected.actions);
+    assert.deepEqual(actual.actions.filter((action) => action.completion === "mandatory").map((action) => action.id), expected.mandatory);
+    assert.equal(Value.Check(actual.optionsSchema, {}), true);
+    assert.equal(Value.Check(actual.optionsSchema, { root: "docs/plans" }), true);
+    for (const invalid of [{ root: "../plans" }, { root: "/plans" }, { root: "plans\\bad" }, { extra: true }]) assert.equal(Value.Check(actual.optionsSchema, invalid), false);
+    const resolved = BUILTIN_ARTIFACT_REGISTRY.resolveProfile({ contractVersion: ARTIFACT_CONTRACT_VERSION, adapterId: "markdown-plan", adapterVersion: "1", profileId: id, profileVersion: "1" });
+    assert.equal(resolved.adapter.id, "markdown-plan");
+    assert.deepEqual(BUILTIN_ARTIFACT_REGISTRY.validateOptions(resolved.profile, { root: "docs/plans" }), { root: "docs/plans" });
+  }
+});
+
+test("workspace IDs map exactly to a default or configured contained plan root and list without latest selection", () => {
+  const root = project("workspace");
+  const adapter = createMarkdownPlanAdapter();
+  assert.throws(() => bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: "run", configuredBinding: "either", options: {} }), /explicit|latest/i);
+  assert.throws(() => bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "../escape" } }), /workspace ID/i);
+  const first = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: "run-1", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "add-auth" } });
+  assert.equal(first.path, join(root, "plans", "add-auth"));
+  const configured = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: "run-2", configuredBinding: "new", options: { root: "docs/plans" }, selection: { mode: "new", workspaceId: "other-plan" } });
+  assert.equal(configured.path, join(root, "docs", "plans", "other-plan"));
+  assert.throws(() => bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: "run-3", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "add-auth" } }), /collision|exists/i);
+  const listed = listPhysicalArtifactWorkspaces({ projectRoot: root, adapter, profile: profile("author"), options: {}, limit: 1 });
+  assert.deepEqual(listed.items.map((item) => item.id), ["add-auth"]);
+  assert.equal(listed.nextCursor, undefined);
+  assert.deepEqual(markdownPlanProtectedRoots({ root: "docs/plans" }), [{ path: "docs/plans", kind: "artifact" }]);
+  assert.deepEqual((adapter as any).protectedWorkspaceRoots?.({ projectRoot: root, profile: profile("author"), options: { root: "docs/plans" } }), [{ path: "docs/plans", kind: "artifact" }]);
+});
+
+test("canonical frontmatter, section structure, stable tasks, validation bounds, and revisions are enforced", async () => {
+  const root = project("format");
+  const adapter = createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:00.000Z" });
+  const value = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "add-auth" } });
+  await assertArtifactActionFilesystemContained({ filesystemRoot: root, workspacePath: value.path!, invoke: () => invoke(adapter, value, "markdown-plan.plan.author", planInput, "author-plan") });
+  const source = readFileSync(join(value.path!, "plan.md"), "utf8");
+  assert.match(source, /^---\nschema-version: 1\nplan-id: add-auth\ntitle: "Add authentication"\nrevision: 1\nlast-operation-id: author-plan\n---\n\n# Summary\n/u);
+  assert.match(source, /# Tasks\n\n- \[ \] session-store: Implement the session store\n- \[ \] auth-tests: Add authentication tests\n$/u);
+  const validation = await invoke(adapter, binding(root, "lifecycle"), "markdown-plan.validate", {}, "validate");
+  assert.deepEqual(validation.data, { valid: true, revision: 1, taskCount: 2, issues: [] });
+  await assert.rejects(() => invoke(adapter, binding(root, "lifecycle"), "markdown-plan.plan.author", planInput, "author-twice"), /already authored/i);
+  await assert.rejects(() => invoke(adapter, binding(root, "lifecycle"), "markdown-plan.plan.update", { ...planInput, tasks: [{ id: "same", text: "One" }, { id: "same", text: "Two" }] }, "duplicate"), /duplicate|task/i);
+  await invoke(adapter, binding(root, "lifecycle"), "markdown-plan.plan.update", { ...planInput, summary: "Revised summary." }, "revise-plan");
+  assert.match(readFileSync(join(value.path!, "plan.md"), "utf8"), /revision: 2\nlast-operation-id: revise-plan/u);
+  writeFileSync(join(value.path!, "plan.md"), readFileSync(join(value.path!, "plan.md"), "utf8").replace("# Summary", "# Unexpected"));
+  const invalid = await invoke(adapter, binding(root, "lifecycle"), "markdown-plan.validate", {}, "invalid");
+  assert.equal(invalid.data.valid, false);
+  assert.equal((await adapter.validateCompletion(binding(root, "lifecycle"))).state, "unsatisfied");
+});
+
+test("execution evidence is adapter-sidecar state bound to exact plan bytes and current repository evidence", async () => {
+  const root = project("evidence"); mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "src", "auth.ts"), "export const auth = true;\n");
+  const digest = `sha256:${createHash("sha256").update(readFileSync(join(root, "src", "auth.ts"))).digest("hex")}`;
+  const adapter = createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:00.000Z" });
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "add-auth" } });
+  await invoke(adapter, created, "markdown-plan.plan.author", planInput, "author");
+  let value = binding(root, "lifecycle");
+  const before = hashArtifactWorkspace(value.path!);
+  const planDigest = resolveCheckpointDigest(adapter.checkpointDescriptor!({ binding: value, checkpointId: "plan", hashes: before }), before).digest;
+  const executionBefore = resolveCheckpointDigest(adapter.checkpointDescriptor!({ binding: value, checkpointId: "execution", hashes: before }), before).digest;
+  const planBytes = readFileSync(join(value.path!, "plan.md"));
+  await invoke(adapter, value, "markdown-plan.tasks.complete", { taskId: "session-store", evidenceRefs: [{ kind: "command", attemptId: "command-1" }, { kind: "repository", path: "src/auth.ts", digest }] }, "complete-session");
+  assert.deepEqual(readFileSync(join(value.path!, "plan.md")), planBytes);
+  const sidecar = JSON.parse(readFileSync(join(value.path!, ".pi-hive", "evidence-v1.json"), "utf8"));
+  assert.equal(sidecar.tasks["session-store"].operationId, "complete-session");
+  const after = hashArtifactWorkspace(value.path!);
+  assert.equal(resolveCheckpointDigest(adapter.checkpointDescriptor!({ binding: value, checkpointId: "plan", hashes: after }), after).digest, planDigest);
+  assert.notEqual(resolveCheckpointDigest(adapter.checkpointDescriptor!({ binding: value, checkpointId: "execution", hashes: after }), after).digest, executionBefore);
+  assert.equal((await adapter.validateCompletion(value)).state, "unsatisfied");
+  await invoke(adapter, value, "markdown-plan.tasks.complete", { taskId: "auth-tests", evidenceRefs: [{ kind: "tool", attemptId: "tool-2" }, { kind: "repository", path: "src/auth.ts", digest }] }, "complete-tests");
+  assert.equal((await adapter.validateCompletion(value)).state, "satisfied");
+  writeFileSync(join(root, "src", "auth.ts"), "export const auth = false;\n");
+  assert.match((await adapter.validateCompletion(value)).issues?.join(" ") ?? "", /repository|stale|hash/i);
+  writeFileSync(join(root, "src", "auth.ts"), "export const auth = true;\n");
+  await invoke(adapter, value, "markdown-plan.plan.update", { ...planInput, summary: "Denied digest revision." }, "revision");
+  value = binding(root, "lifecycle");
+  assert.match((await adapter.validateCompletion(value)).issues?.join(" ") ?? "", /plan|revision|evidence|stale/i);
+});
+
+test("every published profile/binding completion combination enforces its exact authored and executed state", async () => {
+  const root = project("completion-matrix"); mkdirSync(join(root, "src")); writeFileSync(join(root, "src", "proof.ts"), "proof\n");
+  const adapter = createMarkdownPlanAdapter();
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "matrix" } });
+  const forProfile = (profileId: keyof typeof MARKDOWN_PLAN_PROFILES, configuredBinding: "new" | "existing" | "either") => Object.freeze({ ...binding(root, profileId, "matrix"), binding: configuredBinding });
+  const combinations = (profileId: keyof typeof MARKDOWN_PLAN_PROFILES) => profile(profileId).bindings.filter((entry): entry is "new" | "existing" | "either" => entry !== "none").map((entry) => forProfile(profileId, entry));
+  for (const profileId of ["author", "execute", "review", "lifecycle"] as const) {
+    for (const candidate of combinations(profileId)) assert.equal((await adapter.validateCompletion(candidate)).state, "unsatisfied", `${profileId}/${candidate.binding} before authoring`);
+  }
+  await invoke(adapter, created, "markdown-plan.plan.author", { ...planInput, tasks: [{ id: "proof", text: "Prove completion" }] }, "matrix-author");
+  for (const candidate of combinations("author")) assert.equal((await adapter.validateCompletion(candidate)).state, "satisfied", `author/${candidate.binding} after authoring`);
+  for (const profileId of ["execute", "review", "lifecycle"] as const) for (const candidate of combinations(profileId)) assert.equal((await adapter.validateCompletion(candidate)).state, "unsatisfied", `${profileId}/${candidate.binding} before evidence`);
+  const digest = `sha256:${createHash("sha256").update(readFileSync(join(root, "src", "proof.ts"))).digest("hex")}`;
+  const lifecycleBinding = forProfile("lifecycle", "either");
+  await invoke(adapter, lifecycleBinding, "markdown-plan.tasks.complete", { taskId: "proof", evidenceRefs: [{ kind: "tool", attemptId: "tool-proof" }, { kind: "repository", path: "src/proof.ts", digest }] }, "matrix-complete");
+  for (const profileId of ["execute", "review", "lifecycle"] as const) for (const candidate of combinations(profileId)) assert.equal((await adapter.validateCompletion(candidate)).state, "satisfied", `${profileId}/${candidate.binding} after evidence`);
+  const listed = await invoke(adapter, forProfile("execute", "existing"), "markdown-plan.tasks.list", {}, "matrix-list");
+  assert.deepEqual(listed.data.tasks, [{ taskId: "proof", text: "Prove completion", completed: true, evidenceRefCount: 2 }]);
+  const completeAction = profile("lifecycle").actions.find((entry) => entry.id === "markdown-plan.tasks.complete")!;
+  const recovery = adapter.reconcileAction({ binding: lifecycleBinding, hashes: hashArtifactWorkspace(lifecycleBinding.path!), operation: { operationId: "matrix-complete", actionId: completeAction.id, inputHash: "a", expectedWorkspaceHash: lifecycleBinding.workspaceHash!, intentAt: "2026-01-01T00:00:00.000Z" } }, completeAction);
+  assert.equal(recovery.state, "applied");
+});
+
+test("generic file tools reserve default and configured Markdown roots while facade mutations remain the owner", () => {
+  const root = project("reserved");
+  mkdirSync(join(root, "plans", "a"), { recursive: true }); writeFileSync(join(root, "plans", "a", "plan.md"), "x");
+  mkdirSync(join(root, "docs", "plans", "b"), { recursive: true }); writeFileSync(join(root, "docs", "plans", "b", "plan.md"), "x");
+  const capabilities = normalizeCapabilities({ filesystem: [{ path: ".", operations: ["read", "create", "update", "delete"] }] });
+  const effective = { workflowId: "delivery", nodeId: "root", agentId: "root", capabilities, provenance: {}, tools: [], budgets: {}, skills: [], knowledge: [], directMemberIds: [] } as unknown as EffectiveNodePolicy;
+  const resolved = BUILTIN_ARTIFACT_REGISTRY.resolveProfile({ contractVersion: ARTIFACT_CONTRACT_VERSION, adapterId: "markdown-plan", adapterVersion: "1", profileId: "author", profileVersion: "1" });
+  const policy = compileFilesystemPolicy({ projectRoot: root, effectivePolicy: effective, artifact: { resolved, options: { root: "docs/plans" } } } as any);
+  for (const path of ["plans/a/plan.md", "docs/plans/b/plan.md"]) {
+    const result = authorizeFilesystemOperation(policy, { operation: "update", path });
+    assert.equal(result.ok, false); assert.equal(result.code, "FILESYSTEM_PROTECTED");
+  }
+});
+
+test("Markdown plan bounded failure, pagination, handoff, and recovery branches fail closed", async () => {
+  const root = project("edges");
+  const adapter = createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:00.000Z" });
+  for (const options of [{ root: ".pi/plans" }, { root: "openspec/plans" }, { root: "../plans" }, { unknown: true }]) {
+    assert.throws(() => markdownPlanProtectedRoots(options as never), /option|root|invalid/i);
+  }
+  const absent = project("absent-list");
+  assert.deepEqual(listPhysicalArtifactWorkspaces({ projectRoot: absent, adapter, profile: profile("author"), limit: 2 }), { items: [] });
+  assert.equal(adapter.workspaceLifecycle!.resolve({ projectRoot: absent, profileId: "author", workspaceId: "missing", options: {} }), undefined);
+  assert.throws(() => (adapter as any).protectedWorkspaceRoots({ projectRoot: root, profile: {}, options: {} }), /profile/i);
+  for (const id of ["alpha", "beta", "gamma"]) {
+    bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("author"), runId: `run-${id}`, configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: id } });
+  }
+  const first = listPhysicalArtifactWorkspaces({ projectRoot: root, adapter, profile: profile("author"), limit: 1 });
+  assert.deepEqual(first.items.map((entry) => entry.id), ["alpha"]); assert.ok(first.nextCursor);
+  const second = listPhysicalArtifactWorkspaces({ projectRoot: root, adapter, profile: profile("author"), limit: 1, cursor: first.nextCursor });
+  assert.deepEqual(second.items.map((entry) => entry.id), ["beta"]); assert.ok(second.nextCursor);
+  assert.throws(() => listPhysicalArtifactWorkspaces({ projectRoot: root, adapter, profile: profile("author"), limit: 1, cursor: "bad" }), /cursor/i);
+  assert.throws(() => listPhysicalArtifactWorkspaces({ projectRoot: root, adapter, profile: profile("author"), limit: 1, cursor: "markdown-plan-v1:99" }), /stale/i);
+
+  let value = binding(root, "author", "alpha");
+  const empty = await adapter.status({ binding: value, capabilities: ["read"], hashes: hashArtifactWorkspace(value.path!) }, { limit: 1 });
+  assert.equal(empty.status, "blocked"); assert.equal(empty.actions.some((entry) => !entry.available), true);
+  const unread = await invoke(adapter, value, "markdown-plan.plan.read", {}, "read-empty");
+  assert.ok(Array.isArray(unread.data.issues));
+  await invoke(adapter, value, "markdown-plan.plan.author", planInput, "recover-author");
+  value = binding(root, "author", "alpha");
+  const read = await invoke(adapter, value, "markdown-plan.plan.read", {}, "read-current");
+  assert.equal(read.data.revision, 1);
+  await assert.rejects(() => invoke(adapter, value, "markdown-plan.plan.read", { cursor: "bad" }, "read-bad-cursor"), /cursor/i);
+  await assert.rejects(() => invoke(adapter, value, "markdown-plan.plan.read", { cursor: "markdown-plan-read-v1:999999" }, "read-stale-cursor"), /stale/i);
+  assert.throws(() => adapter.status({ binding: value, capabilities: ["read"], hashes: hashArtifactWorkspace(value.path!) }, { limit: 1, cursor: "bad" }), /cursor/i);
+  assert.throws(() => adapter.status({ binding: value, capabilities: ["read"], hashes: hashArtifactWorkspace(value.path!) }, { limit: 1, cursor: "markdown-plan-status-v1:999999" }), /stale/i);
+  const authorAction = profile("author").actions.find((entry) => entry.id === "markdown-plan.plan.author")!;
+  const authorRecovery = adapter.reconcileAction({ binding: value, hashes: hashArtifactWorkspace(value.path!), operation: { operationId: "recover-author", actionId: authorAction.id, inputHash: "a", expectedWorkspaceHash: value.workspaceHash!, intentAt: "2026-01-01T00:00:00.000Z" } }, authorAction);
+  assert.equal(authorRecovery.state, "applied");
+  const unknownRecovery = adapter.reconcileAction({ binding: value, hashes: hashArtifactWorkspace(value.path!), operation: { operationId: "other", actionId: authorAction.id, inputHash: "a", expectedWorkspaceHash: value.workspaceHash!, intentAt: "2026-01-01T00:00:00.000Z" } }, authorAction);
+  assert.equal(unknownRecovery.state, "unknown");
+  assert.throws(() => adapter.checkpointDescriptor!({ binding: value, checkpointId: "unknown", hashes: hashArtifactWorkspace(value.path!) }), /checkpoint/i);
+  const lifecycle = adapter.workspaceLifecycle!;
+  assert.equal(lifecycle.validateHandoffReference!({ projectRoot: root, profileId: "author", reference: { workspaceId: "wrong", checkpoint: "plan", digest: `sha256:${"a".repeat(64)}` }, workspace: { id: "alpha", path: value.path! }, hashes: hashArtifactWorkspace(value.path!) }).state, "incompatible");
+
+  const execute = binding(root, "execute", "alpha");
+  const firstTasks = await invoke(adapter, execute, "markdown-plan.tasks.list", { limit: 1 }, "tasks-first");
+  assert.equal((firstTasks.data.tasks as unknown[]).length, 1); assert.ok(firstTasks.data.nextCursor);
+  const secondTasks = await invoke(adapter, execute, "markdown-plan.tasks.list", { limit: 1, cursor: firstTasks.data.nextCursor }, "tasks-second");
+  assert.equal((secondTasks.data.tasks as unknown[]).length, 1);
+  await assert.rejects(() => invoke(adapter, execute, "markdown-plan.tasks.list", { cursor: "bad" }, "tasks-invalid"), /cursor|schema/i);
+  await assert.rejects(() => invoke(adapter, execute, "markdown-plan.tasks.list", { cursor: "markdown-plan-tasks-v1:999999" }, "tasks-stale"), /stale/i);
+  const completeAction = profile("execute").actions.find((entry) => entry.id === "markdown-plan.tasks.complete")!;
+  await assert.rejects(() => Promise.resolve(adapter.executeAction!({ ...context(execute, "missing-verifier"), verifyEvidence: undefined }, completeAction, { taskId: "session-store", evidenceRefs: [{ kind: "tool", attemptId: "tool" }] })), /verification|evidence/i);
+  assert.equal((await adapter.validateCompletion(execute)).state, "unsatisfied");
+  writeFileSync(join(execute.path!, ".pi-hive", "evidence-v1.json"), "not-json\n");
+  assert.equal((await adapter.validateCompletion(execute)).state, "unsatisfied");
+});
+
+test("bounded status/review views expose plain data without raw HTML or human approval authority", async () => {
+  const root = project("view");
+  const adapter = createMarkdownPlanAdapter();
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "safe-view" } });
+  await invoke(adapter, created, "markdown-plan.plan.author", { ...planInput, tasks: [{ id: "safe", text: "Inspect <img src=x onerror=alert(1)> safely" }] }, "author");
+  const value = binding(root, "lifecycle", "safe-view");
+  const view = await adapter.status({ binding: value, capabilities: ["read", "write", "review"], hashes: hashArtifactWorkspace(value.path!) }, { limit: 20 });
+  assert.doesNotMatch(JSON.stringify(view), /<\/?(?:script|img)|react|dangerouslySetInnerHTML/iu);
+  assert.ok(Buffer.byteLength(JSON.stringify(view), "utf8") <= 65_536);
+  const review = await invoke(adapter, value, "markdown-plan.review.inspect", {}, "review");
+  assert.equal("decision" in review.data || "approved" in review.data, false);
+});
+
+test("status and plan reads paginate by JSON-escaped output bytes without making any legal plan unreadable", async () => {
+  const root = project("escaped-pages");
+  const adapter = createMarkdownPlanAdapter();
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "escaped-pages" } });
+  const tasks = Array.from({ length: 20 }, (_, index) => ({ id: `task-${index}`, text: `${String.fromCharCode(1)}${"x".repeat(1_800)}` }));
+  await invoke(adapter, created, "markdown-plan.plan.author", { title: "Escaped output", summary: `${String.fromCharCode(2)} escaped summary`, tasks }, "author-escaped");
+  const value = binding(root, "lifecycle", "escaped-pages");
+
+  const viewed = new Set<string>();
+  let statusCursor: string | undefined;
+  do {
+    const view = await adapter.status({ binding: value, capabilities: ["read", "write", "review"], hashes: hashArtifactWorkspace(value.path!) }, { limit: 40, ...(statusCursor ? { cursor: statusCursor } : {}) });
+    assert.ok(Buffer.byteLength(JSON.stringify(view), "utf8") <= 65_536);
+    for (const item of view.items) { viewed.add(item.id); assert.ok(item.ref); }
+    statusCursor = view.page.nextCursor;
+  } while (statusCursor);
+  assert.equal(viewed.size, tasks.length);
+
+  let source = "";
+  let readCursor: string | undefined;
+  do {
+    const result = await invoke(adapter, value, "markdown-plan.plan.read", readCursor ? { cursor: readCursor } : {}, `read-${source.length}`);
+    assert.ok(Buffer.byteLength(JSON.stringify(result), "utf8") <= 65_536);
+    source += String(result.data.source);
+    const page = result.data.page as { nextCursor?: string };
+    readCursor = page.nextCursor;
+  } while (readCursor);
+  assert.equal(source, readFileSync(join(value.path!, "plan.md"), "utf8"));
+});
+
+test("evidence sidecars fail closed instead of silently resetting invalid durable state", async () => {
+  const root = project("corrupt-evidence"); mkdirSync(join(root, "src")); writeFileSync(join(root, "src", "proof.ts"), "proof\n");
+  const adapter = createMarkdownPlanAdapter();
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "corrupt-evidence" } });
+  await invoke(adapter, created, "markdown-plan.plan.author", { ...planInput, tasks: [{ id: "proof", text: "Keep durable proof" }] }, "author");
+  const value = binding(root, "lifecycle", "corrupt-evidence");
+  const evidencePath = join(value.path!, ".pi-hive", "evidence-v1.json");
+  const corrupt = "{\"schemaVersion\":1,\"tasks\":BROKEN}\n";
+  writeFileSync(evidencePath, corrupt);
+  const digest = `sha256:${createHash("sha256").update(readFileSync(join(root, "src", "proof.ts"))).digest("hex")}`;
+  await assert.rejects(() => invoke(adapter, value, "markdown-plan.tasks.complete", { taskId: "proof", evidenceRefs: [{ kind: "tool", attemptId: "tool" }, { kind: "repository", path: "src/proof.ts", digest }] }, "must-not-reset"), /evidence|invalid|JSON/i);
+  assert.equal(readFileSync(evidencePath, "utf8"), corrupt);
+});
+
+test("sidecar structural and physical bounds cover the full 256 by 32 contract with strict node semantics", () => {
+  const worstCaseNodes = 7 + MARKDOWN_PLAN_LIMITS.tasks * (6 + MARKDOWN_PLAN_LIMITS.evidenceRefsPerTask * 7);
+  assert.ok(worstCaseNodes <= MARKDOWN_PLAN_LIMITS.sidecarNodes);
+  assert.ok(MARKDOWN_PLAN_LIMITS.sidecarBytes <= ARTIFACT_HASH_LIMITS.fileBytes);
+  const exactly2_048 = Array.from({ length: 2_047 }, () => null);
+  assert.equal((boundedJson(exactly2_048, "exact nodes", { bytes: 16_384, depth: 2, nodes: 2_048 }) as unknown[]).length, 2_047);
+  assert.throws(() => boundedJson([...exactly2_048, null], "extra node", { bytes: 16_384, depth: 2, nodes: 2_048 }), /structural limit/i);
+});
+
+test("task and evidence bounds accept N and reject N+1 while all 256 tasks can retain completion", async () => {
+  const root = project("maximum"); mkdirSync(join(root, "src")); writeFileSync(join(root, "src", "proof.ts"), "proof\n");
+  const adapter = createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:00.000Z" });
+  const created = bindPhysicalArtifactWorkspace({ projectRoot: root, adapter, profile: profile("lifecycle"), runId: "run", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "maximum" } });
+  const tasks = Array.from({ length: MARKDOWN_PLAN_LIMITS.tasks }, (_, index) => ({ id: `task-${index}`, text: `Task ${index}` }));
+  await invoke(adapter, created, "markdown-plan.plan.author", { title: "Maximum", summary: "Complete every bounded task.", tasks }, "author-maximum");
+  const value = binding(root, "lifecycle", "maximum");
+  const digest = `sha256:${createHash("sha256").update(readFileSync(join(root, "src", "proof.ts"))).digest("hex")}`;
+  for (const task of tasks) await invoke(adapter, value, "markdown-plan.tasks.complete", { taskId: task.id, evidenceRefs: [{ kind: "tool", attemptId: `tool-${task.id}` }, { kind: "repository", path: "src/proof.ts", digest }] }, `complete-${task.id}`);
+  assert.equal((await adapter.validateCompletion(value)).state, "satisfied");
+  const sidecar = readFileSync(join(value.path!, ".pi-hive", "evidence-v1.json"), "utf8");
+  assert.equal(Object.keys(JSON.parse(sidecar).tasks).length, MARKDOWN_PLAN_LIMITS.tasks);
+  assert.ok(Buffer.byteLength(sidecar, "utf8") <= MARKDOWN_PLAN_LIMITS.sidecarBytes);
+
+  const extraRoot = project("n-plus-one");
+  const extra = bindPhysicalArtifactWorkspace({ projectRoot: extraRoot, adapter, profile: profile("author"), runId: "run-extra", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "too-many" } });
+  await assert.rejects(() => invoke(adapter, extra, "markdown-plan.plan.author", { title: "Too many", summary: "Rejected.", tasks: [...tasks, { id: "one-extra", text: "Extra" }] }, "author-too-many"), /invalid|task|limit/i);
+
+  const bytesRoot = project("text-bytes");
+  const bytesWorkspace = bindPhysicalArtifactWorkspace({ projectRoot: bytesRoot, adapter, profile: profile("author"), runId: "run-bytes", configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "text-bytes" } });
+  await invoke(adapter, bytesWorkspace, "markdown-plan.plan.author", { title: "Bytes", summary: "Boundary.", tasks: [{ id: "exact", text: "x".repeat(MARKDOWN_PLAN_LIMITS.taskTextBytes) }] }, "author-exact");
+  await assert.rejects(() => invoke(adapter, bytesWorkspace, "markdown-plan.plan.update", { title: "Bytes", summary: "Boundary.", tasks: [{ id: "extra", text: "x".repeat(MARKDOWN_PLAN_LIMITS.taskTextBytes + 1) }] }, "update-extra"), /invalid|limit|task/i);
+});

--- a/tests/artifacts/artifact-registry-none.test.ts
+++ b/tests/artifacts/artifact-registry-none.test.ts
@@ -26,6 +26,16 @@ test("the artifact registry is immutable, built-in-only, and version exact", () 
   assert.equal(resolved.profile.id, "default");
   assert.equal(resolved.profile.optionsSchemaVersion, "1");
 
+  const markdown = BUILTIN_ARTIFACT_REGISTRY.resolveProfile({
+    contractVersion: ARTIFACT_CONTRACT_VERSION,
+    adapterId: "markdown-plan",
+    adapterVersion: ARTIFACT_PROFILE_VERSION,
+    profileId: "author",
+    profileVersion: ARTIFACT_PROFILE_VERSION,
+  });
+  assert.equal(markdown.adapter.id, "markdown-plan");
+  assert.deepEqual(BUILTIN_ARTIFACT_REGISTRY.validateOptions(markdown.profile, { root: "docs/plans" }), { root: "docs/plans" });
+
   const openspec = BUILTIN_ARTIFACT_REGISTRY.resolveProfile({
     contractVersion: ARTIFACT_CONTRACT_VERSION,
     adapterId: "openspec",

--- a/tests/capabilities/capability-filesystem-policy.test.ts
+++ b/tests/capabilities/capability-filesystem-policy.test.ts
@@ -100,7 +100,7 @@ test("all protected subsystem and credential roots override a broad generic gran
   const paths = [
     ".pi/hive/hive-config.yaml", ".pi/hive/workflows/build.yaml", ".pi/hive/agents/a.md", ".pi/hive/skills/x/SKILL.md",
     ".pi/hive/knowledge/shared/knowledge.md", ".pi/hive/sessions/run/journal.jsonl", ".pi/hive/telemetry/events.jsonl",
-    ".pi/hive/dashboard-auth/token", "openspec/changes/x/tasks.md", ".git/config", ".env.local", ".npmrc", "keys/id_ed25519",
+    ".pi/hive/dashboard-auth/token", "openspec/changes/x/tasks.md", "plans/change/plan.md", ".git/config", ".env.local", ".npmrc", "keys/id_ed25519",
     "custom/secret-store/token.json",
   ];
   for (const path of paths) {

--- a/tests/config/config-workflows.test.ts
+++ b/tests/config/config-workflows.test.ts
@@ -50,18 +50,20 @@ test("activation reachability checks mandatory completion actions but not option
   } finally { mandatory.cleanup(); }
 });
 
-test("reserved Markdown profiles quarantine at resolution rather than failing on first run", () => {
+test("implemented Markdown profiles activate with exact options and reachable mandatory actions", () => {
   const fixture = copyWorkflowFixture("artifact-free-debug");
   try {
     const path = join(fixture.projectRoot, ".pi/hive/workflows/debug-chat.yaml");
     const source = readFileSync(path, "utf8")
-      .replace("  adapter: none\n  profile: default\n  binding: none", "  adapter: markdown-plan\n  profile: author\n  binding: new")
+      .replace("  adapter: none\n  profile: default\n  binding: none\n  options: {}", "  adapter: markdown-plan\n  profile: author\n  binding: new\n  options: { root: docs/plans }")
       .replace("\nteam:\n", "\napprovals:\n  plan: required\n\nteam:\n");
     writeFileSync(path, source);
+    const agentPath = join(fixture.projectRoot, ".pi/hive/agents/debugger.md");
+    writeFileSync(agentPath, readFileSync(agentPath, "utf8").replace("  human-input: true", "  human-input: true\n  artifact: [read, write]"));
     const project = loadConfigProject(fixture.projectRoot); assert.equal(project.status, "configured");
     const result = resolveConfigWorkflows(project, loadConfigCatalogs(project));
-    assert.equal(result.workflows[0].status, "invalid");
-    assert.ok(result.workflows[0].diagnosticCodes.includes("ARTIFACT_ADAPTER_UNAVAILABLE"));
+    assert.equal(result.workflows[0].status, "valid");
+    assert.equal(result.workflows[0].diagnosticCodes.includes("ARTIFACT_ADAPTER_UNAVAILABLE"), false);
   } finally { fixture.cleanup(); }
 });
 

--- a/tests/policy/artifact-contracts.test.ts
+++ b/tests/policy/artifact-contracts.test.ts
@@ -36,7 +36,7 @@ test("artifact contract graph is exactly nine rows and deeply immutable", () => 
   assert.deepEqual(artifactProfileContract("openspec", "author")?.checkpoints, ["proposal", "design", "specs", "tasks"]);
 });
 
-test("artifact declarations require valid bindings, empty options, and exact checkpoint sets", () => {
+test("artifact declarations require valid bindings, profile options, and exact checkpoint sets", () => {
   for (const [adapter, profile, bindings, checkpoints] of rows) {
     for (const binding of bindings) {
       const approvals = Object.fromEntries(checkpoints.map((id) => [id, "required"]));
@@ -47,6 +47,8 @@ test("artifact declarations require valid bindings, empty options, and exact che
       assert.ok(validateArtifactDeclaration({ adapter, profile, binding: bindings[0], options: {} }, missing).codes.includes("WORKFLOW_CHECKPOINT_MISSING"));
     }
   }
+  assert.deepEqual(validateArtifactDeclaration({ adapter: "markdown-plan", profile: "author", binding: "new", options: { root: "docs/plans" } }, { plan: "required" }).codes, []);
+  assert.ok(validateArtifactDeclaration({ adapter: "markdown-plan", profile: "author", binding: "new", options: { root: "../plans" } }, { plan: "required" }).codes.includes("ARTIFACT_OPTIONS_UNKNOWN"));
   assert.ok(validateArtifactDeclaration({ adapter: "none", profile: "default", binding: "new", options: {} }, undefined).codes.includes("ARTIFACT_BINDING_INVALID"));
   assert.ok(validateArtifactDeclaration({ adapter: "none", profile: "default", binding: "none", options: { x: true } }, undefined).codes.includes("ARTIFACT_OPTIONS_UNKNOWN"));
   assert.ok(validateArtifactDeclaration({ adapter: "unknown", profile: "default", binding: "none", options: {} }, undefined).codes.includes("ARTIFACT_PROFILE_UNKNOWN"));


### PR DESCRIPTION
## Summary
- add Markdown plan author, execute, review, and lifecycle profiles
- keep human plan bytes stable while recording verified execution evidence in a sidecar
- enforce configurable protected roots, bounded views, approvals, leases, hashes, and recovery

## Validation
- Markdown adapter, split/lifecycle E2E, policy, and shared contract tests
- `just test-node-compat`
- `just coverage-core`
- `just verify`