### PR TITLE
feat(workflows): add durable human questions

### DIFF
--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 export const PACKAGE_BASELINES = Object.freeze({
   packedBytes: 605_461,
-  unpackedBytes: 2_164_548,
+  unpackedBytes: 2_366_282,
   reviewRawBytes: 12_625,
   reviewCompressedBytes: 4_304,
 });

--- a/src/artifacts/approvals.ts
+++ b/src/artifacts/approvals.ts
@@ -424,8 +424,11 @@ export class CheckpointApprovalService {
     return readWorkflowJournal(this.options.projectRoot, this.options.sessionId).find((event) => event.eventId === draft.eventId);
   }
 
-  private projectApprovalStatus(event: WorkflowEventEnvelope, status: Extract<OpenRunStatus, "running" | "waiting_for_human">): void {
+  private projectApprovalStatus(event: WorkflowEventEnvelope, _status: Extract<OpenRunStatus, "running" | "waiting_for_human">): void {
     if (!event.runId) throw new Error("Checkpoint status projection requires a run ID");
+    const status = readWorkflowJournal(this.options.projectRoot, this.options.sessionId)
+      .reduce(reduceRunLifecycle, createEmptyRunLifecycleState(this.options.sessionId)).latestRun?.status;
+    if (status !== "running" && status !== "waiting_for_human") throw new Error("Checkpoint status projection did not restore an open human-control state");
     this.options.onRunStatusChanged?.(event.runId, status, event.timestamp);
   }
 

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -145,7 +145,7 @@ export function resolveConfigWorkflows(project: ConfiguredProject, catalogs: Con
       artifactAvailable: resolvedArtifact !== undefined,
       artifactActionsAvailable: Boolean(resolvedArtifact?.adapter.executeAction && resolvedArtifact.profile.actions.length),
       knowledgeAvailable: false,
-      questionsAvailable: false,
+      questionsAvailable: true,
       projectModel: project.manifest.settings?.defaults?.agent?.model,
       projectThinking: project.manifest.settings?.defaults?.agent?.thinking,
       ...(persistedRootSelection?.workflowId === resource.id ? {

--- a/src/config/snapshot-store.ts
+++ b/src/config/snapshot-store.ts
@@ -303,7 +303,7 @@ function validatePayload(value: unknown): void {
     validateSerializedEffectiveAuthorityNodeV1(entry, {
       rootNodeId: workflowCoverage.rootNodeId,
       directMemberIds: workflowCoverage.directMembers.get(nodeIdForContext) ?? [],
-      subsystems: { artifact: workflowCoverage.artifactAvailable, artifactActions: workflowCoverage.artifactActionsAvailable, knowledge: false, questions: false },
+      subsystems: { artifact: workflowCoverage.artifactAvailable, artifactActions: workflowCoverage.artifactActionsAvailable, knowledge: false, questions: true },
     });
     const workflowNode = workflowCoverage.nodes.get(nodeIdForContext);
     const ceiling = workflowNode ? agentCapabilityCeilings.get(workflowNode.agentId) : undefined;

--- a/src/workflows/attempts.ts
+++ b/src/workflows/attempts.ts
@@ -48,9 +48,16 @@ export function attemptDescriptorFromCommandMetadata(value: CommandAttemptMetada
 }
 export interface AttemptResult { readonly ok: boolean; readonly value?: JsonValue; readonly error?: string; readonly transient?: boolean; readonly policyDenied?: boolean; readonly effectNotApplied?: boolean; readonly assistantOutputObserved?: boolean; readonly toolCallObserved?: boolean; readonly budgetExhausted?: readonly string[] }
 export type AttemptStatus = "pending" | "completed" | "failed" | "unknown_side_effect";
+export interface AttemptConsumerReceiptBinding {
+  readonly deliveryIds: readonly string[]; readonly promptHash: string; readonly transcriptRef: string;
+}
 export interface PersistedAttempt {
   readonly attemptId: string; readonly correlationId: string; readonly nodeId: string; readonly operation: string;
-  readonly inputHash: string; readonly descriptor: AttemptDescriptor; readonly status: AttemptStatus;
+  readonly inputHash: string; readonly replayInputHash: string; readonly descriptor: AttemptDescriptor;
+  /** Immutable binding known at intent publication; used for exact replay identity. */
+  readonly intentConsumerReceipt?: AttemptConsumerReceiptBinding;
+  /** Final binding, atomically extended by deliveries created during a successful dispatch. */
+  readonly consumerReceipt?: AttemptConsumerReceiptBinding; readonly status: AttemptStatus;
   readonly startedAt: string; readonly startedSequence: number; readonly result?: AttemptResult;
   readonly resultSequence?: number; readonly recovery: "none" | "safe-retry" | "reconcile-required";
   readonly reconciliation?: "applied" | "not-applied"; readonly diagnostic?: string;
@@ -58,12 +65,22 @@ export interface PersistedAttempt {
 export interface AttemptState { readonly sessionId: string; readonly runId: string; readonly attempts: Readonly<Record<string, PersistedAttempt>> }
 export interface BeginAttemptInput {
   readonly attemptId: string; readonly correlationId: string; readonly nodeId: string; readonly operation: string;
-  readonly input: unknown; readonly descriptor: AttemptDescriptor;
+  readonly input: unknown; readonly replayInput?: unknown; readonly descriptor: AttemptDescriptor; readonly consumerReceipt?: AttemptConsumerReceiptBinding;
 }
 export type BeginAttemptResult = Readonly<{ state: "started"; attempt: PersistedAttempt }> | Readonly<{ state: "pending"; attempt: PersistedAttempt }> | Readonly<{ state: "completed"; attempt: PersistedAttempt; result: AttemptResult }>;
 export interface AttemptRuntimeOptions { readonly projectRoot: string; readonly projectId: string; readonly sessionId: string; readonly runId: string; readonly now?: () => string }
 export interface ConservativeRetryInput<T> {
   readonly correlationId: string; readonly nodeId: string; readonly operation: string; readonly input: unknown; readonly descriptor: TrustedAttemptDescriptor;
+  readonly consumerReceipt?: AttemptConsumerReceiptBinding;
+  /** Projection-independent identity used only to replay an explicitly recovered successful consumer attempt. */
+  readonly replayInput?: unknown;
+  readonly recoveryAttemptId?: string;
+  /** Exact durable final binding of the explicitly selected recovery attempt. */
+  readonly recoveryConsumerReceipt?: AttemptConsumerReceiptBinding;
+  /** Pure snapshot taken after dispatch; its binding is atomically published with a successful result. */
+  readonly consumerReceiptAfterDispatch?: (attemptId: string) => AttemptConsumerReceiptBinding | undefined;
+  /** Runs only after a successful attempt result is durable, including cache replay. */
+  readonly onConsumerCompleted?: (attemptId: string, binding: AttemptConsumerReceiptBinding) => void | Promise<void>;
   readonly dispatch: (context: Readonly<{ attemptId: string; correlationId: string; ordinal: number }>) => T | Promise<T>;
   readonly sleep?: (milliseconds: number) => void | Promise<void>; readonly random?: () => number;
 }
@@ -92,6 +109,25 @@ function recoveryFor(value: AttemptDescriptor): PersistedAttempt["recovery"] {
   if (value.effect === "model") return "reconcile-required";
   if (isTrustedReadOnlyRetry(value)) return "safe-retry";
   return value.readOnly && value.idempotent && !["network", "approval", "question", "delegation"].includes(value.effect) ? "safe-retry" : "reconcile-required";
+}
+function consumerReceipt(value: unknown): AttemptConsumerReceiptBinding | undefined {
+  if (value === undefined) return undefined;
+  if (!plainRecord(value)) throw new Error("Attempt consumer receipt binding is invalid");
+  exactKeys(value, ["deliveryIds", "promptHash", "transcriptRef"], [], "Attempt consumer receipt binding");
+  if (!Array.isArray(value.deliveryIds) || value.deliveryIds.length > 128 || new Set(value.deliveryIds).size !== value.deliveryIds.length) throw new Error("Attempt consumer receipt delivery IDs are invalid");
+  const deliveryIds = value.deliveryIds.map((id) => boundedId(id, "Attempt consumer receipt delivery ID"));
+  if (typeof value.promptHash !== "string" || !/^[0-9a-f]{64}$/u.test(value.promptHash)) throw new Error("Attempt consumer receipt prompt hash is invalid");
+  return deepFreeze({ deliveryIds, promptHash: value.promptHash, transcriptRef: boundedText(value.transcriptRef, "Attempt consumer transcript reference", 2_048) });
+}
+function finalConsumerReceipt(intent: AttemptConsumerReceiptBinding | undefined, value: unknown): AttemptConsumerReceiptBinding | undefined {
+  const final = consumerReceipt(value);
+  if (!intent) return final;
+  if (!final) return intent;
+  if (final.promptHash !== intent.promptHash || final.transcriptRef !== intent.transcriptRef
+    || intent.deliveryIds.some((deliveryId) => !final.deliveryIds.includes(deliveryId))) {
+    throw new Error("Attempt final consumer receipt must preserve its immutable intent binding");
+  }
+  return final;
 }
 function payload(event: WorkflowEventEnvelope): Record<string, unknown> {
   if (!plainRecord(event.payload) || event.payload.formatVersion !== FORMAT_VERSION) throw new Error("Attempt event payload is invalid");
@@ -135,8 +171,12 @@ export function reduceAttemptState(state: AttemptState, event: WorkflowEventEnve
     const operation = boundedText(data.operation, "Attempt operation", 1_024);
     if (typeof data.inputHash !== "string" || !/^[a-f0-9]{64}$/u.test(data.inputHash)) throw new Error("Attempt input hash is invalid");
     const parsedDescriptor = descriptor(data.descriptor);
+    const receipt = consumerReceipt(data.consumerReceipt);
+    const replayInputHash = data.replayInputHash ?? data.inputHash;
+    if (typeof replayInputHash !== "string" || !/^[a-f0-9]{64}$/u.test(replayInputHash)) throw new Error("Attempt replay input hash is invalid");
     const attempt: PersistedAttempt = Object.freeze({
-      attemptId, correlationId, nodeId, operation, inputHash: data.inputHash, descriptor: parsedDescriptor,
+      attemptId, correlationId, nodeId, operation, inputHash: data.inputHash, replayInputHash, descriptor: parsedDescriptor,
+      ...(receipt ? { intentConsumerReceipt: receipt, consumerReceipt: receipt } : {}),
       status: "pending", startedAt: event.timestamp, startedSequence: event.sequence, recovery: recoveryFor(parsedDescriptor),
     });
     return deepFreeze({ ...state, attempts: { ...state.attempts, [attemptId]: attempt } });
@@ -146,7 +186,9 @@ export function reduceAttemptState(state: AttemptState, event: WorkflowEventEnve
   if (event.type === "attempt.result.recorded") {
     if (event.producer !== "harness" || attempt.status !== "pending") throw new Error("Attempt result is unauthorized or duplicated");
     const result = parseResult(data.result);
-    return deepFreeze({ ...state, attempts: { ...state.attempts, [attemptId]: { ...attempt, status: result.ok ? "completed" : "failed", result, resultSequence: event.sequence, recovery: "none" } } });
+    const receipt = result.ok ? finalConsumerReceipt(attempt.intentConsumerReceipt, data.consumerReceipt) : attempt.consumerReceipt;
+    if (!result.ok && data.consumerReceipt !== undefined) throw new Error("Failed attempt result cannot extend a consumer receipt binding");
+    return deepFreeze({ ...state, attempts: { ...state.attempts, [attemptId]: { ...attempt, ...(receipt ? { consumerReceipt: receipt } : {}), status: result.ok ? "completed" : "failed", result, resultSequence: event.sequence, recovery: "none" } } });
   }
   if (event.type === "attempt.reconciliation.recorded") {
     if (event.producer !== "recovery" || (attempt.status !== "pending" && attempt.status !== "unknown_side_effect")) throw new Error("Attempt reconciliation is unauthorized or stale");
@@ -198,27 +240,47 @@ export class AttemptRuntime {
     const operation = boundedText(input.operation, "Attempt operation", 1_024);
     const parsedDescriptor = descriptor(input.descriptor);
     const hash = hashAttemptInput(input.input);
+    const replayInputHash = hashAttemptInput(input.replayInput ?? input.input);
+    const receipt = consumerReceipt(input.consumerReceipt);
     const existing = this.restore().attempts[attemptId];
     if (existing) {
-      if (existing.correlationId !== correlationId || existing.nodeId !== nodeId || existing.operation !== operation || existing.inputHash !== hash || canonicalJson(existing.descriptor) !== canonicalJson(parsedDescriptor)) throw new Error("Attempt ID reuse with different input or descriptor is rejected");
+      if (existing.correlationId !== correlationId || existing.nodeId !== nodeId || existing.operation !== operation || existing.inputHash !== hash || existing.replayInputHash !== replayInputHash || canonicalJson(existing.descriptor) !== canonicalJson(parsedDescriptor)
+        || canonicalJson(existing.intentConsumerReceipt ?? null) !== canonicalJson(receipt ?? null)) throw new Error("Attempt ID reuse with different input, receipt, or descriptor is rejected");
       if (existing.result) return Object.freeze({ state: "completed", attempt: existing, result: existing.result });
       return Object.freeze({ state: "pending", attempt: existing });
     }
-    this.append("attempt.intent.recorded", { attemptId, correlationId, nodeId, operation, inputHash: hash, descriptor: parsedDescriptor as unknown as JsonValue }, "harness");
+    this.append("attempt.intent.recorded", { attemptId, correlationId, nodeId, operation, inputHash: hash, replayInputHash, descriptor: parsedDescriptor as unknown as JsonValue, ...(receipt ? { consumerReceipt: receipt as unknown as JsonValue } : {}) }, "harness");
     return Object.freeze({ state: "started", attempt: this.restore().attempts[attemptId] });
   }
-  complete(attemptId: string, result: AttemptResult): AttemptResult {
+  complete(attemptId: string, result: AttemptResult, completedConsumerReceipt?: AttemptConsumerReceiptBinding): AttemptResult {
     const parsed = parseResult(result);
     const existing = this.restore().attempts[attemptId];
     if (!existing) throw new Error("Attempt completion has no intent");
+    const receipt = parsed.ok ? finalConsumerReceipt(existing.intentConsumerReceipt, completedConsumerReceipt) : undefined;
+    if (!parsed.ok && completedConsumerReceipt !== undefined) throw new Error("Failed attempt completion cannot bind consumer deliveries");
     if (existing.result) {
-      if (canonicalJson(existing.result) !== canonicalJson(parsed)) throw new Error("Attempt completion conflicts with the recorded result");
+      if (canonicalJson(existing.result) !== canonicalJson(parsed) || canonicalJson(existing.consumerReceipt ?? null) !== canonicalJson(receipt ?? existing.intentConsumerReceipt ?? null)) {
+        throw new Error("Attempt completion conflicts with the recorded result or consumer receipt");
+      }
       return existing.result;
     }
-    this.append("attempt.result.recorded", { attemptId, result: parsed as unknown as JsonValue }, "harness");
+    this.append("attempt.result.recorded", { attemptId, result: parsed as unknown as JsonValue, ...(receipt ? { consumerReceipt: receipt as unknown as JsonValue } : {}) }, "harness");
     return this.restore().attempts[attemptId].result!;
   }
   fail(attemptId: string, error: unknown): AttemptResult { return this.complete(attemptId, errorResult(error)); }
+  replayCompletedConsumer(input: Readonly<{ attemptId: string; nodeId: string; operation: string; replayInput: unknown; descriptor: AttemptDescriptor; consumerReceipt: AttemptConsumerReceiptBinding }>): AttemptResult {
+    const attemptId = boundedId(input.attemptId, "Recovered attempt ID");
+    const attempt = this.restore().attempts[attemptId];
+    const parsedDescriptor = descriptor(input.descriptor);
+    const receipt = consumerReceipt(input.consumerReceipt);
+    if (!attempt || attempt.status !== "completed" || !attempt.result?.ok || !attempt.consumerReceipt || !receipt) throw new Error("Recovered consumer attempt is not a durable successful attempt");
+    if (attempt.nodeId !== boundedId(input.nodeId, "Recovered attempt node ID") || attempt.operation !== boundedText(input.operation, "Recovered attempt operation", 1_024)
+      || attempt.replayInputHash !== hashAttemptInput(input.replayInput) || canonicalJson(attempt.descriptor) !== canonicalJson(parsedDescriptor)
+      || canonicalJson(attempt.consumerReceipt) !== canonicalJson(receipt)) {
+      throw new Error("Recovered consumer attempt identity does not match its exact durable final delivery, prompt, and transcript binding");
+    }
+    return attempt.result;
+  }
   markDispatching(attemptId: string): void {
     const attempt = this.restore().attempts[attemptId];
     if (!attempt || attempt.result || this.dispatching.has(attemptId)) throw new Error("Attempt dispatch claim is stale or duplicated");
@@ -258,28 +320,46 @@ function thrownFromResult(result: AttemptResult): Error {
 export async function executeWithConservativeRetry<T>(runtime: AttemptRuntime, input: ConservativeRetryInput<T>): Promise<T> {
   boundedId(input.correlationId, "Retry correlation ID");
   const parsedDescriptor = requireTrustedDescriptor(input.descriptor);
+  if (input.recoveryAttemptId !== undefined) {
+    const recoveryBinding = consumerReceipt(input.recoveryConsumerReceipt ?? input.consumerReceipt);
+    if (!recoveryBinding) throw new Error("Recovered consumer attempt requires its exact durable final delivery, prompt, and transcript binding");
+    const recovered = runtime.replayCompletedConsumer({
+      attemptId: input.recoveryAttemptId, nodeId: input.nodeId, operation: input.operation,
+      replayInput: input.replayInput ?? input.input, descriptor: parsedDescriptor, consumerReceipt: recoveryBinding,
+    });
+    await input.onConsumerCompleted?.(input.recoveryAttemptId, recoveryBinding);
+    return recovered.value as T;
+  }
   const retries = retryLimit(parsedDescriptor);
   const sleep = input.sleep ?? ((ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); }));
   const random = input.random ?? Math.random;
   for (let ordinal = 1; ordinal <= retries + 1; ordinal++) {
     const attemptId = stableAttemptId(input.correlationId, ordinal);
-    const begun = runtime.begin({ attemptId, correlationId: input.correlationId, nodeId: input.nodeId, operation: input.operation, input: input.input, descriptor: parsedDescriptor });
+    const begun = runtime.begin({ attemptId, correlationId: input.correlationId, nodeId: input.nodeId, operation: input.operation, input: input.input, ...(input.replayInput === undefined ? {} : { replayInput: input.replayInput }), descriptor: parsedDescriptor, ...(input.consumerReceipt ? { consumerReceipt: input.consumerReceipt } : {}) });
     if (begun.state === "pending") {
       if (begun.attempt.recovery === "reconcile-required") throw new Error(`Attempt ${attemptId} has an unknown side effect and requires reconciliation`);
       if (ordinal > retries) throw new Error(`Attempt ${attemptId} was interrupted and the conservative retry allowance is exhausted`);
     }
     if (begun.state === "completed") {
-      if (begun.result.ok) return begun.result.value as T;
+      if (begun.result.ok) {
+        const binding = begun.attempt.consumerReceipt ?? input.consumerReceipt;
+        if (input.onConsumerCompleted && !binding) throw new Error("Completed consumer settlement is missing its durable binding");
+        if (binding) await input.onConsumerCompleted?.(attemptId, binding);
+        return begun.result.value as T;
+      }
       if (!retryableFailure(begun.result, parsedDescriptor) || ordinal > retries) throw thrownFromResult(begun.result);
     } else if (begun.state === "started") {
       runtime.markDispatching(attemptId);
+      let completedValue!: T;
+      let completed = false;
       try {
         try {
-          const value = await input.dispatch({ attemptId, correlationId: input.correlationId, ordinal });
-          runtime.complete(attemptId, value === undefined
+          completedValue = await input.dispatch({ attemptId, correlationId: input.correlationId, ordinal });
+          const completedReceipt = input.consumerReceiptAfterDispatch?.(attemptId) ?? input.consumerReceipt;
+          runtime.complete(attemptId, completedValue === undefined
             ? { ok: true }
-            : { ok: true, value: boundedJson(value, "Attempt dispatch result", { bytes: 65_536, depth: 16, nodes: 4_096 }) });
-          return value;
+            : { ok: true, value: boundedJson(completedValue, "Attempt dispatch result", { bytes: 65_536, depth: 16, nodes: 4_096 }) }, completedReceipt);
+          completed = true;
         } catch (error) {
           const candidate = errorResult(error);
           const modelNoOutputProof = parsedDescriptor.effect === "model"
@@ -295,6 +375,16 @@ export async function executeWithConservativeRetry<T>(runtime: AttemptRuntime, i
         }
       } finally {
         runtime.clearDispatching(attemptId);
+      }
+      if (completed) {
+        // The arbitrary provider effect is not claimed exactly once: this hook
+        // is downstream of the durable successful attempt result. A crash
+        // before that result remains unknown_side_effect; a receipt fault after
+        // it is retryable without redispatching the provider.
+        const binding = runtime.restore().attempts[attemptId]?.consumerReceipt ?? input.consumerReceipt;
+        if (input.onConsumerCompleted && !binding) throw new Error("Completed consumer settlement is missing its durable binding");
+        if (binding) await input.onConsumerCompleted?.(attemptId, binding);
+        return completedValue;
       }
     }
     const rawRandom = random();

--- a/src/workflows/delegation.ts
+++ b/src/workflows/delegation.ts
@@ -30,6 +30,7 @@ const LIMITS = Object.freeze({
   statusPage: 100,
   statusObjectivePreviewBytes: 1_024,
   cursorBytes: 512,
+  questionContinuationTurns: 4_096,
 });
 
 export type DelegationContextReference = StructuredReference;
@@ -62,7 +63,9 @@ export interface PersistedDelegationTask {
   readonly provenance: DelegationProvenance; readonly creationSequence: number; readonly createdAt: string;
   readonly queueState: DelegationQueueState; readonly attempts: readonly DelegationAttempt[];
   readonly lastStartedSequence?: number; readonly suspendedOn?: readonly string[];
-  readonly resumedByResultSequence?: number; readonly result?: PersistedWorkerResult;
+  readonly suspendedOnQuestionIds?: readonly string[];
+  readonly resumedByResultSequence?: number; readonly resumedByQuestionSequence?: number; readonly resumedQuestionIds?: readonly string[];
+  readonly continuedQuestionResumeSequence?: number; readonly questionContinuationTurn?: number; readonly result?: PersistedWorkerResult;
   readonly resultDeliveryPreparedSequence?: number; readonly resultAcceptedSequence?: number;
 }
 export interface PreparedResultDelivery {
@@ -92,10 +95,19 @@ export interface DelegationAcceptanceAuthority {
     ok: false; reason: string; exhausted: readonly string[]; budgetExhausted: boolean; scope: "node" | "run";
   }>;
 }
+export interface DelegationStartAuthority {
+  /** Journal-locked run lifecycle/approval admission check for task.started. */
+  admit(events: readonly WorkflowEventEnvelope[], taskId: string): Readonly<{ ok: true }> | Readonly<{ ok: false; reason: string }>;
+}
+export interface DelegationTerminalAuthority {
+  /** Journal-locked question-delivery check for task.result.recorded. */
+  assertTaskMayTerminal(events: readonly WorkflowEventEnvelope[], taskId: string, status: WorkerResultInput["status"]): void;
+}
 export interface DelegationRuntimeOptions {
   readonly projectRoot: string; readonly projectId: string; readonly sessionId: string; readonly runId: string;
   readonly snapshot: ActivationSnapshotFileV1; readonly createTaskId?: () => string; readonly now?: () => string;
   readonly referenceAuthorizer?: ReferenceAuthorizer; readonly acceptanceAuthority?: DelegationAcceptanceAuthority;
+  readonly startAuthority?: DelegationStartAuthority; readonly terminalAuthority?: DelegationTerminalAuthority;
   /** Fault-injection seam for durable delegation publication recovery tests. */
   readonly journalFault?: (eventType: WorkflowEventEnvelope["type"], stage: JournalFaultStage) => void;
 }
@@ -117,7 +129,7 @@ export interface ResultDeliveryBatch {
   readonly items: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[];
 }
 
-const TRUSTED_CONTEXTS = new WeakMap<object, Readonly<{ sessionId: string; runId: string; bindingSequence: number }>>();
+const TRUSTED_CONTEXTS = new WeakMap<object, Readonly<{ sessionId: string; runId: string; bindingSequence: number; questionContinuationTurn: number }>>();
 const DELEGATION_EVENTS = new Set([
   "task.accepted",
   "task.started",
@@ -129,6 +141,8 @@ const DELEGATION_EVENTS = new Set([
   "scheduler.paused",
   "scheduler.resumed",
   "scheduler.closed",
+  "task.transition",
+  "question.transition",
 ]);
 
 function payloadRecord(event: WorkflowEventEnvelope): Record<string, unknown> {
@@ -263,6 +277,11 @@ function dependenciesAccepted(state: DelegationState, task: PersistedDelegationT
   return Boolean(task.suspendedOn?.length) && task.suspendedOn!.every((dependency) => state.tasks[dependency]?.resultAcceptedSequence !== undefined);
 }
 
+/** One shared recovery/scheduler predicate for every durable same-attempt resume marker. */
+export function isDelegationResumeReady(task: PersistedDelegationTask): boolean {
+  return task.queueState === "active" && (task.resumedByResultSequence !== undefined || task.resumedByQuestionSequence !== undefined);
+}
+
 function validateEventPayload(event: WorkflowEventEnvelope, payload: Record<string, unknown>): void {
   const specifications: Partial<Record<WorkflowEventEnvelope["type"], readonly [readonly string[], readonly string[]]>> = {
     "task.accepted": [["formatVersion", "taskId", "parentNodeId", "targetNodeId", "objective", "contextRefs", "deliverables", "provenance"], []],
@@ -272,6 +291,7 @@ function validateEventPayload(event: WorkflowEventEnvelope, payload: Record<stri
     "task.result.recorded": [["formatVersion", "taskId", "result"], []],
     "task.result.delivery.prepared": [["formatVersion", "deliveryId", "recipientNodeId", "taskIds"], []],
     "task.result.delivery.accepted": [["formatVersion", "deliveryId", "recipientNodeId"], []],
+    "task.transition": [["formatVersion", "operation", "taskId", "attemptId", "resumedByQuestionSequence", "questionIds"], ["questionContinuationTurn"]],
     "scheduler.paused": [["formatVersion", "reason"], []],
     "scheduler.resumed": [["formatVersion"], []],
     "scheduler.closed": [["formatVersion", "reason"], []],
@@ -286,7 +306,7 @@ export function reduceDelegationState(state: DelegationState, event: WorkflowEve
   if (event.sessionId !== state.sessionId) throw new Error("Delegation event session identity mismatch");
   if (event.runId !== state.runId) return state;
   const payload = payloadRecord(event);
-  validateEventPayload(event, payload);
+  if (event.type !== "question.transition") validateEventPayload(event, payload);
   const next = cloneState(state) as DelegationState;
   const mutable = next as unknown as {
     tasks: Record<string, PersistedDelegationTask>;
@@ -296,6 +316,77 @@ export function reduceDelegationState(state: DelegationState, event: WorkflowEve
     closedReason?: string;
   };
   const tasks = mutable.tasks;
+
+  if (event.type === "question.transition") {
+    const operation = payload.operation;
+    if (operation === "create") {
+      exactKeys(payload, ["formatVersion", "operation", "questionId", "nodeId", "definition", "provenance"], ["taskId", "taskAttemptId"], "Question delegation event");
+      if (payload.taskId === undefined) return state;
+      if (event.producer !== "runtime") throw new Error("Question task suspension lacks runtime authority");
+      const taskId = boundedId(payload.taskId, "Question task ID");
+      const questionId = boundedId(payload.questionId, "Question ID");
+      const nodeId = boundedId(payload.nodeId, "Question node ID");
+      const taskAttemptId = boundedId(payload.taskAttemptId, "Question task attempt ID");
+      const task = tasks[taskId];
+      const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+      if (!task || (task.queueState !== "active" && !questionSuspended) || task.targetNodeId !== nodeId || task.runId !== state.runId
+        || task.attempts.at(-1)?.attemptId !== taskAttemptId || task.suspendedOnQuestionIds?.includes(questionId)) throw new Error("Question can suspend only its exact journal-active task attempt");
+      tasks[taskId] = deepFreeze({
+        ...task,
+        queueState: "suspended",
+        suspendedOnQuestionIds: [...(task.suspendedOnQuestionIds ?? []), questionId],
+        ...(task.queueState === "active" ? { resumedQuestionIds: undefined } : {}),
+      });
+      return deepFreeze(next);
+    }
+    if (operation === "answer") {
+      exactKeys(payload, ["formatVersion", "operation", "questionId", "channel", "identity", "operationId", "inputHash", "value"], [], "Question answer delegation event");
+      const questionId = boundedId(payload.questionId, "Question ID");
+      const task = Object.values(tasks).find((candidate) => candidate.queueState === "suspended" && candidate.suspendedOnQuestionIds?.includes(questionId));
+      if (!task) return state;
+      const remaining = task.suspendedOnQuestionIds!.filter((id) => id !== questionId);
+      const resumedQuestionIds = [...(task.resumedQuestionIds ?? []), questionId];
+      tasks[task.taskId] = remaining.length
+        ? deepFreeze({ ...task, suspendedOnQuestionIds: remaining, resumedQuestionIds })
+        : deepFreeze({ ...task, queueState: "active", suspendedOnQuestionIds: undefined, resumedByQuestionSequence: event.sequence, resumedQuestionIds });
+      return deepFreeze(next);
+    }
+    if (operation === "task-delivery-consumed") {
+      exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "taskId", "questionIds", "promptHash", "attemptId", "transcriptRef"], [], "Task question delivery receipt delegation event");
+      const taskId = boundedId(payload.taskId, "Question receipt task ID");
+      const nodeId = boundedId(payload.nodeId, "Question receipt node ID");
+      const task = tasks[taskId];
+      const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+      if (!task || task.targetNodeId !== nodeId || (task.queueState !== "active" && !questionSuspended) || task.result) throw new Error("Task question delivery receipt requires its exact active or question-suspended task");
+      if (task.queueState === "active") tasks[taskId] = deepFreeze({ ...task, resumedByQuestionSequence: event.sequence });
+      return deepFreeze(next);
+    }
+    if (operation === "close-pending" || operation === "tool-answer-returned" || operation === "root-delivery-prepared" || operation === "root-delivery-consumed" || operation === "root-delivery-accepted"
+      || operation === "task-delivery-prepared" || operation === "task-delivery-accepted") return state;
+    throw new Error("Question delegation operation is unsupported");
+  }
+
+  if (event.type === "task.transition") {
+    if (event.producer !== "harness" || (payload.operation !== "question-continuation" && payload.operation !== "question-turn-advanced")) throw new Error("Task question continuation transition is unauthorized");
+    const taskId = boundedId(payload.taskId, "Question continuation task ID");
+    const attemptId = boundedId(payload.attemptId, "Question continuation attempt ID");
+    const resumedByQuestionSequence = payload.resumedByQuestionSequence;
+    const questionIds = stringArray(payload.questionIds, "Question continuation IDs", 128, 256);
+    const task = tasks[taskId];
+    if (!Number.isSafeInteger(resumedByQuestionSequence) || Number(resumedByQuestionSequence) < 1 || !questionIds.length || new Set(questionIds).size !== questionIds.length
+      || !task || task.queueState !== "active" || task.result || task.attempts.at(-1)?.attemptId !== attemptId
+      || task.resumedByQuestionSequence !== resumedByQuestionSequence) throw new Error("Task question continuation does not match its exact active resume marker");
+    if (payload.operation === "question-continuation") {
+      if (payload.questionContinuationTurn !== undefined) throw new Error("Task consumer replay settlement cannot change the continuation turn");
+      tasks[taskId] = deepFreeze({ ...task, continuedQuestionResumeSequence: Number(resumedByQuestionSequence) });
+      return deepFreeze(next);
+    }
+    const continuationTurn = payload.questionContinuationTurn;
+    if (!Number.isSafeInteger(continuationTurn) || Number(continuationTurn) < 1 || Number(continuationTurn) > LIMITS.questionContinuationTurns
+      || Number(continuationTurn) !== (task.questionContinuationTurn ?? 0) + 1) throw new Error("Task question continuation turn is invalid or exhausted");
+    tasks[taskId] = deepFreeze({ ...task, questionContinuationTurn: Number(continuationTurn) });
+    return deepFreeze(next);
+  }
 
   if (event.type === "scheduler.paused") {
     if (event.producer !== "harness" || mutable.schedulerStatus !== "running") throw new Error("Scheduler pause transition is invalid");
@@ -394,12 +485,16 @@ export function reduceDelegationState(state: DelegationState, event: WorkflowEve
   const task = tasks[taskId];
   if (!task) throw new Error(`Unknown delegation task ${taskId}`);
   if (event.type === "task.started") {
-    if (event.producer !== "harness" || queueHead(next, task.targetNodeId)?.taskId !== taskId) throw new Error("Delegation task cannot start out of FIFO order");
+    if (event.producer !== "harness" || !mutable.admissionOpen || mutable.schedulerStatus !== "running" || queueHead(next, task.targetNodeId)?.taskId !== taskId) throw new Error("Delegation task cannot start while admission is closed or out of FIFO order");
     if (Object.values(tasks).some((other) => other.taskId !== taskId && other.targetNodeId === task.targetNodeId && other.queueState === "active")) throw new Error("Delegation node already has an active task");
     const attemptId = boundedId(payload.attemptId, "Delegation attempt ID");
-    if (task.queueState === "active" && task.resumedByResultSequence !== undefined) {
+    if (task.queueState === "active" && (task.resumedByResultSequence !== undefined || task.resumedByQuestionSequence !== undefined)) {
       if (task.attempts.at(-1)?.attemptId !== attemptId) throw new Error("Delegation continuation must preserve the active attempt ID");
-      const { resumedByResultSequence: _resumed, ...continued } = task;
+      // A question resume marker remains authoritative until this same attempt
+      // either terminalizes or suspends again. In particular, a completed
+      // containing model attempt may still need retryable receipt/acceptance
+      // publication without being mistaken for unknown in-flight work.
+      const { resumedByResultSequence: _resultResume, ...continued } = task;
       tasks[taskId] = deepFreeze({ ...continued, lastStartedSequence: event.sequence });
     } else {
       if (task.queueState !== "queued") throw new Error("Delegation task cannot start outside queued or resumed state");
@@ -408,6 +503,7 @@ export function reduceDelegationState(state: DelegationState, event: WorkflowEve
         ...task,
         queueState: "active",
         suspendedOn: undefined,
+        suspendedOnQuestionIds: undefined,
         attempts: [...task.attempts, { attemptId, startedSequence: event.sequence, startedAt: event.timestamp }],
         lastStartedSequence: event.sequence,
       });
@@ -443,7 +539,7 @@ export function reduceDelegationState(state: DelegationState, event: WorkflowEve
     if ((task.queueState === "active" || task.queueState === "suspended") && (!activeAttemptId || result.attemptId !== activeAttemptId)) throw new Error("Worker result does not match the journal-active attempt");
     if (task.queueState === "queued" && result.attemptId !== undefined) throw new Error("Queued cancellation cannot claim a worker attempt");
     const attempts = task.attempts.map((attempt) => attempt.attemptId === result.attemptId ? { ...attempt, resultSequence: event.sequence } : attempt);
-    tasks[taskId] = deepFreeze({ ...task, queueState: "terminal", suspendedOn: undefined, attempts, result });
+    tasks[taskId] = deepFreeze({ ...task, queueState: "terminal", suspendedOn: undefined, suspendedOnQuestionIds: undefined, attempts, result });
   }
   return deepFreeze(next);
 }
@@ -473,9 +569,9 @@ export class DelegationRuntime {
     return replayWorkflowJournal(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), this.zero, reduceDelegationState).state;
   }
 
-  private context(nodeId: string, taskId?: string, attemptId?: string, bindingSequence = 0): DelegationExecutionContext {
+  private context(nodeId: string, taskId?: string, attemptId?: string, bindingSequence = 0, questionContinuationTurn = 0): DelegationExecutionContext {
     const context = Object.freeze({ nodeId, ...(taskId ? { taskId } : {}), ...(attemptId ? { attemptId } : {}) });
-    TRUSTED_CONTEXTS.set(context, { sessionId: this.options.sessionId, runId: this.options.runId, bindingSequence });
+    TRUSTED_CONTEXTS.set(context, { sessionId: this.options.sessionId, runId: this.options.runId, bindingSequence, questionContinuationTurn });
     return context;
   }
 
@@ -487,8 +583,8 @@ export class DelegationRuntime {
   workerExecutionContext(taskId: string, attemptId: string): DelegationExecutionContext {
     const task = this.restore().tasks[boundedId(taskId, "Worker task ID")];
     if (!task || task.queueState !== "active" || task.attempts.at(-1)?.attemptId !== attemptId) throw new Error("Trusted execution context requires the current active worker task");
-    const bindingSequence = Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0);
-    return this.context(task.targetNodeId, task.taskId, attemptId, bindingSequence);
+    const bindingSequence = Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0, task.resumedByQuestionSequence ?? 0);
+    return this.context(task.targetNodeId, task.taskId, attemptId, bindingSequence, task.questionContinuationTurn ?? 0);
   }
 
   private assertContext(context: DelegationExecutionContext): DelegationExecutionContext {
@@ -502,9 +598,10 @@ export class DelegationRuntime {
       return context;
     }
     const task = context.taskId ? state.tasks[context.taskId] : undefined;
-    const bindingSequence = task ? Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0) : -1;
+    const bindingSequence = task ? Math.max(task.lastStartedSequence ?? 0, task.resumedByResultSequence ?? 0, task.resumedByQuestionSequence ?? 0) : -1;
     if (!task || task.queueState !== "active" || task.targetNodeId !== context.nodeId
-      || task.attempts.at(-1)?.attemptId !== context.attemptId || authority.bindingSequence !== bindingSequence) {
+      || task.attempts.at(-1)?.attemptId !== context.attemptId || authority.bindingSequence !== bindingSequence
+      || authority.questionContinuationTurn !== (task.questionContinuationTurn ?? 0)) {
       throw new Error("Trusted worker execution context is no longer the active matching task attempt");
     }
     return context;
@@ -514,12 +611,28 @@ export class DelegationRuntime {
     this.assertContext(context);
   }
 
+  /** Narrow authority for later human_question calls in the same provider batch. */
+  assertQuestionBatchExecutionContext(context: DelegationExecutionContext): void {
+    if (!context || typeof context !== "object") throw new Error("A trusted execution context is required");
+    const authority = TRUSTED_CONTEXTS.get(context as object);
+    if (!authority || authority.sessionId !== this.options.sessionId || authority.runId !== this.options.runId || !context.taskId || !context.attemptId) {
+      throw new Error("A trusted worker question execution context is required");
+    }
+    const task = this.restore().tasks[context.taskId];
+    const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+    const answeredResume = task?.queueState === "active" && task.resumedByQuestionSequence !== undefined;
+    if (!task || (!questionSuspended && !answeredResume) || task.targetNodeId !== context.nodeId || task.result
+      || task.attempts.at(-1)?.attemptId !== context.attemptId || authority.questionContinuationTurn !== (task.questionContinuationTurn ?? 0)) {
+      throw new Error("Trusted worker question context is no longer the same suspended task attempt and continuation turn");
+    }
+  }
+
   private assertDelegatingContext(context: DelegationExecutionContext): DelegationExecutionContext {
     return this.assertContext(context);
   }
 
   private append(
-    type: "task.accepted" | "task.started" | "task.suspended" | "task.interrupted" | "task.result.recorded" | "task.result.delivery.prepared" | "task.result.delivery.accepted" | "scheduler.paused" | "scheduler.resumed" | "scheduler.closed",
+    type: "task.accepted" | "task.started" | "task.suspended" | "task.interrupted" | "task.result.recorded" | "task.result.delivery.prepared" | "task.result.delivery.accepted" | "task.transition" | "scheduler.paused" | "scheduler.resumed" | "scheduler.closed",
     payload: Record<string, JsonValue>,
     producer: "runtime" | "harness" | "recovery",
     validateLocked?: (events: readonly WorkflowEventEnvelope[]) => void,
@@ -582,11 +695,37 @@ export class DelegationRuntime {
   }
 
   start(taskId: string, attemptId: string): void {
-    this.append("task.started", { formatVersion: FORMAT_VERSION, taskId: boundedId(taskId, "Task ID"), attemptId: boundedId(attemptId, "Attempt ID") }, "harness");
+    const id = boundedId(taskId, "Task ID");
+    this.append("task.started", { formatVersion: FORMAT_VERSION, taskId: id, attemptId: boundedId(attemptId, "Attempt ID") }, "harness", (events) => {
+      const admission = this.options.startAuthority?.admit(events, id);
+      if (admission && !admission.ok) throw Object.assign(new Error(admission.reason), { admissionLost: true, effectNotApplied: true });
+    });
   }
 
   suspend(taskId: string, dependencyTaskIds: readonly string[]): void {
     this.append("task.suspended", { formatVersion: FORMAT_VERSION, taskId: boundedId(taskId, "Task ID"), dependencyTaskIds: [...dependencyTaskIds] }, "harness");
+  }
+
+  recordQuestionContinuation(taskId: string, attemptId: string, questionIds: readonly string[]): void {
+    const task = this.restore().tasks[boundedId(taskId, "Question continuation task ID")];
+    if (!task?.resumedByQuestionSequence) throw new Error("Question continuation requires an active resume marker");
+    this.append("task.transition", {
+      formatVersion: FORMAT_VERSION, operation: "question-continuation", taskId: task.taskId,
+      attemptId: boundedId(attemptId, "Question continuation attempt ID"), resumedByQuestionSequence: task.resumedByQuestionSequence,
+      questionIds: [...questionIds],
+    }, "harness");
+  }
+
+  advanceQuestionContinuationTurn(taskId: string, attemptId: string, questionIds: readonly string[]): void {
+    const task = this.restore().tasks[boundedId(taskId, "Question continuation task ID")];
+    if (!task?.resumedByQuestionSequence) throw new Error("Question continuation turn requires an active resume marker");
+    const continuationTurn = (task.questionContinuationTurn ?? 0) + 1;
+    if (continuationTurn > LIMITS.questionContinuationTurns) throw new Error("Question continuation turn bound is exhausted");
+    this.append("task.transition", {
+      formatVersion: FORMAT_VERSION, operation: "question-turn-advanced", taskId: task.taskId,
+      attemptId: boundedId(attemptId, "Question continuation attempt ID"), resumedByQuestionSequence: task.resumedByQuestionSequence,
+      questionIds: [...questionIds], questionContinuationTurn: continuationTurn,
+    }, "harness");
   }
 
   interrupt(taskId: string, reason: string): void {
@@ -597,7 +736,7 @@ export class DelegationRuntime {
   }
 
   reconcileActiveAfterTakeover(verified: boolean, reason = "Verified runtime takeover interrupted the prior attempt"): number {
-    const active = Object.values(this.restore().tasks).filter((task) => task.queueState === "active" && task.resumedByResultSequence === undefined);
+    const active = Object.values(this.restore().tasks).filter((task) => task.queueState === "active" && !isDelegationResumeReady(task));
     if (active.length && !verified) throw new Error("Active delegation recovery requires verified takeover");
     for (const task of active.sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))) {
       const attemptId = task.attempts.at(-1)?.attemptId;
@@ -618,7 +757,9 @@ export class DelegationRuntime {
     if (!task) throw new Error(`Unknown delegation task ${taskId}`);
     const result = normalizedResult(input, task, this.options.referenceAuthorizer);
     if (task.queueState !== "queued") result.attemptId = task.attempts.at(-1)!.attemptId;
-    this.append("task.result.recorded", { formatVersion: FORMAT_VERSION, taskId, result }, "harness");
+    this.append("task.result.recorded", { formatVersion: FORMAT_VERSION, taskId, result }, "harness", (events) => {
+      this.options.terminalAuthority?.assertTaskMayTerminal(events, taskId, input.status);
+    });
   }
 
   pauseAdmission(reason: string): void {
@@ -636,7 +777,7 @@ export class DelegationRuntime {
   cancelPending(reason: string): void {
     this.closeAdmission(reason);
     for (const task of Object.values(this.restore().tasks).sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))) {
-      if (task.queueState === "queued" || task.queueState === "suspended") {
+      if (task.queueState === "queued" || task.queueState === "suspended" || isDelegationResumeReady(task)) {
         this.recordResult(task.taskId, { status: "cancelled", summary: utf8Prefix(reason, LIMITS.resultSummaryBytes), outputRefs: [], evidenceRefs: [] });
       }
     }

--- a/src/workflows/orchestration.ts
+++ b/src/workflows/orchestration.ts
@@ -18,6 +18,8 @@ import { routeDirectMembers, type RouteDirectMembersInput, type RouteRecommendat
 import {
   CANCELLATION_TIMING,
   WorkflowRunLifecycle,
+  createEmptyRunLifecycleState,
+  reduceRunLifecycle,
   isOpenRunStatus,
   type ArtifactReference,
   type CancellationCoordinator,
@@ -28,6 +30,7 @@ import {
   type WorkflowRunLifecycleOptions,
 } from "./runs";
 import { DurableDelegationScheduler } from "./scheduler";
+import { replayWorkflowJournal } from "./replay";
 import {
   WorkerSessionPool,
   type WorkerPromptResponse,
@@ -50,14 +53,17 @@ import {
   attemptDescriptorFromCommandMetadata,
   attemptDescriptorFromTrustedTool,
   executeWithConservativeRetry,
+  type AttemptConsumerReceiptBinding,
   type TrustedAttemptDescriptor,
 } from "./attempts";
 import { ChangeAccountingRuntime, type ChangeAccountingOptions } from "./change-accounting";
 import { recoverUnknownSideEffects, type UnknownSideEffectRecoveryOptions, type UnknownSideEffectRecoveryReport } from "./recovery";
 import {
   assertCompactionPreservation,
+  assertLosslessDynamicPromptInputs,
   assembleRootWorkflowPrompt,
   buildCompactionPreservationBlock,
+  losslessDynamicPromptInputs,
   type WorkflowPromptAssembly,
 } from "./prompts";
 import { appendWorkflowEvent, readWorkflowJournal } from "./journal";
@@ -80,6 +86,9 @@ import { heartbeatCurrentRuntimeOwnership } from "./ownership";
 import { resolveContainedPath } from "../core/safe-path";
 import { CheckpointApprovalService, type CheckpointApprovalServiceOptions } from "../artifacts/approvals";
 import type { CheckpointPolicy } from "../artifacts/checkpoints";
+import { QuestionService, deriveQuestionRunStatus, type AcceptedQuestionForRoot, type QuestionControlAuthenticationRequest, type QuestionPresenter, type RootQuestionAnswerDelivery } from "./questions";
+import { QUESTION_LIMITS } from "./question-validation";
+import { utf8Prefix } from "./values";
 
 export interface RunOrchestrationServiceOptions {
   readonly projectRoot: string; readonly projectId: string; readonly sessionId: string;
@@ -104,16 +113,36 @@ export interface RunOrchestrationServiceOptions {
   /** Human control dependencies for the run-owned generic checkpoint authority. Omission denies every decision. */
   readonly checkpointApproval?: Partial<Pick<CheckpointApprovalServiceOptions, "authenticateControl" | "createRequestId" | "createDecisionId" | "fault">>;
   readonly verifiedTakeover?: () => boolean | Promise<boolean>;
-  readonly completion?: Omit<CompletionValidationHooks, "descendants">;
+  readonly completion?: Omit<CompletionValidationHooks, "descendants" | "questions" | "validateQuestionSet" | "validateRootQuestionDelivery">;
+  readonly questionControl?: Readonly<{ authenticateControl: (request: QuestionControlAuthenticationRequest) => string | undefined; presentLive?: QuestionPresenter; journalFault?: QuestionService["options"]["journalFault"] }>;
   /** Fault-injection seam for workflow lifecycle crash-recovery tests. */
   readonly journalFault?: WorkflowRunLifecycleOptions["journalFault"];
   readonly pauseAuthority: PauseCoordinator; readonly resumeAuthority: ResumeCoordinator;
   readonly cancellationAuthority: Pick<CancellationCoordinator, "terminateProcessTrees" | "capturePartialState" | "releaseLeases">;
 }
+export interface RootModelInvocation {
+  readonly promptContext: WorkflowPromptAssembly;
+  readonly rootQuestionDelivery?: RootQuestionAnswerDelivery;
+  readonly rootQuestionDeliveries?: readonly RootQuestionAnswerDelivery[];
+}
+interface ModelConsumerReceiptBinding {
+  readonly deliveryIds: readonly string[];
+  readonly promptHash: string;
+  readonly transcriptRef: string;
+  /** Pure durable-state snapshot, evaluated after provider dispatch and before result publication. */
+  readonly resolveDeliveryIds?: () => readonly string[];
+  readonly record: (attemptId: string, binding: AttemptConsumerReceiptBinding) => void;
+}
 export interface RootModelDispatchRequest {
   readonly correlationId: string; readonly operation: string; readonly input: unknown; readonly finalization?: boolean;
   readonly installCompactionBoundary?: (boundary: Readonly<{ preservation: string; validate(value: string): void }>) => void;
-  readonly dispatch: () => string | WorkerPromptResponse | Promise<string | WorkerPromptResponse>;
+  readonly dispatch: (invocation: RootModelInvocation) => string | WorkerPromptResponse | Promise<string | WorkerPromptResponse>;
+  /** Package-internal exact prompt/delivery binding prepared by the root service. */
+  readonly promptInvocation?: RootModelInvocation;
+  readonly consumerReceipt?: ModelConsumerReceiptBinding;
+  /** Package-internal durable replay identity, independent of prompt delivery projection. */
+  readonly replayInput?: unknown;
+  readonly recoveryAttemptId?: string;
 }
 export interface TrustedWorkflowDispatch extends WorkerTrustedDispatch {
   model(input: RootModelDispatchRequest): Promise<string | WorkerPromptResponse>;
@@ -135,7 +164,7 @@ interface RunResources {
   readonly budgets: BudgetRuntime; readonly attempts: AttemptRuntime; readonly changes: ChangeAccountingRuntime;
   readonly recoveryIssues: readonly string[];
   readonly dispatchRuntime: DispatchResources;
-  readonly scheduler: DurableDelegationScheduler; readonly workers: WorkerSessionPool;
+  readonly scheduler: DurableDelegationScheduler; readonly workers: WorkerSessionPool; readonly questions: QuestionService;
 }
 interface DispatchResources extends Pick<RunResources, "budgets" | "attempts" | "changes"> {
   readonly assertAdmission: () => void;
@@ -256,6 +285,20 @@ export class RunOrchestrationService {
     const completion: CompletionValidationHooks = {
       ...(options.completion ?? {}),
       descendants: () => this.descendantGate(),
+      questions: () => {
+        const run = this.lifecycle.restore().latestRun;
+        return run ? this.questionRuntimeFor(run.runId).completionGate() : Object.freeze({ state: "not-present" as const });
+      },
+      validateQuestionSet: (events, expectedQuestionIds) => {
+        const run = this.lifecycle.restore().latestRun;
+        if (!run) throw new Error("Question set validation requires a current run");
+        this.questionRuntimeFor(run.runId).assertPendingSet(events, expectedQuestionIds);
+      },
+      validateRootQuestionDelivery: (events) => {
+        const run = this.lifecycle.restore().latestRun;
+        if (!run) throw new Error("Root question delivery validation requires a current run");
+        this.questionRuntimeFor(run.runId).assertRootMayTerminal(events);
+      },
       adapter: async () => {
         const run = this.lifecycle.restore().latestRun;
         const builtin = selectedArtifact?.adapter && run?.artifactWorkspace
@@ -298,6 +341,11 @@ export class RunOrchestrationService {
         });
       },
       settleTerminal: async (settlement) => {
+        this.questionRuntimeFor(settlement.runId).closePending({
+          reason: `run ${settlement.status}`,
+          operationId: settlement.operationId,
+          expectedQuestionIds: settlement.closedQuestionIds,
+        });
         await this.settleTerminalResources(settlement.runId);
         this.releaseArtifactLease("finish");
         await options.completion?.settleTerminal?.(settlement);
@@ -543,24 +591,53 @@ export class RunOrchestrationService {
     });
   }
 
-  private rootPromptAssembly(runId?: string): WorkflowPromptAssembly {
+  private rootPromptAssembly(runId?: string, acceptedAnswers: readonly AcceptedQuestionForRoot[] = []): WorkflowPromptAssembly {
     const run = this.lifecycle.restore().latestRun;
     if (!run || (runId !== undefined && run.runId !== runId)) throw new Error("Root prompt requires the current workflow run");
     const handoff = run.handoffPacketHash ? handoffForRun(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), run.runId) : undefined;
     if (run.handoffPacketHash && handoff?.packetHash !== run.handoffPacketHash) throw new Error("Consumed handoff packet is missing or does not match the run marker");
-    return assembleRootWorkflowPrompt({
+    const answerPromptInputs = acceptedAnswers.flatMap((accepted) => losslessDynamicPromptInputs({
+      provenance: `human-answer:${accepted.questionId}:${accepted.answer.channel}:${accepted.answer.identity}`,
+      content: { questionId: accepted.questionId, definition: accepted.definition, answer: accepted.answer },
+      ref: accepted.transcriptRef,
+    }));
+    const assembly = assembleRootWorkflowPrompt({
       snapshot: this.options.snapshot,
       nodeId: rootNodeId(this.options.snapshot),
       sessionId: this.options.sessionId,
       runId: run.runId,
       ...(handoff ? { handoff: handoffPromptInput(handoff) } : {}),
-      runInputs: run.inputs.map((entry) => ({
-        source: "user" as const,
-        provenance: `run-input:${entry.sequence}:${entry.source}`,
-        content: entry.text,
-        ref: `run:${run.runId}/input:${entry.sequence}`,
-      })),
+      runInputs: [
+        ...run.inputs.map((entry) => ({
+          source: "user" as const,
+          provenance: `run-input:${entry.sequence}:${entry.source}`,
+          content: entry.text,
+          ref: `run:${run.runId}/input:${entry.sequence}`,
+        })),
+        ...answerPromptInputs,
+      ],
     });
+    assertLosslessDynamicPromptInputs(assembly, answerPromptInputs);
+    return assembly;
+  }
+
+  private rootAnswerPromptPage(runId: string, prepared: readonly RootQuestionAnswerDelivery[]): Readonly<{
+    deliveries: readonly RootQuestionAnswerDelivery[];
+    promptContext: WorkflowPromptAssembly;
+  }> {
+    const selected: RootQuestionAnswerDelivery[] = [];
+    let promptContext = this.rootPromptAssembly(runId);
+    for (const delivery of prepared) {
+      try {
+        const candidate = [...selected, delivery];
+        promptContext = this.rootPromptAssembly(runId, candidate.flatMap((entry) => entry.answers));
+        selected.push(delivery);
+      } catch (error) {
+        if (!selected.length || !String(error instanceof Error ? error.message : error).includes("Authority-relevant prompt data was omitted or truncated")) throw error;
+        break;
+      }
+    }
+    return Object.freeze({ deliveries: Object.freeze(selected), promptContext });
   }
 
   private rootCompactionBoundary(runId?: string): Readonly<{ preservation: string; validate(value: string): void }> {
@@ -578,7 +655,9 @@ export class RunOrchestrationService {
   private blockRunForBudget(resources: RunResources, nodeId: string, reason: string): void {
     const bounded = `budget_exhausted: ${reason}`.slice(0, 2_048);
     resources.scheduler.closeAdmission(bounded);
-    resources.scheduler.cancelPending(bounded);
+    // Descendants remain journal-live until terminal preparation freezes and
+    // closes the exact pending question set. Cancelling them here can make the
+    // question terminal guard reject before budget failure is prepared.
     resources.scheduler.abortOwnedWork(bounded, nodeId);
     this.trackCleanup(resources.workers.abortSessionsExcept(nodeId));
   }
@@ -623,12 +702,34 @@ export class RunOrchestrationService {
     inputText = this.modelInputText(request.input),
   ): Promise<string | WorkerPromptResponse> {
     resources.assertAdmission();
-    const rootBoundary = nodeId === rootNodeId(this.options.snapshot) ? this.rootCompactionBoundary() : undefined;
+    const rootPrompt = nodeId === rootNodeId(this.options.snapshot) ? request.promptInvocation?.promptContext ?? this.rootPromptAssembly() : undefined;
+    const rootBoundary = rootPrompt ? Object.freeze({
+      preservation: buildCompactionPreservationBlock(rootPrompt),
+      validate: (value: string) => assertCompactionPreservation(value, rootPrompt),
+    }) : undefined;
     if (rootBoundary) request.installCompactionBoundary?.(rootBoundary);
     try {
+      const attemptInput = request.consumerReceipt ? {
+        requestInput: request.input,
+        consumerReceipt: { deliveryIds: [...request.consumerReceipt.deliveryIds], promptHash: request.consumerReceipt.promptHash, transcriptRef: request.consumerReceipt.transcriptRef },
+      } : request.input;
+      const recoveredBinding = request.recoveryAttemptId
+        ? resources.attempts.restore().attempts[request.recoveryAttemptId]?.consumerReceipt
+        : undefined;
       const value = await executeWithConservativeRetry(resources.attempts, {
-        correlationId: request.correlationId, nodeId, operation: request.operation, input: request.input,
+        correlationId: request.correlationId, nodeId, operation: request.operation, input: attemptInput,
+        replayInput: request.replayInput ?? request.input,
+        ...(request.recoveryAttemptId ? { recoveryAttemptId: request.recoveryAttemptId, ...(recoveredBinding ? { recoveryConsumerReceipt: recoveredBinding } : {}) } : {}),
         descriptor: attemptDescriptorForModel(),
+        ...(request.consumerReceipt ? {
+          consumerReceipt: { deliveryIds: [...request.consumerReceipt.deliveryIds], promptHash: request.consumerReceipt.promptHash, transcriptRef: request.consumerReceipt.transcriptRef },
+          consumerReceiptAfterDispatch: () => ({
+            deliveryIds: [...new Set(request.consumerReceipt!.resolveDeliveryIds?.() ?? request.consumerReceipt!.deliveryIds)],
+            promptHash: request.consumerReceipt!.promptHash,
+            transcriptRef: request.consumerReceipt!.transcriptRef,
+          }),
+          onConsumerCompleted: (attemptId: string, binding: AttemptConsumerReceiptBinding) => request.consumerReceipt!.record(attemptId, binding),
+        } : {}),
         dispatch: async ({ attemptId, ordinal }) => {
           resources.assertAdmission();
           const admitted = resources.budgets.startModelAttempt(nodeId, `${request.correlationId}-provider-${ordinal}`, { finalization: request.finalization });
@@ -638,7 +739,7 @@ export class RunOrchestrationService {
           if (!active.ok) this.throwBudgetAdmission(resources, nodeId, active);
           let response: string | WorkerPromptResponse;
           try {
-            response = await request.dispatch();
+            response = await request.dispatch(request.promptInvocation ?? Object.freeze({ promptContext: rootPrompt! }));
             if (rootBoundary && record(response) && response.compactionSummary !== undefined) {
               if (typeof response.compactionSummary !== "string") throw Object.assign(new Error("Root compaction summary is invalid"), { assistantOutputObserved: true, effectNotApplied: true });
               rootBoundary.validate(response.compactionSummary);
@@ -747,6 +848,16 @@ export class RunOrchestrationService {
     }
   }
 
+  private questionRuntimeFor(runId: string): QuestionService {
+    if (this.current?.runId === runId) return this.current.questions;
+    return new QuestionService({
+      projectRoot: this.options.projectRoot, projectId: this.options.projectId, sessionId: this.options.sessionId, runId,
+      snapshot: this.options.snapshot, now: this.options.now,
+      authenticateControl: this.options.questionControl?.authenticateControl ?? (() => undefined),
+      journalFault: this.options.questionControl?.journalFault,
+    });
+  }
+
   private createResources(runId: string): RunResources {
     const budgets = this.budgetRuntimeFor(runId);
     const changes = this.changeAccountingFor(runId);
@@ -783,6 +894,7 @@ export class RunOrchestrationService {
         attempts.markUnknown(attempt.attemptId, "interrupted non-idempotent dispatch requires trusted reconciliation before admission");
       }
     }
+    const questions = this.questionRuntimeFor(runId);
     const runtime = new DelegationRuntime({
       projectRoot: this.options.projectRoot,
       projectId: this.options.projectId,
@@ -793,6 +905,13 @@ export class RunOrchestrationService {
       now: this.options.now,
       referenceAuthorizer: this.options.referenceAuthorizer,
       acceptanceAuthority: { admit: (events, parentNodeId) => budgets.admitDelegationAgainst(events, parentNodeId) },
+      startAuthority: { admit: (events) => {
+        const locked = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+        if (!locked || locked.runId !== runId || locked.status !== "running" || locked.cancellationRequested || locked.pendingTerminal
+          || locked.waitCauses?.includes("approval")) return Object.freeze({ ok: false as const, reason: "Task start admission lost to run lifecycle, cancellation, finalization, or approval state" });
+        return Object.freeze({ ok: true as const });
+      } },
+      terminalAuthority: { assertTaskMayTerminal: (events, taskId, status) => questions.assertTaskMayTerminal(events, taskId, status) },
     });
     const assertDispatchAdmission = (): void => {
       const run = this.lifecycle.restore().latestRun;
@@ -815,11 +934,21 @@ export class RunOrchestrationService {
       runId,
       snapshot: this.options.snapshot,
       factory: this.options.workerFactory,
-      dispatchModel: ({ task, text, invoke }) => this.dispatchModel(dispatchResources, task.targetNodeId, {
-        correlationId: `worker-model-${task.taskId}-${createHash("sha256").update(text).digest("hex").slice(0, 24)}`,
-        operation: "worker.provider.prompt", input: { taskId: task.taskId, promptHash: createHash("sha256").update(text).digest("hex") }, dispatch: invoke,
+      dispatchModel: ({ task, text, invoke, questionDeliveryIds, resolveQuestionDeliveryIds, promptHash, transcriptRef, onConsumerSuccess, questionContinuationReady }) => this.dispatchModel(dispatchResources, task.targetNodeId, {
+        correlationId: `worker-model-${task.taskId}-${promptHash.slice(0, 24)}-turn-${task.questionContinuationTurn ?? 0}`,
+        operation: "worker.provider.prompt", input: { taskId: task.taskId, promptHash, questionContinuationTurn: task.questionContinuationTurn ?? 0 }, replayInput: { taskId: task.taskId },
+        ...(questions.containingAttemptForTaskContinuation(task.taskId, task.resumedByQuestionSequence) ? { recoveryAttemptId: questions.containingAttemptForTaskContinuation(task.taskId, task.resumedByQuestionSequence) } : {}),
+        dispatch: async () => {
+          try { return await invoke(); }
+          catch (error) {
+            if (questionContinuationReady() && error && typeof error === "object") Object.assign(error, { effectNotApplied: true });
+            throw error;
+          }
+        },
+        consumerReceipt: { deliveryIds: questionDeliveryIds, promptHash, transcriptRef, resolveDeliveryIds: resolveQuestionDeliveryIds, record: onConsumerSuccess },
       }, text),
       dispatchTool: (task, input) => this.dispatchTool(dispatchResources, task.targetNodeId, input),
+      questions,
     });
     workers.rebuildBoundaries(Object.values(runtime.restore().tasks));
     const scheduler = new DurableDelegationScheduler({
@@ -827,7 +956,17 @@ export class RunOrchestrationService {
       maxParallel: Math.min(this.options.maxParallel, budgets.restore().limits.run.maxParallel),
       createAttemptId: this.options.createAttemptId,
       verifiedTakeover: this.options.verifiedTakeover,
-      onRecoveryReconciled: () => this.reconcileDurableNestedDeliveries(runtime),
+      onRecoveryReconciled: () => {
+        // Receipt-to-acceptance publication is retryable control settlement.
+        // It runs before task.started, so a fault cannot become a worker result
+        // or consume the durable same-attempt resume marker.
+        questions.reconcileAnswerDeliveryReceipts();
+        this.reconcileDurableNestedDeliveries(runtime);
+      },
+      canLaunch: () => {
+        const currentRun = this.lifecycle.restore().latestRun;
+        return currentRun?.runId === runId && currentRun.status === "running" && !(currentRun.waitCauses?.includes("approval") ?? false) && !currentRun.cancellationRequested && !currentRun.pendingTerminal;
+      },
       execute: async (task, control) => {
         const state = runtime.restore();
         const deliveredResults = (task.suspendedOn ?? []).flatMap((taskId) => {
@@ -847,7 +986,7 @@ export class RunOrchestrationService {
         workers.rebuildBoundaries(Object.values(runtime.restore().tasks));
       },
     });
-    const resources: RunResources = { runId, runtime, budgets, attempts, changes, recoveryIssues: Object.freeze(recoveryIssues), dispatchRuntime: dispatchResources, scheduler, workers };
+    const resources: RunResources = { runId, runtime, budgets, attempts, changes, recoveryIssues: Object.freeze(recoveryIssues), dispatchRuntime: dispatchResources, scheduler, workers, questions };
     const run = this.lifecycle.restore().latestRun;
     if (run?.runId === runId && run.pendingTerminal) this.failClosedForTerminal(resources);
     else this.reconcileDurableNestedDeliveries(runtime);
@@ -855,6 +994,14 @@ export class RunOrchestrationService {
   }
 
   private failClosedForTerminal(resources: RunResources): void {
+    const run = this.lifecycle.restore().latestRun;
+    if (run?.runId === resources.runId && run.pendingTerminal) {
+      resources.questions.closePending({
+        reason: `run ${run.pendingTerminal.status}`,
+        operationId: run.pendingTerminal.operationId,
+        expectedQuestionIds: run.pendingTerminal.closedQuestionIds,
+      });
+    }
     resources.scheduler.closeAdmission("workflow terminal settlement");
     resources.scheduler.cancelPending("workflow terminal settlement");
     resources.scheduler.abortOwnedWork("workflow terminal settlement");
@@ -922,7 +1069,7 @@ export class RunOrchestrationService {
     const resources = this.resources();
     const tasks = Object.values(resources.runtime.restore().tasks);
     const unsettled = tasks.filter((task) => task.queueState !== "terminal");
-    const undelivered = tasks.filter((task) => task.parentNodeId === resources.runtime.restore().rootNodeId && task.result && task.resultAcceptedSequence === undefined);
+    const undelivered = tasks.filter((task) => task.result && task.resultAcceptedSequence === undefined);
     if (!unsettled.length && !undelivered.length) return Object.freeze({ state: "satisfied" });
     return Object.freeze({
       state: "unsatisfied",
@@ -952,10 +1099,87 @@ export class RunOrchestrationService {
       if (this.lifecycle.restore().latestRun?.status !== "running") throw new Error("Workflow admission requires a running run");
       this.assertRecoveredForAdmission(resources);
     };
+    const isRootContext = context.nodeId === rootNodeId(this.options.snapshot);
+    const assertRootQuestionAdmission = (): void => {
+      if (!isRootContext) return;
+      const pending = Object.values(resources.questions.restore().questions)
+        .filter((question) => question.nodeId === context.nodeId && question.taskId === undefined && question.state === "pending");
+      if (pending.length) throw new Error(`Root dispatch is blocked by ${pending.length} pending durable human question(s)`);
+    };
+    const assertQuestionBatchAdmission = (toolCallId: string, batchCallIds: readonly string[]): void => {
+      if (!batchCallIds.includes(toolCallId) || new Set(batchCallIds).size !== batchCallIds.length) throw new Error("Human question call is not bound to its exact trusted assistant batch");
+      const prior = Object.values(resources.questions.restore().questions).some((question) => question.nodeId === context.nodeId
+        && question.taskId === context.taskId && question.taskAttemptId === context.attemptId
+        && question.provenance.toolCallId !== toolCallId && batchCallIds.includes(question.provenance.toolCallId));
+      if (!prior) {
+        assertAdmission();
+        assertRootQuestionAdmission();
+        return;
+      }
+      const run = this.lifecycle.restore().latestRun;
+      const delegation = resources.runtime.restore();
+      if (!run || run.runId !== resources.runId || run.status !== "running" || run.cancellationRequested || run.pendingTerminal
+        || this.current?.runId !== resources.runId || !delegation.admissionOpen || delegation.schedulerStatus !== "running") {
+        throw new Error("Same-batch human question admission requires the current running workflow attempt");
+      }
+      if (!isRootContext) resources.runtime.assertQuestionBatchExecutionContext(context);
+      this.assertRecoveredForAdmission(resources);
+    };
     const dispatch: TrustedWorkflowDispatch = Object.freeze({
       schemaVersion: 1 as const,
-      model: (input: RootModelDispatchRequest) => { assertAdmission(); return this.dispatchModel(resources.dispatchRuntime, context.nodeId, input); },
-      tool: <T>(input: WorkerTrustedToolDispatchRequest<T>) => { assertAdmission(); return this.dispatchTool(resources.dispatchRuntime, context.nodeId, input); },
+      model: async (input: RootModelDispatchRequest) => {
+        assertAdmission();
+        assertRootQuestionAdmission();
+        if (isRootContext) resources.questions.reconcileAnswerDeliveryReceipts();
+        const preparedRootQuestionDeliveries = isRootContext ? resources.questions.prepareRootAnswerDeliveries(context.nodeId) : [];
+        const rootAnswerPage = isRootContext ? this.rootAnswerPromptPage(resources.runId, preparedRootQuestionDeliveries) : undefined;
+        const rootQuestionDeliveries = rootAnswerPage?.deliveries ?? [];
+        const rootQuestionDelivery = rootQuestionDeliveries.length === 1 ? rootQuestionDeliveries[0] : undefined;
+        const promptContext = rootAnswerPage?.promptContext;
+        const promptHash = promptContext ? createHash("sha256").update(promptContext.text).digest("hex") : undefined;
+        const transcriptRef = isRootContext ? `run:${resources.runId}/node:${context.nodeId}/transcript` : undefined;
+        const { recoveryAttemptId: _untrustedRecoveryAttempt, replayInput: _untrustedReplayInput, ...publicInput } = input;
+        const recoveredRootAttempt = isRootContext && transcriptRef
+          ? Object.values(resources.attempts.restore().attempts).find((attempt) => attempt.correlationId === input.correlationId && attempt.nodeId === context.nodeId
+            && attempt.operation === input.operation && attempt.status === "completed" && attempt.result?.ok && attempt.consumerReceipt?.transcriptRef === transcriptRef)
+          : undefined;
+        const value = await this.dispatchModel(resources.dispatchRuntime, context.nodeId, {
+          ...publicInput,
+          replayInput: input.input,
+          ...(recoveredRootAttempt ? { recoveryAttemptId: recoveredRootAttempt.attemptId } : {}),
+          ...(promptContext ? { promptInvocation: Object.freeze({ promptContext, ...(rootQuestionDelivery ? { rootQuestionDelivery } : {}), ...(rootQuestionDeliveries.length ? { rootQuestionDeliveries } : {}) }) } : {}),
+          ...(promptHash && transcriptRef ? { consumerReceipt: {
+            deliveryIds: rootQuestionDeliveries.map((delivery) => delivery.deliveryId), promptHash, transcriptRef,
+            resolveDeliveryIds: () => {
+              const deliveries = resources.questions.preparedRootAnswerDeliveries(context.nodeId);
+              return [...new Set(deliveries.filter((delivery) => rootQuestionDeliveries.some((candidate) => candidate.deliveryId === delivery.deliveryId)
+                || resources.questions.rootAnswerDeliveryReturnedByTool(delivery)).map((delivery) => delivery.deliveryId))];
+            },
+            record: (attemptId: string, binding: AttemptConsumerReceiptBinding) => {
+              if (binding.transcriptRef !== transcriptRef) throw new Error("Root consumer settlement transcript does not match the root transcript");
+              const boundDeliveryIds = new Set(binding.deliveryIds);
+              for (const delivery of resources.questions.preparedRootAnswerDeliveries(context.nodeId)) {
+                if (boundDeliveryIds.has(delivery.deliveryId)) {
+                  resources.questions.recordRootAnswerDeliveryReceipt(delivery, { promptHash: binding.promptHash, attemptId, transcriptRef: binding.transcriptRef });
+                }
+              }
+            },
+          } } : {}),
+        });
+        if (isRootContext) {
+          resources.questions.reconcileAnswerDeliveryReceipts();
+          this.reconcileQuestionWait(resources);
+        }
+        return value;
+      },
+      tool: <T>(input: WorkerTrustedToolDispatchRequest<T>) => {
+        if (input.toolName === "human_question" && input.questionBatchCallIds && input.questionBatchCurrentCallId) assertQuestionBatchAdmission(input.questionBatchCurrentCallId, input.questionBatchCallIds);
+        else {
+          assertAdmission();
+          assertRootQuestionAdmission();
+        }
+        return this.dispatchTool(resources.dispatchRuntime, context.nodeId, input);
+      },
     });
     const bound: BoundDelegationServices = Object.freeze({
       context,
@@ -966,7 +1190,16 @@ export class RunOrchestrationService {
         try { return resources.runtime.accept(context, input); }
         catch (error) {
           const detail = record(error) ? error : {};
-          if (detail.budgetScope === "run" && Array.isArray(detail.budgetExhausted)) this.blockRunForBudget(resources, context.nodeId, String(error instanceof Error ? error.message : error));
+          if (detail.budgetScope === "run" && Array.isArray(detail.budgetExhausted)) {
+            const reason = String(error instanceof Error ? error.message : error);
+            this.blockRunForBudget(resources, context.nodeId, reason);
+            // Delegation admission is synchronous, so finish its fatal run-wide
+            // settlement on the owned cleanup lane after this call unwinds.
+            this.trackCleanup(Promise.resolve().then(async () => {
+              const terminal = await this.lifecycle.failBudgetExhaustion(reason);
+              if (!terminal.ok) throw new Error(`Run-wide delegation budget exhaustion failed to settle: ${terminal.issues.join("; ")}`);
+            }));
+          }
           throw error;
         }
       },
@@ -1018,6 +1251,14 @@ export class RunOrchestrationService {
               verifyEvidence: (references) => this.verifyArtifactEvidence(resources, references),
             });
           } : undefined,
+          question: async (input, toolCallId, signal, batchCallIds = [toolCallId]) => {
+            assertQuestionBatchAdmission(toolCallId, batchCallIds);
+            const request = { nodeId: context.nodeId, ...(context.taskId ? { taskId: context.taskId } : {}), definition: input, provenance: { source: "human_question" as const, toolCallId } };
+            const question = this.options.questionControl?.presentLive
+              ? await resources.questions.createAndPresent(request, this.options.questionControl.presentLive, signal)
+              : resources.questions.create(request);
+            return Object.freeze({ questionId: question.questionId, state: question.state, suspendTurn: question.state === "pending", ...(question.answer ? { answer: question.answer } : {}) });
+          },
           finish: (input, batch) => this.lifecycle.finish(input, { callerNodeId: context.nodeId, toolBatch: batch }),
         });
         return runWithWorkflowToolRuntime(binding, callback);
@@ -1028,6 +1269,11 @@ export class RunOrchestrationService {
 
   rootServices(): BoundDelegationServices {
     const resources = this.resources();
+    // Root admission, like scheduler recovery, retries durable receipt control
+    // settlement without turning a transient publication fault into a provider
+    // attempt or a permanent recovery diagnosis.
+    resources.questions.reconcileAnswerDeliveryReceipts();
+    this.reconcileQuestionWait(resources);
     this.assertRecoveredForAdmission(resources);
     return this.bind(resources.runtime.rootExecutionContext(), resources);
   }
@@ -1095,8 +1341,27 @@ export class RunOrchestrationService {
     return this.current.runtime.restore();
   }
 
+  private reconcileQuestionWait(resources: RunResources): void {
+    const beforeRun = this.lifecycle.restore().latestRun;
+    if (!beforeRun || (beforeRun.status !== "running" && beforeRun.status !== "waiting_for_human") || beforeRun.cancellationRequested || beforeRun.pendingTerminal) return;
+    const delegation = resources.runtime.restore();
+    const questions = Object.values(resources.questions.restore().questions);
+    const pendingQuestions = questions.filter((question) => question.state === "pending").length;
+    const rootId = rootNodeId(this.options.snapshot);
+    const rootQuestionSuspended = questions.some((question) => question.state === "pending" && question.nodeId === rootId && question.taskId === undefined);
+    const runnableTasks = Object.values(delegation.tasks).filter((task) => task.queueState === "queued" || (task.queueState === "active" && (task.resumedByQuestionSequence !== undefined || task.resumedByResultSequence !== undefined))).length;
+    const derived = deriveQuestionRunStatus({ pendingQuestions, activeExecutions: resources.scheduler.activeCount, runnableTasks, pendingRootInputs: this.lifecycle.pendingInputs().length, rootQuestionSuspended });
+    const hasQuestionCause = beforeRun.waitCauses?.includes("question") ?? false;
+    if (derived === "waiting_for_human" && !hasQuestionCause) {
+      this.lifecycle.transitionToWaitingForHuman("all runnable progress is suspended on durable human questions");
+    } else if (derived === "running" && beforeRun.status === "waiting_for_human" && hasQuestionCause) {
+      this.lifecycle.transitionFromWaitingForHuman("a durable human answer is ready for owner-controlled resume");
+    }
+  }
+
   async runWorkers(): Promise<void> {
     const resources = this.resources();
+    this.reconcileQuestionWait(resources);
     if (Object.values(resources.attempts.restore().attempts).some((attempt) => !attempt.result && attempt.recovery === "reconcile-required")) {
       const report = await recoverUnknownSideEffects(resources.attempts, {
         reconcilers: this.options.recoveryReconcilers,
@@ -1111,10 +1376,12 @@ export class RunOrchestrationService {
       throw new Error(`Worker admission paused for unresolved unknown side effects: ${admissionIssues.join("; ")}`);
     }
     const run = this.lifecycle.restore().latestRun;
-    if (!run || run.runId !== resources.runId || !isOpenRunStatus(run.status) || run.status === "paused" || run.cancellationRequested) {
-      throw new Error("Workers can run only for the current running workflow run");
+    if (!run || run.runId !== resources.runId || run.status !== "running" || run.waitCauses?.includes("approval") || run.cancellationRequested) {
+      throw new Error("Workers can run only for the current running workflow run without a pending approval wait");
     }
+    resources.budgets.resumeActive();
     await resources.scheduler.runUntilSettled();
+    if (!resources.questions.isShutdown()) this.reconcileQuestionWait(resources);
     const recoveryIssues = this.recoveryAdmissionIssues(resources);
     if (recoveryIssues.length) {
       if (this.lifecycle.restore().latestRun?.status === "running") await this.pause(`unknown_side_effect: ${recoveryIssues.join("; ").slice(0, 2_048)}`);
@@ -1219,9 +1486,30 @@ export class RunOrchestrationService {
 
   private cancellationCoordinator(reason: string): CancellationCoordinator {
     const resources = this.resources();
+    const closeFrozenQuestions = (): void => {
+      const frozenRun = this.lifecycle.restore().latestRun;
+      if (!frozenRun || frozenRun.runId !== resources.runId || !frozenRun.cancellationRequested || !frozenRun.cancellationReason) {
+        throw new Error("Cancellation question closure requires the frozen durable cancellation request");
+      }
+      const frozenQuestionIds = frozenRun.cancellationQuestionIds ?? [];
+      const closureHash = createHash("sha256")
+        .update("pi-hive-cancellation-question-closure-v1\0")
+        .update(canonicalJson({ projectId: this.options.projectId, sessionId: this.options.sessionId, runId: frozenRun.runId }))
+        .digest("hex");
+      resources.questions.closePending({
+        reason: utf8Prefix(frozenRun.cancellationReason, QUESTION_LIMITS.reasonBytes),
+        operationId: `cancel-question-closure-sha256-${closureHash}`,
+        expectedQuestionIds: frozenQuestionIds,
+      });
+    };
     return {
       rejectNewWork: () => { resources.scheduler.closeAdmission(reason); },
-      cancelQueuedWork: () => { resources.scheduler.cancelPending(reason); },
+      cancelQueuedWork: () => {
+        // Explicit run cancellation closes the frozen pending set before task
+        // cancellation so ordinary task terminal CAS never strands a question.
+        closeFrozenQuestions();
+        resources.scheduler.cancelPending(reason);
+      },
       abortOwnedWork: async () => {
         resources.scheduler.abortOwnedWork(reason);
         await resources.workers.closeSessions();
@@ -1246,6 +1534,7 @@ export class RunOrchestrationService {
         } as Readonly<Record<string, JsonValue>>;
       },
       releaseLeases: async () => {
+        closeFrozenQuestions();
         this.releaseArtifactLease("cancel");
         await this.options.cancellationAuthority.releaseLeases?.();
       },
@@ -1259,8 +1548,19 @@ export class RunOrchestrationService {
     return result;
   }
 
+  questionControls(): QuestionService {
+    const run = this.lifecycle.restore().latestRun;
+    if (!run || !isOpenRunStatus(run.status)) throw new Error("Question controls require a current open workflow run");
+    return this.questionRuntimeFor(run.runId);
+  }
+
+  activeWorkerCount(): number { return this.current?.scheduler.activeCount ?? 0; }
+
   async shutdown(reason = "process shutdown"): Promise<void> {
     this.artifactCallerIssuer?.revoke();
+    // Question tools may be the promise preventing a worker from reaching its
+    // pause boundary, so abort and await their wrappers before worker settlement.
+    if (this.current) await this.current.questions.shutdown();
     const run = this.lifecycle.restore().latestRun;
     if (run && isOpenRunStatus(run.status)) await this.pause(reason);
     if (this.current) await this.current.workers.closeSessions();
@@ -1268,6 +1568,6 @@ export class RunOrchestrationService {
   }
 
   hasLiveHandles(): boolean {
-    return Boolean(this.current?.scheduler.hasLiveHandles() || this.current?.workers.hasLiveHandles() || this.cleanup.size);
+    return Boolean(this.current?.questions.hasLiveHandles() || this.current?.scheduler.hasLiveHandles() || this.current?.workers.hasLiveHandles() || this.cleanup.size);
   }
 }

--- a/src/workflows/prompts.ts
+++ b/src/workflows/prompts.ts
@@ -25,6 +25,66 @@ export interface DynamicPromptInput {
   readonly content: unknown;
   readonly ref?: string;
 }
+
+const LOSSLESS_DYNAMIC_CHUNK_BYTES = 8_192;
+const LOSSLESS_REQUIRED_ENVELOPE_BYTES = 69_632;
+const PAGINATED_DYNAMIC_SELECTION_BYTES = PROMPT_LIMITS.dynamicAggregateBytes - PROMPT_LIMITS.dynamicSectionBytes - 4_096;
+
+/**
+ * A worker authority delivery reserves one complete task envelope. The exact
+ * post-escaping delivery check keeps both below the page selection budget.
+ */
+export const LOSSLESS_DYNAMIC_DELIVERY_LIMITS = Object.freeze({
+  encodedBytes: PAGINATED_DYNAMIC_SELECTION_BYTES - LOSSLESS_REQUIRED_ENVELOPE_BYTES,
+  sections: PROMPT_LIMITS.dynamicSections - 1,
+});
+
+/**
+ * A root authority delivery reserves both non-pageable root envelopes: the
+ * first durable run input and a consumed handoff. Each is C0-safe, is bounded
+ * to a 32,768-byte section before canonical rendering, and fits the same
+ * 69,632-byte escaped-envelope reserve used by worker task delivery. The
+ * section bound additionally reserves those two envelopes plus the pagination
+ * marker, so a persisted root answer always has a complete containing page.
+ */
+export const ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS = Object.freeze({
+  encodedBytes: PAGINATED_DYNAMIC_SELECTION_BYTES - (2 * LOSSLESS_REQUIRED_ENVELOPE_BYTES),
+  sections: PROMPT_LIMITS.dynamicSections - 3,
+});
+
+/**
+ * Encode authority-relevant dynamic data as complete UTF-8 chunks. Callers
+ * must verify every returned provenance is present and untruncated in the
+ * assembled page before publishing a consumer receipt.
+ */
+export function losslessDynamicPromptInputs(input: Readonly<{ provenance: string; content: unknown; ref: string }>): readonly DynamicPromptInput[] {
+  const serialized = canonicalJson(input.content);
+  const chunks: string[] = [];
+  let chunk = "";
+  let bytes = 0;
+  for (const character of serialized) {
+    const size = Buffer.byteLength(character, "utf8");
+    if (bytes + size > LOSSLESS_DYNAMIC_CHUNK_BYTES && chunk) { chunks.push(chunk); chunk = ""; bytes = 0; }
+    chunk += character;
+    bytes += size;
+  }
+  if (chunk || !chunks.length) chunks.push(chunk);
+  return Object.freeze(chunks.map((content, index) => Object.freeze({
+    source: "tool-output" as const,
+    provenance: `${input.provenance}:chunk:${index + 1}/${chunks.length}`,
+    content,
+    ref: input.ref,
+  })));
+}
+
+export function assertLosslessDynamicPromptInputs(assembly: WorkflowPromptAssembly, inputs: readonly DynamicPromptInput[]): void {
+  for (const input of inputs) {
+    const section = assembly.dynamicSections.find((candidate) => candidate.source === input.source && candidate.provenance === input.provenance);
+    if (!section || section.truncated || section.includedBytes !== section.originalBytes) {
+      throw new Error(`Authority-relevant prompt data was omitted or truncated: ${input.provenance}`);
+    }
+  }
+}
 export interface PromptTaskInput {
   readonly taskId: string;
   readonly parentNodeId: string;
@@ -298,6 +358,32 @@ function dynamicBytes(entries: readonly BoundDynamicResult[]): number {
   return entries.reduce((total, entry) => total + Buffer.byteLength(entry.rendered, "utf8"), 0);
 }
 
+export interface LosslessDynamicDeliveryMeasurement {
+  readonly sections: number;
+  readonly encodedBytes: number;
+}
+
+/** Exact post-escaping size of one lossless authority delivery. */
+export function measureLosslessDynamicPromptDelivery(inputs: readonly DynamicPromptInput[]): LosslessDynamicDeliveryMeasurement {
+  const entries = inputs.map((input) => boundDynamic(input));
+  return Object.freeze({ sections: entries.length, encodedBytes: dynamicBytes(entries) });
+}
+
+function assertLosslessDynamicPromptDeliveryBound(inputs: readonly DynamicPromptInput[], limits: LosslessDynamicDeliveryMeasurement): void {
+  const measured = measureLosslessDynamicPromptDelivery(inputs);
+  if (measured.sections > limits.sections || measured.encodedBytes > limits.encodedBytes) {
+    throw new Error(`Question answer exceeds the exact lossless delivery page bound (${measured.encodedBytes}/${limits.encodedBytes} encoded bytes)`);
+  }
+}
+
+export function assertLosslessDynamicPromptDeliveryFits(inputs: readonly DynamicPromptInput[]): void {
+  assertLosslessDynamicPromptDeliveryBound(inputs, LOSSLESS_DYNAMIC_DELIVERY_LIMITS);
+}
+
+export function assertLosslessRootDynamicPromptDeliveryFits(inputs: readonly DynamicPromptInput[]): void {
+  assertLosslessDynamicPromptDeliveryBound(inputs, ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS);
+}
+
 /**
  * Select a bounded first/latest page and add a durable pagination index rather
  * than rejecting a legal stream merely because it contains more than 64
@@ -307,6 +393,7 @@ function boundDynamicPage(inputs: readonly DynamicPromptInput[], required?: Read
   const requiredIndex = required === undefined
     ? -1
     : inputs.findIndex((entry) => entry.source === required.source && entry.provenance === required.provenance);
+  const protectedFirstIndex = requiredIndex < 0 ? 0 : -1;
   const maxSelected = Math.max(0, PROMPT_LIMITS.dynamicSections - 1);
   const priority: number[] = [];
   const prioritySet = new Set<number>();
@@ -331,7 +418,7 @@ function boundDynamicPage(inputs: readonly DynamicPromptInput[], required?: Read
   }
   const selectedBudget = PROMPT_LIMITS.dynamicAggregateBytes - PROMPT_LIMITS.dynamicSectionBytes - 4_096;
   while (selected.length && dynamicBytes(selected) > selectedBudget) {
-    let removeAt = selectedIndexes.findIndex((index) => index !== requiredIndex && index !== 0);
+    let removeAt = selectedIndexes.findIndex((index) => index !== requiredIndex && index !== protectedFirstIndex);
     if (removeAt < 0) removeAt = selectedIndexes.findIndex((index) => index !== requiredIndex);
     if (removeAt < 0) break;
     selectedIndexes = selectedIndexes.filter((_index, position) => position !== removeAt);

--- a/src/workflows/question-validation.ts
+++ b/src/workflows/question-validation.ts
@@ -1,0 +1,240 @@
+export const QUESTION_LIMITS = Object.freeze({
+  promptBytes: 16_384,
+  questions: 128,
+  choices: 64,
+  choiceValueBytes: 1_024,
+  choiceLabelBytes: 1_024,
+  choicesBytes: 32_768,
+  textAnswerBytes: 32_768,
+  patternBytes: 256,
+  idBytes: 256,
+  identityBytes: 1_024,
+  reasonBytes: 2_048,
+  operationIdBytes: 256,
+  dtoItems: 40,
+  dtoBytes: 65_536,
+  cursorBytes: 512,
+});
+
+export type QuestionKind = "single" | "multi" | "text" | "confirm";
+export type QuestionAnswerValue = string | readonly string[] | boolean | null;
+
+export interface QuestionChoice {
+  readonly value: string;
+  readonly label: string;
+}
+export interface QuestionTextValidation {
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly pattern?: string;
+}
+export interface QuestionMultiValidation {
+  readonly minItems?: number;
+  readonly maxItems?: number;
+}
+export type QuestionValidation = QuestionTextValidation | QuestionMultiValidation;
+export interface QuestionDefinition {
+  readonly prompt: string;
+  readonly kind: QuestionKind;
+  readonly choices?: readonly QuestionChoice[];
+  readonly validation?: QuestionValidation;
+  readonly required: boolean;
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+    && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+}
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[], required: readonly string[], label: string): void {
+  const keys = Object.keys(value);
+  const permitted = new Set(allowed);
+  if (required.some((key) => !(key in value)) || keys.some((key) => !permitted.has(key))) throw new Error(`${label} has unknown or missing fields`);
+}
+function hasUnsafeC0Control(value: string): boolean {
+  // Preserve ordinary structured whitespace while rejecting controls whose
+  // six-byte JSON escapes can amplify an otherwise bounded persisted value.
+  return [...value].some((character) => {
+    const code = character.codePointAt(0)!;
+    return code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d;
+  });
+}
+function boundedString(value: unknown, label: string, bytes: number, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && !value.trim()) || Buffer.byteLength(value, "utf8") > bytes || hasUnsafeC0Control(value)) {
+    throw new Error(`${label} is invalid or exceeds its byte limit`);
+  }
+  return value;
+}
+function boundedInteger(value: unknown, label: string, minimum: number, maximum: number): number {
+  if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > maximum) throw new Error(`${label} is invalid`);
+  return Number(value);
+}
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+function safePattern(pattern: string): RegExp {
+  // Closed linear-time subset: the whole expression is anchored, atoms are
+  // literals, character classes, or dot, and at most one atom is quantified.
+  // Whole-input anchoring prevents native RegExp from retrying a large fixed
+  // repetition at every answer offset (for example a{32768}b).
+  let trailingBackslashes = 0;
+  for (let index = pattern.length - 2; index >= 0 && pattern[index] === "\\"; index--) trailingBackslashes++;
+  if (!pattern.startsWith("^") || !pattern.endsWith("$") || trailingBackslashes % 2 === 1) {
+    throw new Error("Question text validation pattern must be anchored to the complete answer");
+  }
+  let index = 1;
+  const end = pattern.length - 1;
+  let quantifiers = 0;
+  while (index < end) {
+    const character = pattern[index];
+    if (character === "\\") {
+      const escaped = pattern[index + 1];
+      if (!escaped || !/[dDsSwW\\.^$*+?()[\]{}|-]/u.test(escaped)) throw new Error("Question text validation pattern is outside the safe grammar");
+      index += 2;
+    } else if (character === "[") {
+      index++;
+      if (pattern[index] === "^") index++;
+      let members = 0;
+      while (index < end && pattern[index] !== "]") {
+        if (pattern[index] === "\\") {
+          if (index + 1 >= end) throw new Error("Question text validation pattern is invalid");
+          index += 2;
+        } else index++;
+        members++;
+      }
+      if (!members || pattern[index] !== "]") throw new Error("Question text validation pattern is invalid");
+      index++;
+    } else {
+      if ("()|^$*+?{}[]".includes(character)) throw new Error("Question text validation pattern is outside the safe grammar");
+      index++;
+    }
+    if (index < end && "*+?".includes(pattern[index])) { quantifiers++; index++; }
+    else if (index < end && pattern[index] === "{") {
+      const match = /^\{([0-9]+)(?:,([0-9]*))?\}/u.exec(pattern.slice(index, end));
+      if (!match) throw new Error("Question text validation pattern is invalid");
+      const minimum = Number(match[1]);
+      const maximum = match[2] === undefined ? minimum : match[2] === "" ? QUESTION_LIMITS.textAnswerBytes : Number(match[2]);
+      if (!Number.isSafeInteger(minimum) || !Number.isSafeInteger(maximum) || minimum > maximum || maximum > QUESTION_LIMITS.textAnswerBytes) throw new Error("Question text validation pattern repetition is invalid");
+      quantifiers++; index += match[0].length;
+    }
+    if (quantifiers > 1) throw new Error("Question text validation pattern exceeds the bounded-complexity grammar");
+  }
+  try { return new RegExp(pattern, "u"); } catch { throw new Error("Question text validation pattern is invalid"); }
+}
+
+export function normalizeQuestionDefinition(value: unknown): QuestionDefinition {
+  if (!plainRecord(value)) throw new Error("Question definition must be an object");
+  exactKeys(value, ["prompt", "kind", "choices", "validation", "required"], ["prompt", "kind", "required"], "Question definition");
+  const prompt = boundedString(value.prompt, "Question prompt", QUESTION_LIMITS.promptBytes);
+  const kind = value.kind;
+  if (kind !== "single" && kind !== "multi" && kind !== "text" && kind !== "confirm") throw new Error("Question kind is invalid");
+  if (typeof value.required !== "boolean") throw new Error("Question required flag is invalid");
+
+  let choices: readonly QuestionChoice[] | undefined;
+  if (kind === "single" || kind === "multi") {
+    if (!Array.isArray(value.choices) || value.choices.length < 1 || value.choices.length > QUESTION_LIMITS.choices) throw new Error("Question choices are invalid or exceed their limit");
+    const seen = new Set<string>();
+    const normalized = value.choices.map((raw, index) => {
+      if (!plainRecord(raw)) throw new Error(`Question choice ${index} must be an object`);
+      exactKeys(raw, ["value", "label"], ["value", "label"], `Question choice ${index}`);
+      const choiceValue = boundedString(raw.value, `Question choice ${index} value`, QUESTION_LIMITS.choiceValueBytes);
+      const label = boundedString(raw.label, `Question choice ${index} label`, QUESTION_LIMITS.choiceLabelBytes);
+      if (seen.has(choiceValue)) throw new Error("Question choice values must be unique");
+      seen.add(choiceValue);
+      return { value: choiceValue, label };
+    });
+    if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > QUESTION_LIMITS.choicesBytes) throw new Error("Question choices exceed their aggregate byte limit");
+    choices = normalized;
+  } else if (value.choices !== undefined) throw new Error(`Question choices are not valid for ${kind}`);
+
+  let validation: QuestionValidation | undefined;
+  if (kind === "text") {
+    if (value.validation !== undefined) {
+      if (!plainRecord(value.validation)) throw new Error("Question text validation must be an object");
+      exactKeys(value.validation, ["minLength", "maxLength", "pattern"], [], "Question text validation");
+      const minLength = value.validation.minLength === undefined ? 0 : boundedInteger(value.validation.minLength, "Question text minLength", 0, QUESTION_LIMITS.textAnswerBytes);
+      const maxLength = value.validation.maxLength === undefined ? QUESTION_LIMITS.textAnswerBytes : boundedInteger(value.validation.maxLength, "Question text maxLength", 0, QUESTION_LIMITS.textAnswerBytes);
+      if (minLength > maxLength) throw new Error("Question text validation length range is invalid");
+      const pattern = value.validation.pattern === undefined ? undefined : boundedString(value.validation.pattern, "Question text pattern", QUESTION_LIMITS.patternBytes);
+      if (pattern !== undefined) safePattern(pattern);
+      validation = { ...(value.validation.minLength !== undefined ? { minLength } : {}), ...(value.validation.maxLength !== undefined ? { maxLength } : {}), ...(pattern !== undefined ? { pattern } : {}) };
+    }
+  } else if (kind === "multi") {
+    if (value.validation !== undefined) {
+      if (!plainRecord(value.validation)) throw new Error("Question multi validation must be an object");
+      exactKeys(value.validation, ["minItems", "maxItems"], [], "Question multi validation");
+      const minItems = value.validation.minItems === undefined ? (value.required ? 1 : 0) : boundedInteger(value.validation.minItems, "Question multi minItems", 0, choices!.length);
+      const maxItems = value.validation.maxItems === undefined ? choices!.length : boundedInteger(value.validation.maxItems, "Question multi maxItems", 0, choices!.length);
+      if (minItems > maxItems) throw new Error("Question multi validation selection range is invalid");
+      validation = { ...(value.validation.minItems !== undefined ? { minItems } : {}), ...(value.validation.maxItems !== undefined ? { maxItems } : {}) };
+    }
+  } else if (value.validation !== undefined) throw new Error(`Question validation is not valid for ${kind}`);
+
+  return deepFreeze({ prompt, kind, ...(choices ? { choices } : {}), ...(validation ? { validation } : {}), required: value.required });
+}
+
+export function validateQuestionAnswer(definitionInput: QuestionDefinition, answer: unknown): QuestionAnswerValue {
+  const definition = normalizeQuestionDefinition(definitionInput);
+  if (answer === undefined) throw new Error("Question answer must be explicit; undefined is invalid");
+  if (answer === null) {
+    if (definition.required) throw new Error("Question answer is required");
+    return null;
+  }
+  if (definition.kind === "confirm") {
+    if (typeof answer !== "boolean") throw new Error("Confirm question answer must be boolean");
+    return answer;
+  }
+  if (definition.kind === "text") {
+    if (typeof answer !== "string" || Buffer.byteLength(answer, "utf8") > QUESTION_LIMITS.textAnswerBytes || hasUnsafeC0Control(answer)) throw new Error("Text question answer has an invalid type, control character, or byte length");
+    const validation = definition.validation as QuestionTextValidation | undefined;
+    const min = validation?.minLength ?? (definition.required ? 1 : 0);
+    const max = validation?.maxLength ?? QUESTION_LIMITS.textAnswerBytes;
+    if (answer.length < min || answer.length > max) throw new Error("Text question answer fails length validation");
+    if (validation?.pattern && !safePattern(validation.pattern).test(answer)) throw new Error("Text question answer fails pattern validation");
+    return answer;
+  }
+  const allowed = new Set(definition.choices!.map((choice) => choice.value));
+  if (definition.kind === "single") {
+    if (typeof answer !== "string" || !allowed.has(answer)) throw new Error("Single question answer must name one valid choice");
+    return answer;
+  }
+  if (!Array.isArray(answer) || answer.some((entry) => typeof entry !== "string" || !allowed.has(entry))) throw new Error("Multi question answer must be an array of valid choices");
+  if (new Set(answer).size !== answer.length) throw new Error("Multi question answer choices must be unique");
+  const validation = definition.validation as QuestionMultiValidation | undefined;
+  const min = validation?.minItems ?? (definition.required ? 1 : 0);
+  const max = validation?.maxItems ?? definition.choices!.length;
+  if (answer.length < min || answer.length > max) throw new Error("Multi question answer fails selection validation");
+  return deepFreeze([...answer].sort());
+}
+
+export function parseCommandAnswer(definition: QuestionDefinition, raw: string): QuestionAnswerValue {
+  if (typeof raw !== "string" || !raw.length) throw new Error("Question command value is required; use explicit null for an omitted optional answer");
+  const trimmed = raw.trim();
+  // Command encoding is deliberately unambiguous: bare `null` is the optional
+  // null value, while JSON strings represent colliding literal text (including
+  // `"null"` and `""`). Existing unquoted non-colliding values remain valid.
+  if (!definition.required && trimmed === "null") return null;
+  if (definition.kind === "confirm") {
+    const normalized = trimmed.toLowerCase();
+    if (["true", "yes", "y", "1"].includes(normalized)) return true;
+    if (["false", "no", "n", "0"].includes(normalized)) return false;
+    throw new Error("Confirm question command answer must be yes/no or true/false");
+  }
+  if (definition.kind === "multi") {
+    let answer: unknown;
+    if (trimmed.startsWith("[")) {
+      try { answer = JSON.parse(raw); } catch { throw new Error("Multi question command answer must be JSON or comma-separated choices"); }
+    } else answer = raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+    return validateQuestionAnswer(definition, answer);
+  }
+  if (trimmed.startsWith('"')) {
+    let answer: unknown;
+    try { answer = JSON.parse(trimmed); } catch { throw new Error(`${definition.kind === "text" ? "Text" : "Single"} question command answer has invalid JSON string encoding`); }
+    if (typeof answer !== "string") throw new Error(`${definition.kind === "text" ? "Text" : "Single"} question command answer must be a JSON string`);
+    return validateQuestionAnswer(definition, answer);
+  }
+  return validateQuestionAnswer(definition, raw);
+}

--- a/src/workflows/questions.ts
+++ b/src/workflows/questions.ts
@@ -1,0 +1,1200 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { ActivationSnapshotFileV1 } from "../config/snapshot";
+import type { JsonValue } from "../config/types";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { createWorkflowEvent, type WorkflowEventEnvelope, type WorkflowEventProducer } from "./events";
+import { appendWorkflowEventChecked, readWorkflowJournal, type JournalFaultStage } from "./journal";
+import { replayWorkflowJournal } from "./replay";
+import { createEmptyRunLifecycleState, isOpenRunStatus, reduceRunLifecycle } from "./runs";
+import { DelegationRuntime, createDelegationState, reduceDelegationState } from "./delegation";
+import { createAttemptState, reduceAttemptState } from "./attempts";
+import {
+  QUESTION_LIMITS,
+  normalizeQuestionDefinition,
+  validateQuestionAnswer,
+  type QuestionAnswerValue,
+  type QuestionDefinition,
+} from "./question-validation";
+import { deepFreeze, exactKeys, plainRecord } from "./values";
+import { assertLosslessDynamicPromptDeliveryFits, assertLosslessRootDynamicPromptDeliveryFits, losslessDynamicPromptInputs } from "./prompts";
+
+const FORMAT_VERSION = 1 as const;
+export type QuestionStateName = "pending" | "answered" | "closed";
+export type QuestionAnswerChannel = "live" | "dashboard" | "command";
+
+export interface QuestionCreationProvenance {
+  readonly source: "human_question";
+  readonly toolCallId: string;
+  readonly agentId: string;
+}
+export interface PersistedQuestionAnswer {
+  readonly value: QuestionAnswerValue;
+  readonly channel: QuestionAnswerChannel;
+  readonly identity: string;
+  readonly operationId: string;
+  readonly inputHash: string;
+  readonly answeredAt: string;
+}
+export interface PersistedQuestionClosure {
+  readonly reason: string;
+  readonly operationId: string;
+  readonly closedAt: string;
+}
+export interface QuestionDeliveryReceipt {
+  readonly promptHash: string;
+  readonly attemptId: string;
+  readonly transcriptRef: string;
+  readonly consumedSequence: number;
+  readonly consumedAt: string;
+}
+export interface PersistedQuestion {
+  readonly questionId: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly nodeId: string;
+  readonly taskId?: string;
+  readonly taskAttemptId?: string;
+  readonly definition: QuestionDefinition;
+  readonly provenance: QuestionCreationProvenance;
+  readonly createdAt: string;
+  readonly creationSequence: number;
+  readonly state: QuestionStateName;
+  readonly answer?: PersistedQuestionAnswer;
+  readonly closure?: PersistedQuestionClosure;
+  readonly toolAnswerReturnedSequence?: number;
+  readonly rootDeliveryId?: string;
+  readonly rootDeliveryPreparedSequence?: number;
+  readonly rootDeliveryReceipt?: QuestionDeliveryReceipt;
+  readonly rootDeliveryAcceptedSequence?: number;
+  readonly taskDeliveryId?: string;
+  readonly taskDeliveryPreparedSequence?: number;
+  readonly taskDeliveryReceipt?: QuestionDeliveryReceipt;
+  readonly taskDeliveryAcceptedSequence?: number;
+}
+export interface QuestionState {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly questions: Readonly<Record<string, PersistedQuestion>>;
+}
+export interface QuestionCreateRequest {
+  readonly nodeId: string;
+  readonly taskId?: string;
+  readonly definition: unknown;
+  readonly provenance: Readonly<{ source: "human_question"; toolCallId: string }>;
+}
+export interface QuestionControlAuthenticationRequest {
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly questionId: string;
+  readonly expectedState: "pending";
+  readonly channel: QuestionAnswerChannel;
+  readonly operationId: string;
+  readonly claimedIdentity: string;
+  readonly credential?: unknown;
+}
+export interface QuestionAnswerRequest extends QuestionControlAuthenticationRequest {
+  readonly value: unknown;
+}
+export interface QuestionCloseRequest {
+  readonly reason: string;
+  readonly operationId: string;
+  readonly expectedQuestionIds?: readonly string[];
+}
+export interface QuestionPresentationAnswer {
+  readonly value: unknown;
+  readonly claimedIdentity: string;
+  readonly credential?: unknown;
+  readonly operationId: string;
+}
+export type QuestionPresenter = (question: PersistedQuestion, signal: AbortSignal) => QuestionPresentationAnswer | undefined | Promise<QuestionPresentationAnswer | undefined>;
+export interface QuestionServiceOptions {
+  readonly projectRoot: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly snapshot: ActivationSnapshotFileV1;
+  readonly createQuestionId?: () => string;
+  readonly now?: () => string;
+  readonly authenticateControl: (request: QuestionControlAuthenticationRequest) => string | undefined;
+  readonly journalFault?: (eventType: "question.transition", stage: JournalFaultStage) => void;
+}
+export interface QuestionStatusRequest { readonly state?: QuestionStateName; readonly limit?: number; readonly cursor?: string }
+export interface QuestionStatusItem {
+  readonly questionId: string; readonly projectId: string; readonly sessionId: string; readonly runId: string; readonly nodeId: string; readonly taskId?: string;
+  readonly kind: QuestionDefinition["kind"]; readonly required: boolean; readonly state: QuestionStateName;
+  readonly promptPreview: string; readonly promptBytes: number; readonly promptTruncated: boolean; readonly choiceCount: number;
+  readonly createdAt: string; readonly answerChannel?: QuestionAnswerChannel; readonly answeredAt?: string; readonly closedAt?: string;
+  readonly readRef: string;
+}
+export interface QuestionStatusPage { readonly total: number; readonly items: readonly QuestionStatusItem[]; readonly nextCursor?: string }
+export interface QuestionDetailRequest {
+  readonly projectId: string; readonly sessionId: string; readonly runId: string; readonly questionId: string;
+  readonly cursor?: string; readonly choiceLimit?: number;
+}
+export interface QuestionDetailPage {
+  readonly questionId: string; readonly projectId: string; readonly sessionId: string; readonly runId: string; readonly nodeId: string; readonly taskId?: string;
+  readonly state: QuestionStateName; readonly kind: QuestionDefinition["kind"]; readonly required: boolean; readonly validation?: QuestionDefinition["validation"];
+  readonly promptChunk: string; readonly promptOffset: number; readonly promptBytes: number; readonly promptComplete: boolean;
+  readonly choices: readonly Readonly<{ value: string; label: string }>[]; readonly choiceOffset: number; readonly choiceCount: number;
+  readonly createdAt: string; readonly nextCursor?: string;
+}
+export interface AcceptedQuestionForTask {
+  readonly questionId: string; readonly runId: string; readonly nodeId: string; readonly taskId: string; readonly taskAttemptId: string;
+  readonly definition: QuestionDefinition; readonly answer: PersistedQuestionAnswer; readonly transcriptRef: string;
+}
+export interface AcceptedQuestionForRoot {
+  readonly questionId: string; readonly runId: string; readonly nodeId: string;
+  readonly definition: QuestionDefinition; readonly answer: PersistedQuestionAnswer; readonly transcriptRef: string;
+}
+export interface RootQuestionAnswerDelivery {
+  readonly deliveryId: string; readonly nodeId: string; readonly questionIds: readonly string[];
+  readonly answers: readonly AcceptedQuestionForRoot[];
+}
+export interface TaskQuestionAnswerDelivery {
+  readonly deliveryId: string; readonly nodeId: string; readonly taskId: string; readonly questionIds: readonly string[];
+  readonly answers: readonly AcceptedQuestionForTask[];
+}
+export interface QuestionDeliveryReceiptInput {
+  readonly promptHash: string;
+  readonly attemptId: string;
+  readonly transcriptRef: string;
+}
+
+function boundedString(value: unknown, label: string, bytes: number): string {
+  if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > bytes || value.includes("\0") || value.includes("/") || value.includes("\\")) throw new Error(`${label} is invalid or exceeds its byte limit`);
+  return value;
+}
+function boundedText(value: unknown, label: string, bytes: number): string {
+  if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > bytes
+    || [...value].some((character) => {
+      const code = character.codePointAt(0)!;
+      return code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d;
+    })) throw new Error(`${label} is invalid or exceeds its byte limit`);
+  return value;
+}
+function recordPayload(event: WorkflowEventEnvelope): Record<string, unknown> {
+  if (!plainRecord(event.payload) || event.payload.formatVersion !== FORMAT_VERSION) throw new Error("Question event payload is invalid");
+  return event.payload;
+}
+function questionAnswerProducer(channel: QuestionAnswerChannel): WorkflowEventProducer {
+  return channel === "dashboard" ? "dashboard" : channel === "command" ? "runtime" : "harness";
+}
+function answerChannel(value: unknown): QuestionAnswerChannel {
+  if (value !== "live" && value !== "dashboard" && value !== "command") throw new Error("Question answer channel is invalid");
+  return value;
+}
+function questionAnswerTranscriptRef(question: Pick<PersistedQuestion, "runId" | "nodeId" | "taskId" | "questionId">): string {
+  return question.taskId
+    ? `run:${question.runId}/node:${question.nodeId}/task:${question.taskId}/question:${question.questionId}`
+    : `run:${question.runId}/node:${question.nodeId}/question:${question.questionId}`;
+}
+
+function assertQuestionAnswerDeliverable(question: Pick<PersistedQuestion, "questionId" | "runId" | "nodeId" | "taskId" | "definition">, answer: PersistedQuestionAnswer): void {
+  const inputs = losslessDynamicPromptInputs({
+    provenance: `human-answer:${question.questionId}:${answer.channel}:${answer.identity}`,
+    content: { questionId: question.questionId, definition: question.definition, answer },
+    ref: questionAnswerTranscriptRef(question),
+  });
+  if (question.taskId === undefined) assertLosslessRootDynamicPromptDeliveryFits(inputs);
+  else assertLosslessDynamicPromptDeliveryFits(inputs);
+}
+
+function parseAnswer(payload: Record<string, unknown>, question: PersistedQuestion, event: WorkflowEventEnvelope): PersistedQuestionAnswer {
+  const channel = answerChannel(payload.channel);
+  if (event.producer !== questionAnswerProducer(channel)) throw new Error("Question answer channel lacks matching producer authority");
+  const identity = boundedText(payload.identity, "Question answer identity", QUESTION_LIMITS.identityBytes);
+  const operationId = boundedString(payload.operationId, "Question answer operation ID", QUESTION_LIMITS.operationIdBytes);
+  const inputHash = payload.inputHash;
+  if (typeof inputHash !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(inputHash)) throw new Error("Question answer input hash is invalid");
+  const value = validateQuestionAnswer(question.definition, payload.value);
+  const answer = deepFreeze({ value, channel, identity, operationId, inputHash, answeredAt: event.timestamp });
+  assertQuestionAnswerDeliverable(question, answer);
+  return answer;
+}
+
+function answerInputHash(input: Readonly<{ projectId: string; sessionId: string; runId: string; questionId: string; expectedState: "pending"; channel: QuestionAnswerChannel; identity: string; value: QuestionAnswerValue }>): string {
+  return `sha256:${createHash("sha256").update(canonicalJson(input)).digest("hex")}`;
+}
+
+function parseDeliveryReceipt(payload: Record<string, unknown>, event: WorkflowEventEnvelope): QuestionDeliveryReceipt {
+  const promptHash = payload.promptHash;
+  if (typeof promptHash !== "string" || !/^[0-9a-f]{64}$/u.test(promptHash)) throw new Error("Question delivery receipt prompt hash is invalid");
+  return deepFreeze({
+    promptHash,
+    attemptId: boundedString(payload.attemptId, "Question delivery receipt attempt ID", QUESTION_LIMITS.idBytes),
+    transcriptRef: boundedText(payload.transcriptRef, "Question delivery receipt transcript reference", 2_048),
+    consumedSequence: event.sequence,
+    consumedAt: event.timestamp,
+  });
+}
+
+export function createEmptyQuestionState(sessionId: string, runId: string): QuestionState {
+  boundedString(sessionId, "Question session ID", QUESTION_LIMITS.idBytes);
+  boundedString(runId, "Question run ID", QUESTION_LIMITS.idBytes);
+  return deepFreeze({ sessionId, runId, questions: {} });
+}
+
+export function reduceQuestionState(state: QuestionState, event: WorkflowEventEnvelope): QuestionState {
+  if (event.sessionId !== state.sessionId) throw new Error("Question event session identity mismatch");
+  if (event.runId !== undefined && event.runId !== state.runId) return state;
+  if (event.type !== "question.transition") return state;
+  if (event.runId !== state.runId) throw new Error("Question event run identity mismatch");
+  const payload = recordPayload(event);
+  exactKeys(payload, ["formatVersion", "operation"], ["questionId", "nodeId", "taskId", "taskAttemptId", "definition", "provenance", "channel", "identity", "operationId", "inputHash", "deliveryId", "value", "questionIds", "reason", "promptHash", "attemptId", "transcriptRef"], "Question event");
+  const operation = payload.operation;
+  const questions = { ...state.questions };
+  if (operation === "create") {
+    if (event.producer !== "runtime") throw new Error("Question creation lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "questionId", "nodeId", "definition", "provenance"], ["taskId", "taskAttemptId"], "Question create event");
+    const questionId = boundedString(payload.questionId, "Question ID", QUESTION_LIMITS.idBytes);
+    if (questions[questionId]) throw new Error("Question ID is duplicated");
+    if (Object.keys(questions).length >= QUESTION_LIMITS.questions) throw new Error("Questions exceed their per-run limit");
+    const nodeId = boundedString(payload.nodeId, "Question node ID", QUESTION_LIMITS.idBytes);
+    const taskId = payload.taskId === undefined ? undefined : boundedString(payload.taskId, "Question task ID", QUESTION_LIMITS.idBytes);
+    const taskAttemptId = payload.taskAttemptId === undefined ? undefined : boundedString(payload.taskAttemptId, "Question task attempt ID", QUESTION_LIMITS.idBytes);
+    if (Boolean(taskId) !== Boolean(taskAttemptId)) throw new Error("Task-bound question requires its exact task attempt identity");
+    if (!plainRecord(payload.provenance)) throw new Error("Question provenance is invalid");
+    exactKeys(payload.provenance, ["source", "toolCallId", "agentId"], [], "Question provenance");
+    if (payload.provenance.source !== "human_question") throw new Error("Question provenance source is invalid");
+    const provenance: QuestionCreationProvenance = deepFreeze({
+      source: "human_question",
+      toolCallId: boundedString(payload.provenance.toolCallId, "Question tool call ID", QUESTION_LIMITS.idBytes),
+      agentId: boundedString(payload.provenance.agentId, "Question agent ID", QUESTION_LIMITS.idBytes),
+    });
+    questions[questionId] = deepFreeze({
+      questionId, projectId: event.projectId, sessionId: event.sessionId, runId: event.runId,
+      nodeId, ...(taskId ? { taskId, taskAttemptId } : {}), definition: normalizeQuestionDefinition(payload.definition), provenance,
+      createdAt: event.timestamp, creationSequence: event.sequence, state: "pending" as const,
+    });
+  } else if (operation === "answer") {
+    exactKeys(payload, ["formatVersion", "operation", "questionId", "channel", "identity", "operationId", "inputHash", "value"], [], "Question answer event");
+    const questionId = boundedString(payload.questionId, "Question ID", QUESTION_LIMITS.idBytes);
+    const question = questions[questionId];
+    if (!question || question.state !== "pending") throw new Error("Question answer CAS requires exact pending state; question is answered, closed, or unknown");
+    questions[questionId] = deepFreeze({ ...question, state: "answered" as const, answer: parseAnswer(payload, question, event) });
+  } else if (operation === "tool-answer-returned") {
+    if (event.producer !== "runtime") throw new Error("Question tool answer return lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "questionId", "nodeId"], ["taskId"], "Question tool answer return event");
+    const questionId = boundedString(payload.questionId, "Question ID", QUESTION_LIMITS.idBytes);
+    const nodeId = boundedString(payload.nodeId, "Question node ID", QUESTION_LIMITS.idBytes);
+    const taskId = payload.taskId === undefined ? undefined : boundedString(payload.taskId, "Question task ID", QUESTION_LIMITS.idBytes);
+    const question = questions[questionId];
+    if (!question || question.nodeId !== nodeId || question.taskId !== taskId || question.state !== "answered" || !question.answer || question.toolAnswerReturnedSequence !== undefined) throw new Error("Question tool answer return requires its exact answered question");
+    questions[questionId] = deepFreeze({ ...question, toolAnswerReturnedSequence: event.sequence });
+  } else if (operation === "root-delivery-prepared") {
+    if (event.producer !== "runtime") throw new Error("Root question delivery preparation lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "questionIds"], [], "Root question delivery prepare event");
+    const deliveryId = boundedString(payload.deliveryId, "Root question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Root question delivery IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Root question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.taskId !== undefined || question.nodeId !== nodeId || question.state !== "answered" || !question.answer || question.rootDeliveryAcceptedSequence !== undefined
+        || (question.rootDeliveryId !== undefined && question.rootDeliveryId !== deliveryId)) throw new Error("Root question delivery preparation requires exact undelivered answered questions");
+      questions[questionId] = deepFreeze({ ...question, rootDeliveryId: deliveryId, rootDeliveryPreparedSequence: event.sequence });
+    }
+  } else if (operation === "root-delivery-consumed") {
+    if (event.producer !== "runtime") throw new Error("Root question delivery receipt lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "questionIds", "promptHash", "attemptId", "transcriptRef"], [], "Root question delivery receipt event");
+    const deliveryId = boundedString(payload.deliveryId, "Root question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    const receipt = parseDeliveryReceipt(payload, event);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Root question delivery receipt IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Root question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.nodeId !== nodeId || question.taskId !== undefined || question.rootDeliveryId !== deliveryId || question.rootDeliveryPreparedSequence === undefined
+        || question.rootDeliveryReceipt !== undefined || question.rootDeliveryAcceptedSequence !== undefined) throw new Error("Root question delivery receipt requires its exact prepared batch");
+      questions[questionId] = deepFreeze({ ...question, rootDeliveryReceipt: receipt });
+    }
+  } else if (operation === "root-delivery-accepted") {
+    if (event.producer !== "runtime") throw new Error("Root question delivery acceptance lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "questionIds"], [], "Root question delivery accept event");
+    const deliveryId = boundedString(payload.deliveryId, "Root question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Root question delivery IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Root question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.nodeId !== nodeId || question.rootDeliveryId !== deliveryId || question.rootDeliveryPreparedSequence === undefined || question.rootDeliveryReceipt === undefined || question.rootDeliveryAcceptedSequence !== undefined) throw new Error("Root question delivery acceptance requires its exact consumed batch");
+      questions[questionId] = deepFreeze({ ...question, rootDeliveryAcceptedSequence: event.sequence });
+    }
+  } else if (operation === "task-delivery-prepared") {
+    if (event.producer !== "runtime") throw new Error("Task question delivery preparation lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "taskId", "questionIds"], [], "Task question delivery prepare event");
+    const deliveryId = boundedString(payload.deliveryId, "Task question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Task question delivery node ID", QUESTION_LIMITS.idBytes);
+    const taskId = boundedString(payload.taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Task question delivery IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Task question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.taskId !== taskId || question.nodeId !== nodeId || question.state !== "answered" || !question.answer || question.taskDeliveryAcceptedSequence !== undefined
+        || (question.taskDeliveryId !== undefined && question.taskDeliveryId !== deliveryId)) throw new Error("Task question delivery preparation requires exact undelivered answered questions");
+      questions[questionId] = deepFreeze({ ...question, taskDeliveryId: deliveryId, taskDeliveryPreparedSequence: event.sequence });
+    }
+  } else if (operation === "task-delivery-consumed") {
+    if (event.producer !== "runtime") throw new Error("Task question delivery receipt lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "taskId", "questionIds", "promptHash", "attemptId", "transcriptRef"], [], "Task question delivery receipt event");
+    const deliveryId = boundedString(payload.deliveryId, "Task question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Task question delivery node ID", QUESTION_LIMITS.idBytes);
+    const taskId = boundedString(payload.taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    const receipt = parseDeliveryReceipt(payload, event);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Task question delivery receipt IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Task question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.nodeId !== nodeId || question.taskId !== taskId || question.taskDeliveryId !== deliveryId || question.taskDeliveryPreparedSequence === undefined
+        || question.taskDeliveryReceipt !== undefined || question.taskDeliveryAcceptedSequence !== undefined) throw new Error("Task question delivery receipt requires its exact prepared batch");
+      questions[questionId] = deepFreeze({ ...question, taskDeliveryReceipt: receipt });
+    }
+  } else if (operation === "task-delivery-accepted") {
+    if (event.producer !== "runtime") throw new Error("Task question delivery acceptance lacks runtime authority");
+    exactKeys(payload, ["formatVersion", "operation", "deliveryId", "nodeId", "taskId", "questionIds"], [], "Task question delivery accept event");
+    const deliveryId = boundedString(payload.deliveryId, "Task question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(payload.nodeId, "Task question delivery node ID", QUESTION_LIMITS.idBytes);
+    const taskId = boundedString(payload.taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    if (!Array.isArray(payload.questionIds) || !payload.questionIds.length || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Task question delivery IDs are invalid");
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Task question delivery question ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.nodeId !== nodeId || question.taskId !== taskId || question.taskDeliveryId !== deliveryId || question.taskDeliveryPreparedSequence === undefined || question.taskDeliveryReceipt === undefined || question.taskDeliveryAcceptedSequence !== undefined) throw new Error("Task question delivery acceptance requires its exact consumed batch");
+      questions[questionId] = deepFreeze({ ...question, taskDeliveryAcceptedSequence: event.sequence });
+    }
+  } else if (operation === "close-pending") {
+    if (event.producer !== "harness") throw new Error("Question terminal closure lacks harness authority");
+    exactKeys(payload, ["formatVersion", "operation", "questionIds", "reason", "operationId"], [], "Question close event");
+    if (!Array.isArray(payload.questionIds) || payload.questionIds.length > QUESTION_LIMITS.questions || new Set(payload.questionIds).size !== payload.questionIds.length) throw new Error("Question terminal closure IDs are invalid");
+    const reason = boundedText(payload.reason, "Question closure reason", QUESTION_LIMITS.reasonBytes);
+    const operationId = boundedString(payload.operationId, "Question closure operation ID", QUESTION_LIMITS.operationIdBytes);
+    for (const rawId of payload.questionIds) {
+      const questionId = boundedString(rawId, "Question closure ID", QUESTION_LIMITS.idBytes);
+      const question = questions[questionId];
+      if (!question || question.state !== "pending") throw new Error("Question terminal closure CAS requires every exact question to remain pending");
+      questions[questionId] = deepFreeze({ ...question, state: "closed" as const, closure: deepFreeze({ reason, operationId, closedAt: event.timestamp }) });
+    }
+  } else throw new Error("Question transition operation is unsupported");
+  return deepFreeze({ ...state, questions });
+}
+
+export function deriveQuestionRunStatus(input: Readonly<{ pendingQuestions: number; activeExecutions: number; runnableTasks: number; pendingRootInputs: number; rootQuestionSuspended: boolean }>): "running" | "waiting_for_human" {
+  for (const [key, value] of Object.entries(input)) {
+    if (key === "rootQuestionSuspended") {
+      if (typeof value !== "boolean") throw new Error(`Question waiting derivation ${key} is invalid`);
+    } else if (!Number.isSafeInteger(value) || Number(value) < 0) throw new Error(`Question waiting derivation ${key} is invalid`);
+  }
+  const runnableRootInputs = input.rootQuestionSuspended ? 0 : input.pendingRootInputs;
+  return input.pendingQuestions > 0 && input.activeExecutions === 0 && input.runnableTasks === 0 && runnableRootInputs === 0 ? "waiting_for_human" : "running";
+}
+
+function utf8Prefix(value: string, bytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= bytes) return value;
+  let output = "", used = 0;
+  for (const character of value) { const size = Buffer.byteLength(character, "utf8"); if (used + size > bytes) break; output += character; used += size; }
+  return output;
+}
+function detailOffset(cursor: string | undefined, question: PersistedQuestion): { prompt: number; choice: number } {
+  if (cursor === undefined) return { prompt: 0, choice: 0 };
+  if (Buffer.byteLength(cursor, "utf8") > QUESTION_LIMITS.cursorBytes) throw new Error("Question detail cursor is invalid");
+  const match = /^([1-9][0-9]*):(0|[1-9][0-9]*):(0|[1-9][0-9]*)$/u.exec(cursor);
+  if (!match || Number(match[1]) !== question.creationSequence) throw new Error("Question detail cursor is invalid or stale");
+  const prompt = Number(match[2]), choice = Number(match[3]);
+  if (!Number.isSafeInteger(prompt) || !Number.isSafeInteger(choice) || prompt > question.definition.prompt.length || choice > (question.definition.choices?.length ?? 0)) throw new Error("Question detail cursor is invalid or stale");
+  return { prompt, choice };
+}
+function statusCursor(cursor: string | undefined, state: QuestionStateName | undefined, questions: readonly PersistedQuestion[]): number {
+  if (cursor === undefined) return 0;
+  if (Buffer.byteLength(cursor, "utf8") > QUESTION_LIMITS.cursorBytes) throw new Error("Question status cursor is invalid");
+  const match = /^(all|pending|answered|closed):([1-9][0-9]*)$/u.exec(cursor);
+  const expectedFilter = state ?? "all";
+  const sequence = Number(match?.[2]);
+  if (!match || match[1] !== expectedFilter || !Number.isSafeInteger(sequence) || !questions.some((question) => question.creationSequence === sequence)) {
+    throw new Error("Question status cursor is invalid, stale, or bound to a different filter");
+  }
+  return sequence;
+}
+
+interface LivePresentation {
+  readonly controller: AbortController;
+  readonly settlement: Promise<QuestionPresentationAnswer | undefined>;
+}
+
+export class QuestionService {
+  readonly options: QuestionServiceOptions;
+  private readonly presentations = new Map<string, LivePresentation>();
+  private closed = false;
+
+  constructor(options: QuestionServiceOptions) {
+    boundedString(options.projectId, "Question project ID", QUESTION_LIMITS.idBytes);
+    boundedString(options.sessionId, "Question session ID", QUESTION_LIMITS.idBytes);
+    boundedString(options.runId, "Question run ID", QUESTION_LIMITS.idBytes);
+    if (typeof options.authenticateControl !== "function") throw new Error("Question control authentication is required");
+    this.options = options;
+  }
+
+  restore(events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId)): QuestionState {
+    return replayWorkflowJournal(events, createEmptyQuestionState(this.options.sessionId, this.options.runId), reduceQuestionState).state;
+  }
+
+  private authority(nodeId: string): { nodeId: string; agentId: string } {
+    const authority = this.options.snapshot.payload.authority.nodes.find((entry) => entry.nodeId === nodeId);
+    const effective = plainRecord(authority?.capabilities) && plainRecord(authority.capabilities.effective) ? authority.capabilities.effective : undefined;
+    if (!authority || !Array.isArray(authority.tools) || !authority.tools.includes("human_question") || effective?.["human-input"] !== true) {
+      throw new Error(`Node ${nodeId} lacks effective human-input capability or human_question is not enabled`);
+    }
+    const team = this.options.snapshot.payload.workflow.team as { nodes?: unknown } | undefined;
+    const node = Array.isArray(team?.nodes) ? team.nodes.find((entry) => plainRecord(entry) && entry.id === nodeId) : undefined;
+    if (!plainRecord(node) || typeof node.agentId !== "string") throw new Error("Question node is absent from immutable topology");
+    return { nodeId, agentId: node.agentId };
+  }
+
+  create(input: QuestionCreateRequest): PersistedQuestion {
+    if (this.closed) throw new Error("Question service is shut down");
+    if (!plainRecord(input)) throw new Error("Question creation request is invalid");
+    exactKeys(input, ["nodeId", "definition", "provenance"], ["taskId"], "Question creation request");
+    const nodeId = boundedString(input.nodeId, "Question node ID", QUESTION_LIMITS.idBytes);
+    const taskId = input.taskId === undefined ? undefined : boundedString(input.taskId, "Question task ID", QUESTION_LIMITS.idBytes);
+    const authority = this.authority(nodeId);
+    if (!plainRecord(input.provenance)) throw new Error("Question creation provenance is invalid");
+    exactKeys(input.provenance, ["source", "toolCallId"], [], "Question creation provenance");
+    if (input.provenance.source !== "human_question") throw new Error("Question creation provenance source is invalid");
+    const definition = normalizeQuestionDefinition(input.definition);
+    let taskAttemptId: string | undefined;
+    if (taskId) {
+      const existingEvents = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+      const currentRun = replayWorkflowJournal(existingEvents, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+      if (currentRun && currentRun.runId !== this.options.runId) throw new Error("Question creation service is stale and does not target the current run identity");
+      const delegation = replayWorkflowJournal(existingEvents, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+      const task = delegation.tasks[taskId];
+      const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+      if (!task || task.runId !== this.options.runId || task.targetNodeId !== nodeId || (task.queueState !== "active" && !questionSuspended) || task.result) {
+        throw new Error("Question creation requires the exact journal-active task and node");
+      }
+      taskAttemptId = boundedString(task.attempts.at(-1)?.attemptId, "Question task attempt ID", QUESTION_LIMITS.idBytes);
+    }
+    const questionId = boundedString(this.options.createQuestionId?.() ?? `question-${randomUUID()}`, "Question ID", QUESTION_LIMITS.idBytes);
+    const timestamp = this.options.now?.() ?? new Date().toISOString();
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp,
+      payload: {
+        formatVersion: FORMAT_VERSION, operation: "create", questionId, nodeId, ...(taskId ? { taskId, taskAttemptId } : {}),
+        definition: structuredClone(definition) as unknown as JsonValue,
+        provenance: { source: "human_question", toolCallId: boundedString(input.provenance.toolCallId, "Question tool call ID", QUESTION_LIMITS.idBytes), agentId: authority.agentId },
+      },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const state = this.restore(events);
+        if (state.questions[questionId]) throw new Error("Question ID is duplicated");
+        if (Object.keys(state.questions).length >= QUESTION_LIMITS.questions) throw new Error("Questions exceed their per-run limit");
+        const run = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+        if (run && run.runId !== this.options.runId) throw new Error("Question creation service is stale and does not target the current run");
+        if (run && (!isOpenRunStatus(run.status) || run.cancellationRequested || run.pendingTerminal)) throw new Error("Question creation is denied for a terminal, cancelling, or finalizing run");
+        if (taskId) {
+          const delegation = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+          const task = delegation.tasks[taskId];
+          const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+          if (!delegation.admissionOpen || delegation.schedulerStatus !== "running") throw new Error("Question creation is denied while scheduler admission is paused or closed");
+          if (!task || task.runId !== this.options.runId || task.targetNodeId !== nodeId || (task.queueState !== "active" && !questionSuspended)
+            || task.attempts.at(-1)?.attemptId !== taskAttemptId || task.result) throw new Error("Question creation requires the exact journal-active task attempt and node");
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const published = readWorkflowJournal(this.options.projectRoot, this.options.sessionId).some((event) => event.eventId === draft.eventId);
+      if (!published) throw error;
+    }
+    return this.restore().questions[questionId];
+  }
+
+  async createAndPresent(input: QuestionCreateRequest, presenter: QuestionPresenter, signal?: AbortSignal): Promise<PersistedQuestion> {
+    if (typeof presenter !== "function") throw new Error("Question presenter is required");
+    const pending = this.create(input);
+    const controller = new AbortController();
+    let settleAbort!: () => void;
+    const aborted = new Promise<undefined>((resolve) => {
+      settleAbort = () => resolve(undefined);
+      controller.signal.addEventListener("abort", settleAbort, { once: true });
+    });
+    const abortFromCaller = (): void => controller.abort(signal?.reason ?? "Question caller aborted");
+    if (signal?.aborted) abortFromCaller(); else signal?.addEventListener("abort", abortFromCaller, { once: true });
+    const presentation = Promise.resolve().then(() => presenter(pending, controller.signal));
+    void presentation.catch(() => undefined);
+    let durablePoll: ReturnType<typeof setTimeout> | undefined;
+    const durableSettlement = new Promise<undefined>((resolve, reject) => {
+      const observe = (): void => {
+        if (controller.signal.aborted) { resolve(undefined); return; }
+        try {
+          const current = this.restore().questions[pending.questionId];
+          if (current?.state !== "pending") {
+            controller.abort("Question settled by the durable winner");
+            resolve(undefined);
+            return;
+          }
+          durablePoll = setTimeout(observe, 10);
+        } catch (error) {
+          controller.abort("Durable question settlement observation failed");
+          reject(error);
+        }
+      };
+      durablePoll = setTimeout(observe, 10);
+    });
+    const settlement = Promise.race([presentation, aborted, durableSettlement]);
+    this.presentations.set(pending.questionId, { controller, settlement });
+    try {
+      const proposed = await settlement;
+      let answered: PersistedQuestion;
+      if (proposed === undefined || controller.signal.aborted) answered = this.restore().questions[pending.questionId];
+      else {
+        try {
+          answered = this.answer({
+            projectId: pending.projectId, sessionId: pending.sessionId, runId: pending.runId, questionId: pending.questionId, expectedState: "pending",
+            value: proposed.value, channel: "live", claimedIdentity: proposed.claimedIdentity, credential: proposed.credential, operationId: proposed.operationId,
+          });
+        } catch (error) {
+          const winner = this.restore().questions[pending.questionId];
+          if (winner?.state !== "answered" || !winner.answer) throw error;
+          answered = winner;
+        }
+      }
+      if (answered.state === "answered" && answered.answer) {
+        if (answered.taskId === undefined) this.prepareRootAnswerDeliveries(answered.nodeId, [answered.questionId]);
+        else this.prepareTaskAnswerDeliveries(answered.taskId, [answered.questionId]);
+        this.markToolAnswerReturned(answered);
+        answered = this.restore().questions[answered.questionId];
+      }
+      return answered;
+    } finally {
+      if (durablePoll) clearTimeout(durablePoll);
+      signal?.removeEventListener("abort", abortFromCaller);
+      controller.signal.removeEventListener("abort", settleAbort);
+      this.presentations.delete(pending.questionId);
+    }
+  }
+
+  answer(input: QuestionAnswerRequest): PersistedQuestion {
+    if (this.closed) throw new Error("Question service is shut down");
+    if (!plainRecord(input)) throw new Error("Question answer request is invalid");
+    exactKeys(input, ["projectId", "sessionId", "runId", "questionId", "expectedState", "value", "channel", "claimedIdentity", "operationId"], ["credential"], "Question answer request");
+    const projectId = boundedString(input.projectId, "Question project ID", QUESTION_LIMITS.idBytes);
+    const sessionId = boundedString(input.sessionId, "Question session ID", QUESTION_LIMITS.idBytes);
+    const runId = boundedString(input.runId, "Question run ID", QUESTION_LIMITS.idBytes);
+    const questionId = boundedString(input.questionId, "Question ID", QUESTION_LIMITS.idBytes);
+    if (input.expectedState !== "pending") throw new Error("Question answer expected state must be pending");
+    const channel = answerChannel(input.channel);
+    const operationId = boundedString(input.operationId, "Question answer operation ID", QUESTION_LIMITS.operationIdBytes);
+    const claimedIdentity = boundedText(input.claimedIdentity, "Question claimed identity", QUESTION_LIMITS.identityBytes);
+    const authenticationRequest: QuestionControlAuthenticationRequest = {
+      projectId, sessionId, runId, questionId, expectedState: "pending", channel, operationId, claimedIdentity, credential: input.credential,
+    };
+    const identity = this.options.authenticateControl(authenticationRequest);
+    if (!identity) throw new Error("Question answer is not authenticated or authorized");
+    const authenticatedIdentity = boundedText(identity, "Question authenticated identity", QUESTION_LIMITS.identityBytes);
+    if (projectId !== this.options.projectId || sessionId !== this.options.sessionId || runId !== this.options.runId) throw new Error("Question answer exact project/session/run identity does not match this control service");
+    const state = this.restore();
+    const current = state.questions[questionId];
+    if (!current || current.projectId !== projectId || current.sessionId !== sessionId || current.runId !== runId) throw new Error("Question answer exact durable identity is unknown or mismatched");
+    const value = validateQuestionAnswer(current.definition, input.value);
+    const inputHash = answerInputHash({ projectId, sessionId, runId, questionId, expectedState: "pending", channel, identity: authenticatedIdentity, value });
+    const existingOperation = Object.values(state.questions).find((question) => question.answer?.operationId === operationId)?.answer;
+    if (existingOperation) {
+      if (existingOperation.inputHash !== inputHash) throw new Error("Question answer operation ID reuse with different input is rejected");
+      return current;
+    }
+    if (current.state !== "pending") throw new Error("Question answer CAS requires exact pending state; question is already answered, closed, or unknown");
+    const answeredAt = this.options.now?.() ?? new Date().toISOString();
+    const persistedAnswer = deepFreeze({ value, channel, identity: authenticatedIdentity, operationId, inputHash, answeredAt });
+    assertQuestionAnswerDeliverable(current, persistedAnswer);
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: questionAnswerProducer(channel), timestamp: answeredAt,
+      payload: { formatVersion: FORMAT_VERSION, operation: "answer", questionId, channel, identity: authenticatedIdentity, operationId, inputHash, value: structuredClone(value) as JsonValue },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const lockedState = this.restore(events);
+        const operation = Object.values(lockedState.questions).find((question) => question.answer?.operationId === operationId)?.answer;
+        if (operation) {
+          if (operation.inputHash !== inputHash) throw new Error("Question answer operation ID reuse with different input is rejected");
+          throw new Error("Question answer operation was recorded concurrently");
+        }
+        const locked = lockedState.questions[questionId];
+        if (!locked || locked.projectId !== projectId || locked.sessionId !== sessionId || locked.runId !== runId || locked.state !== "pending") throw new Error("Question answer CAS lost: exact question identity is already answered, closed, or unknown");
+        validateQuestionAnswer(locked.definition, value);
+        assertQuestionAnswerDeliverable(locked, persistedAnswer);
+        const run = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+        if (run && run.runId !== this.options.runId) throw new Error("Question answer service is stale and does not target the current run");
+        if (run && (!isOpenRunStatus(run.status) || run.cancellationRequested || run.pendingTerminal)) throw new Error("Question answer is late because the run is terminal, cancelling, or finalizing");
+        if (locked.taskId) {
+          const delegation = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+          const task = delegation.tasks[locked.taskId];
+          const questionSuspended = task?.queueState === "suspended" && task.suspendedOnQuestionIds?.includes(questionId) === true && !task.suspendedOn?.length;
+          if (!task || task.runId !== this.options.runId || task.targetNodeId !== locked.nodeId || task.attempts.at(-1)?.attemptId !== locked.taskAttemptId
+            || (task.queueState !== "active" && !questionSuspended) || task.result) {
+            throw new Error("Task-bound question answer is late because its exact task attempt is no longer live");
+          }
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const reconciled = this.restore().questions[questionId];
+      if (reconciled?.state === "answered" && reconciled.answer?.operationId === operationId && reconciled.answer.inputHash === inputHash) {
+        this.presentations.get(questionId)?.controller.abort("Question answered by the durable winner");
+        return reconciled;
+      }
+      throw error;
+    }
+    const answered = this.restore().questions[questionId];
+    if (answered.state !== "answered" || answered.answer?.operationId !== operationId || answered.answer.inputHash !== inputHash) throw new Error("Published question answer could not be reconciled");
+    this.presentations.get(questionId)?.controller.abort("Question answered by the durable winner");
+    return answered;
+  }
+
+  closePending(input: QuestionCloseRequest): Readonly<{ closedQuestionIds: readonly string[] }> {
+    if (!plainRecord(input)) throw new Error("Question closure request is invalid");
+    exactKeys(input, ["reason", "operationId"], ["expectedQuestionIds"], "Question closure request");
+    const reason = boundedText(input.reason, "Question closure reason", QUESTION_LIMITS.reasonBytes);
+    const operationId = boundedString(input.operationId, "Question closure operation ID", QUESTION_LIMITS.operationIdBytes);
+    const state = this.restore();
+    const pending = Object.values(state.questions).filter((question) => question.state === "pending").map((question) => question.questionId).sort();
+    let expected: string[] | undefined;
+    if (input.expectedQuestionIds !== undefined) {
+      if (!Array.isArray(input.expectedQuestionIds) || input.expectedQuestionIds.length > QUESTION_LIMITS.questions || new Set(input.expectedQuestionIds).size !== input.expectedQuestionIds.length
+        || input.expectedQuestionIds.some((id) => typeof id !== "string")) throw new Error("Expected question closure IDs are invalid");
+      expected = [...input.expectedQuestionIds].sort();
+    }
+    const operationQuestions = Object.values(state.questions).filter((question) => question.closure?.operationId === operationId).sort((a, b) => a.questionId.localeCompare(b.questionId));
+    if (operationQuestions.length) {
+      const operationIds = operationQuestions.map((question) => question.questionId);
+      if (operationQuestions.some((question) => question.closure?.reason !== reason) || (expected && canonicalJson(expected) !== canonicalJson(operationIds))) {
+        throw new Error("Question closure conflicts with the exact operation set or reason");
+      }
+      return deepFreeze({ closedQuestionIds: operationIds });
+    }
+    if (expected) {
+      const conflicts = expected.some((questionId) => state.questions[questionId]?.state === "closed");
+      if (conflicts) throw new Error("Question closure conflicts with a different operation or reason");
+      if (canonicalJson(expected) !== canonicalJson(pending)) throw new Error("Question closure set changed before terminal settlement");
+    }
+    if (!pending.length) return deepFreeze({ closedQuestionIds: [] });
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "harness", timestamp: this.options.now?.() ?? new Date().toISOString(),
+      payload: { formatVersion: FORMAT_VERSION, operation: "close-pending", questionIds: pending, reason, operationId },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const locked = Object.values(this.restore(events).questions).filter((question) => question.state === "pending").map((question) => question.questionId).sort();
+        if (canonicalJson(locked) !== canonicalJson(pending)) throw new Error("Question terminal closure CAS lost because pending state changed");
+        const run = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+        if (run && run.runId !== this.options.runId) throw new Error("Question closure service is stale and does not target the current run");
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const published = readWorkflowJournal(this.options.projectRoot, this.options.sessionId).some((event) => event.eventId === draft.eventId);
+      if (!published) throw error;
+    }
+    const restored = this.restore();
+    if (pending.some((questionId) => restored.questions[questionId]?.state !== "closed" || restored.questions[questionId].closure?.operationId !== operationId)) throw new Error("Published question closure could not be reconciled");
+    return deepFreeze({ closedQuestionIds: pending });
+  }
+
+  pendingForTask(taskId: string): readonly PersistedQuestion[] {
+    const id = boundedString(taskId, "Question task ID", QUESTION_LIMITS.idBytes);
+    return deepFreeze(Object.values(this.restore().questions).filter((question) => question.taskId === id && question.state === "pending").sort((a, b) => a.creationSequence - b.creationSequence));
+  }
+
+  acceptedAnswersForTask(taskId: string): readonly AcceptedQuestionForTask[] {
+    const id = boundedString(taskId, "Question task ID", QUESTION_LIMITS.idBytes);
+    return deepFreeze(Object.values(this.restore().questions).filter((question): question is PersistedQuestion & { taskId: string; answer: PersistedQuestionAnswer } => question.taskId === id && question.state === "answered" && question.answer !== undefined && question.taskDeliveryAcceptedSequence === undefined)
+      .sort((a, b) => a.creationSequence - b.creationSequence)
+      .map((question) => this.taskAnswer(question)));
+  }
+
+  private taskAnswer(question: PersistedQuestion & { taskId: string; answer: PersistedQuestionAnswer }): AcceptedQuestionForTask {
+    if (!question.taskAttemptId) throw new Error("Task question is missing its immutable attempt identity");
+    return deepFreeze({ questionId: question.questionId, runId: question.runId, nodeId: question.nodeId, taskId: question.taskId, taskAttemptId: question.taskAttemptId, definition: question.definition, answer: question.answer, transcriptRef: questionAnswerTranscriptRef(question) });
+  }
+
+  private rootAnswer(question: PersistedQuestion & { answer: PersistedQuestionAnswer }): AcceptedQuestionForRoot {
+    return deepFreeze({ questionId: question.questionId, runId: question.runId, nodeId: question.nodeId, definition: question.definition, answer: question.answer, transcriptRef: questionAnswerTranscriptRef(question) });
+  }
+
+  private markToolAnswerReturned(question: PersistedQuestion): void {
+    const current = this.restore().questions[question.questionId];
+    if (current?.toolAnswerReturnedSequence !== undefined) return;
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp: this.options.now?.() ?? new Date().toISOString(),
+      payload: { formatVersion: FORMAT_VERSION, operation: "tool-answer-returned", questionId: question.questionId, nodeId: question.nodeId, ...(question.taskId ? { taskId: question.taskId } : {}) },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const locked = this.restore(events).questions[question.questionId];
+        if (!locked || locked.nodeId !== question.nodeId || locked.taskId !== question.taskId || locked.state !== "answered" || !locked.answer || locked.toolAnswerReturnedSequence !== undefined) throw new Error("Question tool answer return changed before publication");
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      if (this.restore().questions[question.questionId]?.toolAnswerReturnedSequence === undefined) throw error;
+    }
+  }
+
+  private appendDeliveryPreparation(input: Readonly<{ scope: "root" | "task"; nodeId: string; taskId?: string; questionIds: readonly string[] }>): void {
+    if (!input.questionIds.length) return;
+    const deliveryId = boundedString(`${input.scope}-question-delivery-${randomUUID()}`, "Question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const operation = input.scope === "root" ? "root-delivery-prepared" : "task-delivery-prepared";
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp: this.options.now?.() ?? new Date().toISOString(),
+      payload: { formatVersion: FORMAT_VERSION, operation, deliveryId, nodeId: input.nodeId, ...(input.taskId ? { taskId: input.taskId } : {}), questionIds: [...input.questionIds] },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const locked = this.restore(events);
+        const task = input.scope === "task"
+          ? replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state.tasks[input.taskId!]
+          : undefined;
+        if (input.scope === "task" && (!task || task.targetNodeId !== input.nodeId || task.result || (task.queueState !== "active" && task.queueState !== "suspended"))) {
+          throw new Error("Task question delivery preparation requires its exact live task attempt");
+        }
+        for (const questionId of input.questionIds) {
+          const question = locked.questions[questionId];
+          const valid = input.scope === "root"
+            ? question?.nodeId === input.nodeId && question.taskId === undefined && question.rootDeliveryId === undefined && question.rootDeliveryAcceptedSequence === undefined
+            : question?.nodeId === input.nodeId && question.taskId === input.taskId && question.taskAttemptId === task?.attempts.at(-1)?.attemptId
+              && question.taskDeliveryId === undefined && question.taskDeliveryAcceptedSequence === undefined;
+          if (!valid || question.state !== "answered" || !question.answer) throw new Error(`${input.scope === "root" ? "Root" : "Task"} question answer delivery changed before preparation or belongs to a stale task attempt`);
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const published = readWorkflowJournal(this.options.projectRoot, this.options.sessionId).some((event) => event.eventId === draft.eventId);
+      if (!published) throw error;
+    }
+  }
+
+  private appendDeliveryReceipt(input: Readonly<{ scope: "root" | "task"; deliveryId: string; nodeId: string; taskId?: string; questionIds: readonly string[]; receipt: QuestionDeliveryReceiptInput }>): void {
+    const deliveryId = boundedString(input.deliveryId, "Question delivery receipt ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(input.nodeId, "Question delivery receipt node ID", QUESTION_LIMITS.idBytes);
+    const taskId = input.taskId === undefined ? undefined : boundedString(input.taskId, "Question delivery receipt task ID", QUESTION_LIMITS.idBytes);
+    const questionIds = input.questionIds.map((questionId) => boundedString(questionId, "Question delivery receipt question ID", QUESTION_LIMITS.idBytes));
+    if (!questionIds.length || new Set(questionIds).size !== questionIds.length) throw new Error("Question delivery receipt question IDs are invalid");
+    const promptHash = input.receipt.promptHash;
+    if (typeof promptHash !== "string" || !/^[0-9a-f]{64}$/u.test(promptHash)) throw new Error("Question delivery receipt prompt hash is invalid");
+    const attemptId = boundedString(input.receipt.attemptId, "Question delivery receipt attempt ID", QUESTION_LIMITS.idBytes);
+    const transcriptRef = boundedText(input.receipt.transcriptRef, "Question delivery receipt transcript reference", 2_048);
+    const operation = input.scope === "root" ? "root-delivery-consumed" : "task-delivery-consumed";
+    const receiptMatches = (question: PersistedQuestion): boolean => {
+      const receipt = input.scope === "root" ? question.rootDeliveryReceipt : question.taskDeliveryReceipt;
+      return Boolean(receipt && receipt.promptHash === promptHash && receipt.attemptId === attemptId && receipt.transcriptRef === transcriptRef);
+    };
+    const current = this.restore();
+    if (input.scope === "task") {
+      const delegation = replayWorkflowJournal(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+      const task = delegation.tasks[taskId!];
+      if (!task || task.targetNodeId !== nodeId || task.result || (task.queueState !== "active" && task.queueState !== "suspended")
+        || questionIds.some((questionId) => current.questions[questionId]?.taskAttemptId !== task.attempts.at(-1)?.attemptId)) {
+        throw new Error("Task question delivery receipt requires the exact immutable task attempt");
+      }
+    }
+    if (questionIds.every((questionId) => receiptMatches(current.questions[questionId]))) return;
+    const draft = createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp: this.options.now?.() ?? new Date().toISOString(), attemptId,
+      payload: { formatVersion: FORMAT_VERSION, operation, deliveryId, nodeId, ...(taskId ? { taskId } : {}), questionIds, promptHash, attemptId, transcriptRef },
+    });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const locked = this.restore(events);
+        for (const questionId of questionIds) {
+          const question = locked.questions[questionId];
+          const valid = input.scope === "root"
+            ? question?.nodeId === nodeId && question.taskId === undefined && question.rootDeliveryId === deliveryId && question.rootDeliveryPreparedSequence !== undefined && question.rootDeliveryReceipt === undefined && question.rootDeliveryAcceptedSequence === undefined
+            : question?.nodeId === nodeId && question.taskId === taskId && question.taskDeliveryId === deliveryId && question.taskDeliveryPreparedSequence !== undefined && question.taskDeliveryReceipt === undefined && question.taskDeliveryAcceptedSequence === undefined;
+          if (!valid) throw new Error(`${input.scope === "root" ? "Root" : "Task"} question delivery receipt changed before publication`);
+        }
+        if (input.scope === "task") {
+          const delegation = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+          const task = delegation.tasks[taskId!];
+          const questionSuspended = task?.queueState === "suspended" && Boolean(task.suspendedOnQuestionIds?.length) && !task.suspendedOn?.length;
+          if (!task || task.targetNodeId !== nodeId || (task.queueState !== "active" && !questionSuspended) || task.result
+            || questionIds.some((questionId) => locked.questions[questionId]?.taskAttemptId !== task.attempts.at(-1)?.attemptId)) {
+            throw new Error("Task question delivery receipt requires its exact journal-active immutable task attempt");
+          }
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const restored = this.restore();
+      if (!questionIds.every((questionId) => receiptMatches(restored.questions[questionId]))) throw error;
+    }
+  }
+
+  taskAnswerDeliveryReturnedByTool(delivery: TaskQuestionAnswerDelivery): boolean {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds)) throw new Error("Task question answer delivery is invalid");
+    const state = this.restore();
+    return delivery.questionIds.length > 0 && delivery.questionIds.every((questionId) => state.questions[questionId]?.taskDeliveryId === delivery.deliveryId && state.questions[questionId]?.toolAnswerReturnedSequence !== undefined);
+  }
+
+  rootAnswerDeliveryReturnedByTool(delivery: RootQuestionAnswerDelivery): boolean {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds)) throw new Error("Root question answer delivery is invalid");
+    const state = this.restore();
+    return delivery.questionIds.length > 0 && delivery.questionIds.every((questionId) => state.questions[questionId]?.rootDeliveryId === delivery.deliveryId && state.questions[questionId]?.toolAnswerReturnedSequence !== undefined);
+  }
+
+  recordTaskAnswerDeliveryReceipt(delivery: TaskQuestionAnswerDelivery, receipt: QuestionDeliveryReceiptInput): void {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds) || !plainRecord(receipt)) throw new Error("Task question delivery receipt is invalid");
+    this.appendDeliveryReceipt({ scope: "task", deliveryId: delivery.deliveryId, nodeId: delivery.nodeId, taskId: delivery.taskId, questionIds: delivery.questionIds, receipt });
+  }
+
+  recordRootAnswerDeliveryReceipt(delivery: RootQuestionAnswerDelivery, receipt: QuestionDeliveryReceiptInput): void {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds) || !plainRecord(receipt)) throw new Error("Root question delivery receipt is invalid");
+    this.appendDeliveryReceipt({ scope: "root", deliveryId: delivery.deliveryId, nodeId: delivery.nodeId, questionIds: delivery.questionIds, receipt });
+  }
+
+  reconcileTaskAnswerDeliveryReceipts(taskId: string): void {
+    const id = boundedString(taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    for (const delivery of this.preparedTaskAnswerDeliveries(id)) {
+      const state = this.restore();
+      if (delivery.questionIds.every((questionId) => state.questions[questionId]?.taskDeliveryReceipt !== undefined)) this.acceptTaskAnswerDelivery(delivery);
+    }
+  }
+
+  reconcileRootAnswerDeliveryReceipts(nodeId: string): void {
+    const id = boundedString(nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    for (const delivery of this.preparedRootAnswerDeliveries(id)) {
+      const state = this.restore();
+      if (delivery.questionIds.every((questionId) => state.questions[questionId]?.rootDeliveryReceipt !== undefined)) this.acceptRootAnswerDelivery(delivery);
+    }
+  }
+
+  markTaskConsumerReplaySettled(taskId: string, taskAttemptId: string, questionIds: readonly string[]): void {
+    const runtime = new DelegationRuntime({
+      projectRoot: this.options.projectRoot, projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      snapshot: this.options.snapshot, now: this.options.now,
+    });
+    runtime.recordQuestionContinuation(taskId, taskAttemptId, questionIds);
+  }
+
+  containingAttemptForTaskContinuation(taskId: string, resumedByQuestionSequence: number | undefined): string | undefined {
+    const id = boundedString(taskId, "Task continuation question ID", QUESTION_LIMITS.idBytes);
+    if (resumedByQuestionSequence === undefined) return undefined;
+    if (!Number.isSafeInteger(resumedByQuestionSequence) || resumedByQuestionSequence < 1) throw new Error("Task question continuation sequence is invalid");
+    const events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+    const task = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state.tasks[id];
+    if (task?.continuedQuestionResumeSequence === resumedByQuestionSequence) return undefined;
+    const attempts = new Set(Object.values(this.restore(events).questions)
+      .filter((question) => question.taskId === id && question.taskDeliveryReceipt?.consumedSequence === resumedByQuestionSequence)
+      .map((question) => question.taskDeliveryReceipt!.attemptId));
+    if (attempts.size > 1) throw new Error("Task question continuation is bound to conflicting containing attempts");
+    return [...attempts][0];
+  }
+
+  private reconcileCompletedAttemptReceipts(): void {
+    const events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+    const attempts = replayWorkflowJournal(events, createAttemptState(this.options.sessionId, this.options.runId), reduceAttemptState).state;
+    for (const attempt of Object.values(attempts.attempts).sort((left, right) => left.startedSequence - right.startedSequence)) {
+      if (attempt.status !== "completed" || !attempt.result?.ok || !attempt.consumerReceipt?.deliveryIds.length) continue;
+      const receipt = { promptHash: attempt.consumerReceipt.promptHash, attemptId: attempt.attemptId, transcriptRef: attempt.consumerReceipt.transcriptRef };
+      const taskDeliveries = new Map(this.preparedTaskAnswerDeliveriesForAll().map((delivery) => [delivery.deliveryId, delivery]));
+      const rootDeliveries = new Map(this.preparedRootAnswerDeliveriesForAll().map((delivery) => [delivery.deliveryId, delivery]));
+      for (const deliveryId of attempt.consumerReceipt.deliveryIds) {
+        const task = taskDeliveries.get(deliveryId);
+        if (task) this.recordTaskAnswerDeliveryReceipt(task, receipt);
+        const root = rootDeliveries.get(deliveryId);
+        if (root) this.recordRootAnswerDeliveryReceipt(root, receipt);
+      }
+    }
+  }
+
+  private preparedTaskAnswerDeliveriesForAll(): readonly TaskQuestionAnswerDelivery[] {
+    const taskIds = new Set(Object.values(this.restore().questions).flatMap((question) => question.taskId ? [question.taskId] : []));
+    return deepFreeze([...taskIds].sort().flatMap((taskId) => this.preparedTaskAnswerDeliveries(taskId)));
+  }
+
+  private preparedRootAnswerDeliveriesForAll(): readonly RootQuestionAnswerDelivery[] {
+    const nodeIds = new Set(Object.values(this.restore().questions).filter((question) => question.taskId === undefined).map((question) => question.nodeId));
+    return deepFreeze([...nodeIds].sort().flatMap((nodeId) => this.preparedRootAnswerDeliveries(nodeId)));
+  }
+
+  /** Retryable control settlement performed before worker admission after restart. */
+  reconcileAnswerDeliveryReceipts(): void {
+    this.reconcileCompletedAttemptReceipts();
+    const state = this.restore();
+    const taskIds = new Set<string>();
+    const rootNodeIds = new Set<string>();
+    for (const question of Object.values(state.questions)) {
+      if (question.taskDeliveryReceipt && question.taskDeliveryAcceptedSequence === undefined && question.taskId) taskIds.add(question.taskId);
+      if (question.rootDeliveryReceipt && question.rootDeliveryAcceptedSequence === undefined && question.taskId === undefined) rootNodeIds.add(question.nodeId);
+    }
+    for (const taskId of [...taskIds].sort()) this.reconcileTaskAnswerDeliveryReceipts(taskId);
+    for (const nodeId of [...rootNodeIds].sort()) this.reconcileRootAnswerDeliveryReceipts(nodeId);
+  }
+
+  prepareTaskAnswerDeliveries(taskId: string, exactQuestionIds?: readonly string[]): readonly TaskQuestionAnswerDelivery[] {
+    const id = boundedString(taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    const events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
+    const beforePreparation = this.restore(events);
+    const task = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state.tasks[id];
+    const undelivered = Object.values(beforePreparation.questions).filter((question) => question.taskId === id && question.state === "answered" && question.answer
+      && question.taskDeliveryAcceptedSequence === undefined);
+    if (undelivered.length && (!task || task.result || (task.queueState !== "active" && task.queueState !== "suspended")
+      || undelivered.some((question) => question.taskAttemptId !== task.attempts.at(-1)?.attemptId))) {
+      throw new Error("Task question delivery preparation requires the exact immutable live task attempt");
+    }
+    this.reconcileTaskAnswerDeliveryReceipts(id);
+    const requested = exactQuestionIds === undefined ? undefined : new Set(exactQuestionIds.map((questionId) => boundedString(questionId, "Task question delivery question ID", QUESTION_LIMITS.idBytes)));
+    const state = this.restore();
+    if (requested && requested.size !== exactQuestionIds!.length) throw new Error("Task question delivery IDs are duplicated");
+    const eligible = Object.values(state.questions).filter((question): question is PersistedQuestion & { taskId: string; answer: PersistedQuestionAnswer } => question.taskId === id && question.state === "answered" && question.answer !== undefined
+      && question.taskDeliveryAcceptedSequence === undefined && question.taskDeliveryId === undefined && (!requested || requested.has(question.questionId))).sort((a, b) => a.creationSequence - b.creationSequence);
+    if (requested && [...requested].some((questionId) => {
+      const question = state.questions[questionId];
+      return !question || question.taskId !== id || question.state !== "answered" || !question.answer || question.taskDeliveryAcceptedSequence !== undefined;
+    })) throw new Error("Task question delivery requires exact undelivered answered questions");
+    // Each containing turn receives one complete answer envelope. This is a
+    // deliberate continuation page: prompt bounding may omit or truncate a
+    // many-answer batch, but a single maximum-size W21 answer is losslessly
+    // chunked by the prompt assembler before its receipt can be published.
+    if (eligible.length) this.appendDeliveryPreparation({ scope: "task", nodeId: eligible[0].nodeId, taskId: id, questionIds: [eligible[0].questionId] });
+    return this.preparedTaskAnswerDeliveries(id);
+  }
+
+  preparedTaskAnswerDeliveries(taskId: string): readonly TaskQuestionAnswerDelivery[] {
+    const id = boundedString(taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    const prepared = Object.values(this.restore().questions).filter((question): question is PersistedQuestion & { taskId: string; answer: PersistedQuestionAnswer; taskDeliveryId: string } => question.taskId === id && question.state === "answered" && question.answer !== undefined
+      && question.taskDeliveryId !== undefined && question.taskDeliveryAcceptedSequence === undefined).sort((a, b) => a.creationSequence - b.creationSequence);
+    const groups = new Map<string, typeof prepared>();
+    for (const question of prepared) groups.set(question.taskDeliveryId, [...(groups.get(question.taskDeliveryId) ?? []), question]);
+    return deepFreeze([...groups.entries()].map(([deliveryId, questions]) => ({
+      deliveryId, nodeId: questions[0].nodeId, taskId: id, questionIds: questions.map((question) => question.questionId), answers: questions.map((question) => this.taskAnswer(question)),
+    })));
+  }
+
+  acceptTaskAnswerDelivery(delivery: TaskQuestionAnswerDelivery): void {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds)) throw new Error("Task question answer delivery is invalid");
+    const deliveryId = boundedString(delivery.deliveryId, "Task question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(delivery.nodeId, "Task question delivery node ID", QUESTION_LIMITS.idBytes);
+    const taskId = boundedString(delivery.taskId, "Task question delivery task ID", QUESTION_LIMITS.idBytes);
+    const questionIds = delivery.questionIds.map((id) => boundedString(id, "Task question delivery question ID", QUESTION_LIMITS.idBytes));
+    const state = this.restore();
+    const delegation = replayWorkflowJournal(readWorkflowJournal(this.options.projectRoot, this.options.sessionId), createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state;
+    const task = delegation.tasks[taskId];
+    if (!task || task.targetNodeId !== nodeId || task.result || (task.queueState !== "active" && task.queueState !== "suspended")
+      || questionIds.some((questionId) => state.questions[questionId]?.taskAttemptId !== task.attempts.at(-1)?.attemptId)) {
+      throw new Error("Task question delivery acceptance requires the exact immutable task attempt");
+    }
+    if (questionIds.every((questionId) => state.questions[questionId]?.taskDeliveryId === deliveryId && state.questions[questionId]?.taskDeliveryAcceptedSequence !== undefined)) return;
+    const draft = createWorkflowEvent({ projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp: this.options.now?.() ?? new Date().toISOString(),
+      payload: { formatVersion: FORMAT_VERSION, operation: "task-delivery-accepted", deliveryId, nodeId, taskId, questionIds } });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        const locked = this.restore(events);
+        const lockedTask = replayWorkflowJournal(events, createDelegationState(this.options.sessionId, this.options.runId, this.options.snapshot), reduceDelegationState).state.tasks[taskId];
+        if (!lockedTask || lockedTask.targetNodeId !== nodeId || lockedTask.result || (lockedTask.queueState !== "active" && lockedTask.queueState !== "suspended")) {
+          throw new Error("Task question answer delivery acceptance lost its live task attempt");
+        }
+        for (const questionId of questionIds) {
+          const question = locked.questions[questionId];
+          if (!question || question.nodeId !== nodeId || question.taskId !== taskId || question.taskAttemptId !== lockedTask.attempts.at(-1)?.attemptId
+            || question.taskDeliveryId !== deliveryId || question.taskDeliveryReceipt === undefined || question.taskDeliveryAcceptedSequence !== undefined) {
+            throw new Error("Task question answer delivery acceptance CAS lost or targets a stale task attempt");
+          }
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const restored = this.restore();
+      if (!questionIds.every((questionId) => restored.questions[questionId]?.taskDeliveryId === deliveryId && restored.questions[questionId]?.taskDeliveryAcceptedSequence !== undefined)) throw error;
+    }
+  }
+
+  prepareRootAnswerDeliveries(nodeId: string, exactQuestionIds?: readonly string[]): readonly RootQuestionAnswerDelivery[] {
+    const rootNodeId = boundedString(nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    this.reconcileRootAnswerDeliveryReceipts(rootNodeId);
+    const requested = exactQuestionIds === undefined ? undefined : new Set(exactQuestionIds.map((questionId) => boundedString(questionId, "Root question delivery question ID", QUESTION_LIMITS.idBytes)));
+    const state = this.restore();
+    if (requested && requested.size !== exactQuestionIds!.length) throw new Error("Root question delivery IDs are duplicated");
+    const eligible = Object.values(state.questions).filter((question): question is PersistedQuestion & { answer: PersistedQuestionAnswer } => question.nodeId === rootNodeId && question.taskId === undefined && question.state === "answered"
+      && question.answer !== undefined && question.rootDeliveryAcceptedSequence === undefined && question.rootDeliveryId === undefined && (!requested || requested.has(question.questionId))).sort((a, b) => a.creationSequence - b.creationSequence);
+    if (requested && [...requested].some((questionId) => {
+      const question = state.questions[questionId];
+      return !question || question.nodeId !== rootNodeId || question.taskId !== undefined || question.state !== "answered" || !question.answer || question.rootDeliveryAcceptedSequence !== undefined;
+    })) throw new Error("Root question delivery requires exact undelivered answered questions");
+    if (eligible.length) this.appendDeliveryPreparation({ scope: "root", nodeId: rootNodeId, questionIds: [eligible[0].questionId] });
+    return this.preparedRootAnswerDeliveries(rootNodeId);
+  }
+
+  preparedRootAnswerDeliveries(nodeId: string): readonly RootQuestionAnswerDelivery[] {
+    const rootNodeId = boundedString(nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    const prepared = Object.values(this.restore().questions).filter((question): question is PersistedQuestion & { answer: PersistedQuestionAnswer; rootDeliveryId: string } => question.nodeId === rootNodeId && question.taskId === undefined
+      && question.state === "answered" && question.answer !== undefined && question.rootDeliveryId !== undefined && question.rootDeliveryAcceptedSequence === undefined).sort((a, b) => a.creationSequence - b.creationSequence);
+    const groups = new Map<string, typeof prepared>();
+    for (const question of prepared) groups.set(question.rootDeliveryId, [...(groups.get(question.rootDeliveryId) ?? []), question]);
+    return deepFreeze([...groups.entries()].map(([deliveryId, questions]) => ({
+      deliveryId, nodeId: rootNodeId, questionIds: questions.map((question) => question.questionId), answers: questions.map((question) => this.rootAnswer(question)),
+    })));
+  }
+
+  prepareRootAnswerDelivery(nodeId: string): RootQuestionAnswerDelivery | undefined {
+    return this.prepareRootAnswerDeliveries(nodeId)[0];
+  }
+
+  acceptRootAnswerDelivery(delivery: RootQuestionAnswerDelivery): void {
+    if (!plainRecord(delivery) || !Array.isArray(delivery.questionIds)) throw new Error("Root question answer delivery is invalid");
+    const deliveryId = boundedString(delivery.deliveryId, "Root question delivery ID", QUESTION_LIMITS.operationIdBytes);
+    const nodeId = boundedString(delivery.nodeId, "Root question delivery node ID", QUESTION_LIMITS.idBytes);
+    const questionIds = delivery.questionIds.map((id) => boundedString(id, "Root question delivery question ID", QUESTION_LIMITS.idBytes));
+    const state = this.restore();
+    if (questionIds.every((questionId) => state.questions[questionId]?.rootDeliveryId === deliveryId && state.questions[questionId]?.rootDeliveryAcceptedSequence !== undefined)) return;
+    const draft = createWorkflowEvent({ projectId: this.options.projectId, sessionId: this.options.sessionId, runId: this.options.runId,
+      type: "question.transition", producer: "runtime", timestamp: this.options.now?.() ?? new Date().toISOString(),
+      payload: { formatVersion: FORMAT_VERSION, operation: "root-delivery-accepted", deliveryId, nodeId, questionIds } });
+    try {
+      appendWorkflowEventChecked(this.options.projectRoot, draft, (events) => {
+        for (const questionId of questionIds) {
+          const question = this.restore(events).questions[questionId];
+          if (!question || question.nodeId !== nodeId || question.rootDeliveryId !== deliveryId || question.rootDeliveryReceipt === undefined || question.rootDeliveryAcceptedSequence !== undefined) throw new Error("Root question answer delivery acceptance CAS lost");
+        }
+      }, { fault: (stage) => this.options.journalFault?.("question.transition", stage) });
+    } catch (error) {
+      const restored = this.restore();
+      if (!questionIds.every((questionId) => restored.questions[questionId]?.rootDeliveryId === deliveryId && restored.questions[questionId]?.rootDeliveryAcceptedSequence !== undefined)) throw error;
+    }
+  }
+
+  private undeliveredAnswered(state: QuestionState, taskId?: string): readonly PersistedQuestion[] {
+    return Object.values(state.questions).filter((question) => question.state === "answered" && question.answer
+      && (taskId === undefined ? question.taskId === undefined && question.rootDeliveryAcceptedSequence === undefined
+        : question.taskId === taskId && question.taskDeliveryAcceptedSequence === undefined));
+  }
+
+  assertTaskMayTerminal(events: readonly WorkflowEventEnvelope[], taskId: string, terminalStatus?: "completed" | "blocked" | "failed" | "cancelled"): void {
+    const id = boundedString(taskId, "Terminal task question ID", QUESTION_LIMITS.idBytes);
+    const state = this.restore(events);
+    const pending = Object.values(state.questions).filter((question) => question.taskId === id && question.state === "pending");
+    const undelivered = this.undeliveredAnswered(state, id);
+    if (pending.length || undelivered.length) {
+      const run = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+      if (terminalStatus === "cancelled" && run?.runId === this.options.runId && (run.cancellationRequested || run.pendingTerminal)) return;
+      throw new Error(`Worker terminal publication rejected: ${pending.length} pending and ${undelivered.length} answered-undelivered question(s) remain for the same task attempt`);
+    }
+  }
+
+  assertPendingSet(events: readonly WorkflowEventEnvelope[], expectedQuestionIds: readonly string[]): void {
+    const expected = [...expectedQuestionIds].sort();
+    const state = this.restore(events);
+    const pending = Object.values(state.questions).filter((question) => question.state === "pending").map((question) => question.questionId).sort();
+    if (canonicalJson(pending) !== canonicalJson(expected)) throw new Error("Exact pending question set changed before journal publication");
+  }
+
+  assertRootMayTerminal(events: readonly WorkflowEventEnvelope[]): void {
+    const undelivered = this.undeliveredAnswered(this.restore(events));
+    if (undelivered.length) throw new Error(`Terminal publication rejected: ${undelivered.length} answered root question(s) remain undelivered`);
+  }
+
+  completionGate(): Readonly<{ state: "satisfied" | "unsatisfied"; issues?: readonly string[]; pendingQuestionIds?: readonly string[] }> {
+    const state = this.restore();
+    const pending = Object.values(state.questions).filter((question) => question.state === "pending").map((question) => question.questionId).sort();
+    const undelivered = Object.values(state.questions).filter((question) => question.state === "answered" && question.answer
+      && (question.taskId === undefined ? question.rootDeliveryAcceptedSequence === undefined : question.taskDeliveryAcceptedSequence === undefined));
+    if (pending.length || undelivered.length) return deepFreeze({
+      state: "unsatisfied",
+      issues: [
+        ...(pending.length ? [`${pending.length} human question(s) remain pending`] : []),
+        ...(undelivered.length ? [`${undelivered.length} answered human question(s) have not reached their owning root or task transcript`] : []),
+      ],
+      ...(pending.length ? { pendingQuestionIds: pending } : {}),
+    });
+    return deepFreeze({ state: "satisfied" });
+  }
+
+  detail(request: QuestionDetailRequest): QuestionDetailPage {
+    if (!plainRecord(request)) throw new Error("Question detail request is invalid");
+    exactKeys(request, ["projectId", "sessionId", "runId", "questionId"], ["cursor", "choiceLimit"], "Question detail request");
+    const projectId = boundedString(request.projectId, "Question detail project ID", QUESTION_LIMITS.idBytes);
+    const sessionId = boundedString(request.sessionId, "Question detail session ID", QUESTION_LIMITS.idBytes);
+    const runId = boundedString(request.runId, "Question detail run ID", QUESTION_LIMITS.idBytes);
+    const questionId = boundedString(request.questionId, "Question detail question ID", QUESTION_LIMITS.idBytes);
+    if (projectId !== this.options.projectId || sessionId !== this.options.sessionId || runId !== this.options.runId) throw new Error("Question detail exact identity does not match this control service");
+    const question = this.restore().questions[questionId];
+    if (!question) throw new Error("Question detail identity is unknown");
+    const rawLimit = request.choiceLimit ?? QUESTION_LIMITS.choices;
+    if (!Number.isSafeInteger(rawLimit) || rawLimit < 1 || rawLimit > QUESTION_LIMITS.choices) throw new Error("Question detail choice limit is invalid");
+    if (request.cursor !== undefined && typeof request.cursor !== "string") throw new Error("Question detail cursor is invalid");
+    const start = detailOffset(request.cursor, question);
+    const remainingPrompt = question.definition.prompt.slice(start.prompt);
+    const promptChunk = utf8Prefix(remainingPrompt, 8_192);
+    const promptOffset = start.prompt + promptChunk.length;
+    const allChoices = question.definition.choices ?? [];
+    const choices: Array<{ value: string; label: string }> = [];
+    const base = {
+      questionId, projectId, sessionId, runId, nodeId: question.nodeId, ...(question.taskId ? { taskId: question.taskId } : {}),
+      state: question.state, kind: question.definition.kind, required: question.definition.required,
+      ...(question.definition.validation ? { validation: question.definition.validation } : {}),
+      promptChunk, promptOffset: start.prompt, promptBytes: Buffer.byteLength(question.definition.prompt, "utf8"), promptComplete: promptOffset === question.definition.prompt.length,
+      choiceOffset: start.choice, choiceCount: allChoices.length, createdAt: question.createdAt,
+    };
+    for (const choice of allChoices.slice(start.choice, start.choice + Number(rawLimit))) {
+      const candidateChoices = [...choices, choice];
+      const nextPrompt = promptOffset < question.definition.prompt.length;
+      const nextChoice = start.choice + candidateChoices.length < allChoices.length;
+      const candidate = { ...base, choices: candidateChoices, ...(nextPrompt || nextChoice ? { nextCursor: `${question.creationSequence}:${promptOffset}:${start.choice + candidateChoices.length}` } : {}) };
+      if (Buffer.byteLength(JSON.stringify(candidate), "utf8") > QUESTION_LIMITS.dtoBytes) break;
+      choices.push(choice);
+    }
+    if (start.choice < allChoices.length && !choices.length) throw new Error("Question detail cannot make progress within its output bound");
+    const nextPrompt = promptOffset < question.definition.prompt.length;
+    const nextChoice = start.choice + choices.length < allChoices.length;
+    const result = deepFreeze({ ...base, choices, ...(nextPrompt || nextChoice ? { nextCursor: `${question.creationSequence}:${promptOffset}:${start.choice + choices.length}` } : {}) });
+    if (Buffer.byteLength(JSON.stringify(result), "utf8") > QUESTION_LIMITS.dtoBytes) throw new Error("Question detail DTO exceeds its bounded output contract");
+    return result;
+  }
+
+  status(request: QuestionStatusRequest = {}): QuestionStatusPage {
+    if (!plainRecord(request)) throw new Error("Question status request is invalid");
+    exactKeys(request, [], ["state", "limit", "cursor"], "Question status request");
+    if (request.state !== undefined && request.state !== "pending" && request.state !== "answered" && request.state !== "closed") throw new Error("Question status filter is invalid");
+    const rawLimit = request.limit;
+    if (rawLimit !== undefined && !Number.isSafeInteger(rawLimit)) throw new Error("Question status limit is invalid");
+    const limit = rawLimit === undefined ? 20 : Number(rawLimit);
+    if (limit < 1 || limit > QUESTION_LIMITS.dtoItems) throw new Error("Question status limit is invalid");
+    if (request.cursor !== undefined && typeof request.cursor !== "string") throw new Error("Question status cursor is invalid");
+    const questions = Object.values(this.restore().questions).sort((a, b) => a.creationSequence - b.creationSequence);
+    const afterSequence = statusCursor(request.cursor as string | undefined, request.state, questions);
+    const all = questions.filter((question) => (request.state === undefined || question.state === request.state) && question.creationSequence > afterSequence);
+    const total = questions.filter((question) => request.state === undefined || question.state === request.state).length;
+    const items: QuestionStatusItem[] = [];
+    let lastSequence = afterSequence;
+    for (const question of all.slice(0, limit)) {
+      const preview = utf8Prefix(question.definition.prompt, 512);
+      const item = deepFreeze({
+        questionId: question.questionId, projectId: question.projectId, sessionId: question.sessionId,
+        runId: question.runId, nodeId: question.nodeId, ...(question.taskId ? { taskId: question.taskId } : {}),
+        kind: question.definition.kind, required: question.definition.required, state: question.state,
+        promptPreview: preview, promptBytes: Buffer.byteLength(question.definition.prompt, "utf8"), promptTruncated: preview !== question.definition.prompt,
+        choiceCount: question.definition.choices?.length ?? 0, createdAt: question.createdAt,
+        ...(question.answer ? { answerChannel: question.answer.channel, answeredAt: question.answer.answeredAt } : {}),
+        ...(question.closure ? { closedAt: question.closure.closedAt } : {}),
+        readRef: `run:${question.runId}/question:${question.questionId}`,
+      });
+      const cursor = `${request.state ?? "all"}:${question.creationSequence}`;
+      const candidate = { total, items: [...items, item], ...(items.length + 1 < all.length ? { nextCursor: cursor } : {}) };
+      if (Buffer.byteLength(JSON.stringify(candidate), "utf8") > QUESTION_LIMITS.dtoBytes) break;
+      items.push(item);
+      lastSequence = question.creationSequence;
+    }
+    if (all.length && !items.length) throw new Error("Question status cannot make progress within its output bound");
+    const result = deepFreeze({ total, items, ...(items.length < all.length ? { nextCursor: `${request.state ?? "all"}:${lastSequence}` } : {}) });
+    if (Buffer.byteLength(JSON.stringify(result), "utf8") > QUESTION_LIMITS.dtoBytes) throw new Error("Question status DTO exceeds its bounded output contract");
+    return result;
+  }
+
+  hasLiveHandles(): boolean { return this.presentations.size > 0; }
+  isShutdown(): boolean { return this.closed; }
+
+  async shutdown(): Promise<void> {
+    this.closed = true;
+    const tracked = [...this.presentations.values()];
+    for (const { controller } of tracked) controller.abort("Question service shutdown");
+    await Promise.allSettled(tracked.map(({ settlement }) => settlement));
+  }
+}

--- a/src/workflows/runs.ts
+++ b/src/workflows/runs.ts
@@ -107,9 +107,15 @@ export interface WorkflowRunRecord {
   readonly pendingDelivery?: PendingInputDelivery;
   readonly cancellationRequested: boolean;
   readonly cancellationReason?: string;
+  /** Exact question closure set frozen atomically with the cancellation request. */
+  readonly cancellationQuestionIds?: readonly string[];
   readonly cancellationSettlementFailure?: string;
   readonly pauseState?: Readonly<Record<string, JsonValue>>;
   readonly resumeStatus?: Exclude<OpenRunStatus, "paused">;
+  /** Durable exact approval requests; the approval wait cause remains until this set is empty. */
+  readonly pendingApprovalRequestIds?: readonly string[];
+  /** Durable independent causes whose removal controls waiting_for_human settlement. */
+  readonly waitCauses?: readonly ("approval" | "question")[];
   readonly pauseReleasePending?: boolean;
   readonly pendingTerminal?: PendingTerminalSettlement;
   readonly terminal?: PersistedTerminalEnvelope;
@@ -144,6 +150,10 @@ export interface TerminalSettlementRequest {
 export interface CompletionValidationHooks {
   readonly descendants?: () => CompletionGateResult | Promise<CompletionGateResult>;
   readonly questions?: () => CompletionGateResult | Promise<CompletionGateResult>;
+  /** Synchronously validates the exact pending question projection under a journal append lock. */
+  readonly validateQuestionSet?: (events: readonly WorkflowEventEnvelope[], expectedQuestionIds: readonly string[]) => void;
+  /** Rejects ordinary root terminal preparation while an answered root value is not transcript-delivered. */
+  readonly validateRootQuestionDelivery?: (events: readonly WorkflowEventEnvelope[]) => void;
   readonly adapter?: () => CompletionGateResult | Promise<CompletionGateResult>;
   readonly approvals?: () => CompletionGateResult | Promise<CompletionGateResult>;
   readonly evidence?: (references: readonly EvidenceReference[]) => CompletionGateResult | Promise<CompletionGateResult>;
@@ -288,6 +298,13 @@ function requiredString(payload: Record<string, JsonValue>, key: string, maxByte
   return value;
 }
 
+function hasUnsafeInputControl(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0)!;
+    return code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d;
+  });
+}
+
 function parseInput(value: JsonValue | undefined, expectedKind?: RunInputKind): RunInputRecord {
   const input = recordPayload(value as JsonValue);
   const sequence = input.sequence;
@@ -297,11 +314,13 @@ function parseInput(value: JsonValue | undefined, expectedKind?: RunInputKind): 
   if (kind !== "initial" && kind !== "steering" && kind !== "handoff") throw new Error("Run input kind is invalid");
   if (expectedKind && kind !== expectedKind) throw new Error("Run input kind does not match event");
   if (source !== "interactive" && source !== "rpc" && source !== "extension" && source !== "handoff") throw new Error("Run input source is invalid");
+  const text = requiredString(input, "text", RUN_LIFECYCLE_LIMITS.inputBytes);
+  if (hasUnsafeInputControl(text)) throw new Error("Run input text contains an unsafe control character");
   return freezeInput({
     sequence: sequence as number,
     inputId: requiredString(input, "inputId"),
     kind,
-    text: requiredString(input, "text", RUN_LIFECYCLE_LIMITS.inputBytes),
+    text,
     source,
     receivedAt: requiredString(input, "receivedAt"),
   });
@@ -343,14 +362,21 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
 
   if (event.type === "approval.recorded" && payload.subsystem === "checkpoint-approval" && (payload.operation === "request" || payload.operation === "decision")) {
     const run = requireCurrentRun(state, event);
-    if (!isOpenRunStatus(run.status) || run.cancellationRequested || run.pendingTerminal) throw new Error("Checkpoint approval cannot change a terminal, cancelling, or finalizing run");
+    if (!isOpenRunStatus(run.status) || run.status === "paused" || run.cancellationRequested || run.pendingTerminal) throw new Error("Checkpoint approval cannot change a terminal, paused, cancelling, or finalizing run");
+    const causes = new Set(run.waitCauses ?? (run.status === "waiting_for_human" ? ["approval" as const] : []));
+    const requestId = requiredString(payload, "requestId", RUN_LIFECYCLE_LIMITS.requestIdBytes);
+    const pendingApprovals = new Set(run.pendingApprovalRequestIds ?? []);
     if (payload.operation === "request") {
-      if (event.producer !== "harness" || run.status !== "running") throw new Error("Checkpoint approval request lacks harness authority or a running run");
-      return freezeRun(state, { ...run, status: "waiting_for_human" });
+      if (event.producer !== "harness" || (run.status !== "running" && run.status !== "waiting_for_human")) throw new Error("Checkpoint approval request lacks harness authority or an open run");
+      if (pendingApprovals.has(requestId)) throw new Error("Checkpoint approval request identity is already pending");
+      pendingApprovals.add(requestId);
+      causes.add("approval");
+      return freezeRun(state, { ...run, status: "waiting_for_human", pendingApprovalRequestIds: Object.freeze([...pendingApprovals].sort()), waitCauses: Object.freeze([...causes].sort()) });
     }
     if (payload.operation === "decision") {
-      if ((event.producer !== "dashboard" && event.producer !== "harness") || run.status !== "waiting_for_human") throw new Error("Checkpoint decision lacks human control authority or a waiting run");
-      return freezeRun(state, { ...run, status: "running" });
+      if ((event.producer !== "dashboard" && event.producer !== "harness") || run.status !== "waiting_for_human" || !causes.has("approval") || !pendingApprovals.delete(requestId)) throw new Error("Checkpoint decision lacks human control authority or an exact pending approval wait");
+      if (!pendingApprovals.size) causes.delete("approval");
+      return freezeRun(state, { ...run, status: causes.size ? "waiting_for_human" : "running", pendingApprovalRequestIds: Object.freeze([...pendingApprovals].sort()), waitCauses: Object.freeze([...causes].sort()) });
     }
     throw new Error("Checkpoint approval operation is unsupported");
   }
@@ -397,7 +423,8 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
     if (run.pendingTerminal) throw new Error("Run terminal settlement is already prepared");
     if (run.cancellationRequested) throw new Error("Run cancellation was already requested");
     const reason = requiredString(payload, "reason", RUN_LIFECYCLE_LIMITS.summaryBytes);
-    return freezeRun(state, { ...run, cancellationRequested: true, cancellationReason: reason });
+    const cancellationQuestionIds = payload.closedQuestionIds === undefined ? Object.freeze([]) : terminalStringArray(payload.closedQuestionIds, "cancellation questions", 256);
+    return freezeRun(state, { ...run, cancellationRequested: true, cancellationReason: reason, cancellationQuestionIds });
   }
 
   if (event.type === "run.cancel.settlement.failed") {
@@ -429,8 +456,23 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
     if (!isOpenRunStatus(run.status) || run.cancellationRequested || run.pendingTerminal) throw new Error("Terminal, cancelling, or finalizing run state is immutable");
     const from = statusValue(payload.from);
     const to = statusValue(payload.to);
-    if (from !== run.status || !isOpenRunStatus(from) || !isOpenRunStatus(to) || from === to) {
+    const waitCause = payload.waitCause;
+    const waitOperation = payload.waitOperation;
+    const isCauseTransition = waitCause === "question" && (waitOperation === "add" || waitOperation === "remove")
+      && from === "waiting_for_human" && to === "waiting_for_human";
+    if (from !== run.status || !isOpenRunStatus(from) || !isOpenRunStatus(to) || (from === to && !isCauseTransition)) {
       throw new Error(`Invalid run transition: ${String(from)} -> ${String(to)}`);
+    }
+    if (waitCause !== undefined || waitOperation !== undefined) {
+      if (waitCause !== "question" || (waitOperation !== "add" && waitOperation !== "remove") || from === "paused" || to === "paused") throw new Error("Run wait-cause transition is invalid");
+      const causes = new Set(run.waitCauses ?? (run.status === "waiting_for_human" ? ["question" as const] : []));
+      if (waitOperation === "add") causes.add("question"); else {
+        if (!causes.has("question")) throw new Error("Run question wait cause is not active");
+        causes.delete("question");
+      }
+      const expectedStatus: OpenRunStatus = causes.size ? "waiting_for_human" : "running";
+      if (to !== expectedStatus) throw new Error("Run wait-cause transition does not match remaining causes");
+      return freezeRun(state, { ...run, status: expectedStatus, waitCauses: Object.freeze([...causes].sort()) });
     }
     if (to === "paused") {
       if (from === "paused") throw new Error(`Invalid run transition: ${String(from)} -> ${String(to)}`);
@@ -452,6 +494,7 @@ export function reduceRunLifecycle(state: RunLifecycleState, event: WorkflowEven
     if (terminal.status !== "cancelled" && !budgetFailure && (run.pendingDelivery || run.deliveredThrough !== run.inputs.length)) throw new Error("Terminal outcome requires every input to be delivered");
     if (terminal.runId !== run.runId) throw new Error("Terminal envelope run identity mismatch");
     if (terminal.status === "cancelled" && !run.cancellationRequested) throw new Error("Cancelled terminal requires a cancellation request");
+    if (terminal.status === "cancelled" && canonicalJson(terminal.closedQuestionIds) !== canonicalJson(run.cancellationQuestionIds ?? [])) throw new Error("Cancelled terminal question closures do not match the frozen cancellation set");
     if (terminal.status !== "cancelled" && run.cancellationRequested) throw new Error("Cancellation in progress blocks a non-cancelled terminal outcome");
     if (terminal.status !== "cancelled") {
       if (!run.pendingTerminal) throw new Error("Non-cancelled terminal outcome requires durable settlement preparation");
@@ -477,7 +520,7 @@ function asJson(value: unknown): JsonValue {
 
 function validateInput(input: RecordRunInput): void {
   if (!input.inputId || Buffer.byteLength(input.inputId, "utf8") > 256) throw new Error("Run input ID is invalid");
-  if (!input.text || Buffer.byteLength(input.text, "utf8") > RUN_LIFECYCLE_LIMITS.inputBytes) throw new Error("Run input text is empty or too large");
+  if (!input.text || Buffer.byteLength(input.text, "utf8") > RUN_LIFECYCLE_LIMITS.inputBytes || hasUnsafeInputControl(input.text)) throw new Error("Run input text is empty, unsafe, or too large");
   if (input.source !== "interactive" && input.source !== "rpc" && input.source !== "extension" && input.source !== "handoff") throw new Error("Run input source is invalid");
 }
 
@@ -889,22 +932,42 @@ export class WorkflowRunLifecycle {
     });
   }
 
+  transitionFromWaitingForHuman(reason: string): void {
+    if (!reason.trim()) throw new Error("Human-resume reason is required");
+    const run = this.restore().latestRun;
+    if (!run || run.status !== "waiting_for_human" || run.cancellationRequested || run.pendingTerminal) throw new Error("Only a waiting non-finalizing run can resume from human input");
+    const causes = new Set(run.waitCauses ?? ["question" as const]);
+    if (!causes.has("question")) throw new Error("Run is not waiting on a human question");
+    causes.delete("question");
+    const to = causes.size ? "waiting_for_human" as const : "running" as const;
+    const timestamp = this.options.now?.() ?? new Date().toISOString();
+    appendWorkflowEventChecked(this.options.projectRoot, createWorkflowEvent({
+      projectId: this.options.projectId, sessionId: this.options.sessionId, runId: run.runId, type: "run.transition",
+      payload: { formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, from: "waiting_for_human", to, reason: reason.slice(0, 2_048), waitCause: "question", waitOperation: "remove" },
+      producer: "runtime", timestamp,
+    }), (existing) => {
+      const locked = replayWorkflowJournal(existing, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
+      if (!locked || locked.runId !== run.runId || locked.status !== "waiting_for_human" || !(locked.waitCauses ?? ["question"]).includes("question") || locked.cancellationRequested || locked.pendingTerminal) throw new Error("Run changed before human-answer resume persistence");
+    });
+    this.options.onRunStatusChanged?.(run.runId, to, timestamp);
+  }
+
   transitionToWaitingForHuman(reason: string): void {
     if (!reason.trim()) throw new Error("Waiting reason is required");
     const run = this.restore().latestRun;
-    if (!run || run.status !== "running" || run.cancellationRequested || run.pendingTerminal) throw new Error("Only a running non-finalizing run can wait for human input");
+    if (!run || (run.status !== "running" && run.status !== "waiting_for_human") || run.waitCauses?.includes("question") || run.cancellationRequested || run.pendingTerminal) throw new Error("Only an open non-question-waiting run can wait for human input");
     const timestamp = this.options.now?.() ?? new Date().toISOString();
     appendWorkflowEventChecked(this.options.projectRoot, createWorkflowEvent({
       projectId: this.options.projectId,
       sessionId: this.options.sessionId,
       runId: run.runId,
       type: "run.transition",
-      payload: { formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, from: "running", to: "waiting_for_human", reason: reason.slice(0, 2_048) },
+      payload: { formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, from: run.status, to: "waiting_for_human", reason: reason.slice(0, 2_048), waitCause: "question", waitOperation: "add" },
       producer: "runtime",
       timestamp,
     }), (existing) => {
       const locked = replayWorkflowJournal(existing, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
-      if (!locked || locked.runId !== run.runId || locked.status !== "running" || locked.cancellationRequested || locked.pendingTerminal) throw new Error("Run changed before waiting state persistence");
+      if (!locked || locked.runId !== run.runId || locked.status !== run.status || locked.waitCauses?.includes("question") || locked.cancellationRequested || locked.pendingTerminal) throw new Error("Run changed before waiting state persistence");
     });
     this.options.onRunStatusChanged?.(run.runId, "waiting_for_human", timestamp);
   }
@@ -1011,9 +1074,10 @@ export class WorkflowRunLifecycle {
     }
   }
 
-  requestCancellation(reason: string): void {
+  requestCancellation(reason: string, closedQuestionIds: readonly string[] = [], validateQuestionSet?: (events: readonly WorkflowEventEnvelope[], expectedQuestionIds: readonly string[]) => void): void {
     if (!reason.trim()) throw new Error("Cancellation reason is empty");
     const boundedReason = truncateUtf8(reason, RUN_LIFECYCLE_LIMITS.summaryBytes);
+    const boundedQuestionIds = terminalStringArray(closedQuestionIds, "cancellation questions", 256);
     const events = readWorkflowJournal(this.options.projectRoot, this.options.sessionId);
     const state = replayWorkflowJournal(events, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state;
     const run = state.latestRun;
@@ -1021,16 +1085,17 @@ export class WorkflowRunLifecycle {
     if (run.pendingTerminal) throw new Error("Cannot cancel while terminal settlement is in progress");
     if (run.cancellationRequested) return;
     const timestamp = this.options.now?.() ?? new Date().toISOString();
-    const draft = createWorkflowEvent({ projectId: this.options.projectId, sessionId: this.options.sessionId, runId: run.runId, type: "run.cancel.requested", payload: { formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, reason: boundedReason }, producer: "harness", timestamp });
+    const draft = createWorkflowEvent({ projectId: this.options.projectId, sessionId: this.options.sessionId, runId: run.runId, type: "run.cancel.requested", payload: { formatVersion: RUN_LIFECYCLE_FORMAT_VERSION, reason: boundedReason, closedQuestionIds: [...boundedQuestionIds] }, producer: "harness", timestamp });
     try {
       appendWorkflowEventChecked(this.options.projectRoot, draft, (existing) => {
         const locked = replayWorkflowJournal(existing, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
         if (!locked || locked.runId !== run.runId || !isOpenRunStatus(locked.status) || locked.pendingTerminal) throw new Error("Run changed before cancellation could be requested");
         if (locked.cancellationRequested) throw new Error("Cancellation was already requested concurrently");
+        validateQuestionSet?.(existing, boundedQuestionIds);
       });
     } catch (error) {
       const latest = this.restore().latestRun;
-      if (latest?.runId === run.runId && latest.cancellationRequested) return;
+      if (latest?.runId === run.runId && latest.cancellationRequested && canonicalJson(latest.cancellationQuestionIds ?? []) === canonicalJson(boundedQuestionIds)) return;
       throw error;
     }
   }
@@ -1064,7 +1129,20 @@ export class WorkflowRunLifecycle {
     if (initial?.status === "cancelled" && initial.terminal) return Object.freeze({ envelope: initial.terminal, rendered: canonicalJson(initial.terminal) });
     if (!initial || !isOpenRunStatus(initial.status)) throw new Error("Cannot cancel a terminal or missing run");
     this.assertCurrentRuntimeOwner();
-    if (!initial.cancellationRequested) this.requestCancellation(reason);
+    if (!initial.cancellationRequested) {
+      for (let attempt = 0; attempt <= 256; attempt++) {
+        const questionGate = await runGate("questions", this.options.completion?.questions);
+        const expected = Object.freeze([...(questionGate.pendingQuestionIds ?? [])].sort());
+        try {
+          this.requestCancellation(reason, expected, this.options.completion?.validateQuestionSet);
+          break;
+        } catch (error) {
+          const latest = this.restore().latestRun;
+          if (latest?.cancellationRequested) break;
+          if (!this.options.completion?.validateQuestionSet || !/question set changed/i.test(String(error instanceof Error ? error.message : error)) || attempt === 256) throw error;
+        }
+      }
+    }
     const run = this.restore().latestRun!;
     const terminalSummary = truncateUtf8(`Cancelled: ${run.cancellationReason ?? reason}`, RUN_LIFECYCLE_LIMITS.summaryBytes);
     if (!terminalSummary) throw new Error("Cancellation terminal summary is invalid");
@@ -1083,6 +1161,7 @@ export class WorkflowRunLifecycle {
 
   private async settleCancellation(run: WorkflowRunRecord, terminalSummary: string, coordinator: CancellationCoordinator, settlementKey: string): Promise<CancellationResult> {
     const diagnostics: string[] = [];
+    const closedQuestionIds = Object.freeze([...(run.cancellationQuestionIds ?? [])]);
     if (OUTSTANDING_CANCELLATION_STEPS.get(settlementKey)?.size) {
       this.persistCancellationSettlementFailure(run.runId, ["a previously timed-out coordinator action is still running"]);
     }
@@ -1144,7 +1223,7 @@ export class WorkflowRunLifecycle {
       evidenceRefs: [],
       data: {},
       unsatisfiedGates: [],
-      closedQuestionIds: [],
+      closedQuestionIds,
       partialState,
       finishedByNodeId: "harness",
       finishedAt,
@@ -1199,7 +1278,7 @@ export class WorkflowRunLifecycle {
         if (!locked || locked.runId !== run.runId || !isOpenRunStatus(locked.status) || locked.cancellationRequested || locked.pendingTerminal?.operationId !== prepared.operationId) throw new Error("Terminal settlement changed before commit");
         const { operationId: _lockedOperationId, ...lockedPayload } = locked.pendingTerminal;
         if (canonicalJson(lockedPayload) !== canonicalJson(payload)) throw new Error("Terminal settlement payload changed before commit");
-      });
+      }, { fault: (stage) => this.options.journalFault?.("terminal.recorded", stage) });
     } catch (error) {
       const latest = this.restore().latestRun;
       if (latest?.terminal && latest.runId === run.runId) return Object.freeze({ ok: true, envelope: latest.terminal, rendered: canonicalJson(latest.terminal) });
@@ -1226,6 +1305,8 @@ export class WorkflowRunLifecycle {
         : Object.freeze({ ok: false, issues: Object.freeze(["A different terminal settlement is already prepared for this run"]) });
     }
 
+    const questionGate = await runGate("questions", this.options.completion?.questions);
+    const closedQuestionIds = Object.freeze([...(questionGate.pendingQuestionIds ?? [])].sort());
     let fileChanges: readonly FileChangeRecord[] = [];
     let changeCoverage = "partial";
     let partialState: Readonly<Record<string, JsonValue>> = Object.freeze({});
@@ -1248,7 +1329,7 @@ export class WorkflowRunLifecycle {
       evidenceRefs: [],
       data: { failureCode: "budget_exhausted" },
       unsatisfiedGates: ["budget_exhausted"],
-      closedQuestionIds: [],
+      closedQuestionIds,
       partialState,
       finishedByNodeId: this.options.rootNodeId,
       finishedAt,
@@ -1266,11 +1347,13 @@ export class WorkflowRunLifecycle {
       }), (existing) => {
         const locked = replayWorkflowJournal(existing, createEmptyRunLifecycleState(this.options.sessionId), reduceRunLifecycle).state.latestRun;
         if (!locked || locked.runId !== restored.runId || !isOpenRunStatus(locked.status) || locked.cancellationRequested || locked.pendingTerminal) throw new Error("Run changed before budget failure preparation");
+        this.options.completion?.validateQuestionSet?.(existing, closedQuestionIds);
       }, { fault: (stage) => this.options.journalFault?.("run.terminal.prepared", stage) });
     } catch (error) {
       const concurrent = this.restore().latestRun;
       if (concurrent?.terminal?.data.failureCode === "budget_exhausted") return Object.freeze({ ok: true, envelope: concurrent.terminal, rendered: canonicalJson(concurrent.terminal) });
       if (concurrent?.pendingTerminal?.data.failureCode === "budget_exhausted") return this.commitPreparedTerminal(concurrent, concurrent.pendingTerminal);
+      if (this.options.completion?.validateQuestionSet && /question set changed/i.test(String(error instanceof Error ? error.message : error))) return this.failBudgetExhaustion(reason);
       return Object.freeze({ ok: false, issues: Object.freeze([String(error instanceof Error ? error.message : error)]) });
     }
     const prepared = this.restore().latestRun?.pendingTerminal;
@@ -1391,6 +1474,7 @@ export class WorkflowRunLifecycle {
         if (!lockedRun || lockedRun.runId !== run.runId || !isOpenRunStatus(lockedRun.status)) throw new Error("run changed during finish validation");
         if (lockedRun.cancellationRequested || lockedRun.pendingTerminal) throw new Error("cancellation or terminal settlement started during finish validation");
         if (lockedRun.pendingDelivery || lockedRun.deliveredThrough !== lockedRun.inputs.length) throw new Error("input arrived during finish validation and must be delivered");
+        hooks.validateRootQuestionDelivery?.(existing);
       }, { fault: (stage) => this.options.journalFault?.("run.terminal.prepared", stage) });
     } catch (error) {
       return Object.freeze({ ok: false, issues: Object.freeze([String(error instanceof Error ? error.message : error)]) });

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -5,10 +5,13 @@ import {
   type DelegationRuntime,
   type PersistedDelegationTask,
   type WorkerResultInput,
+  isDelegationResumeReady,
 } from "./delegation";
 import { compareText as compare, utf8Prefix } from "./values";
 
-export type SchedulerExecutionResult = WorkerResultInput | Readonly<{ status: "suspended"; dependencyTaskIds: readonly string[] }>;
+export type SchedulerExecutionResult = WorkerResultInput
+  | Readonly<{ status: "suspended"; dependencyTaskIds?: readonly string[]; questionIds?: readonly string[] }>
+  | Readonly<{ status: "continuation"; questionIds: readonly string[] }>;
 
 export interface SchedulerTaskControl {
   readonly signal: AbortSignal; readonly attemptId: string;
@@ -25,6 +28,8 @@ export interface DurableDelegationSchedulerOptions {
   readonly verifiedTakeover?: () => boolean | Promise<boolean>;
   readonly onRecoveryReconciled?: () => void | Promise<void>;
   readonly onResultDurable?: (task: PersistedDelegationTask) => void | Promise<void>;
+  /** Volatile run-wide gate: false stops new launches without mutating queued/resume-ready tasks or active work. */
+  readonly canLaunch?: () => boolean;
 }
 interface ActiveExecution {
   readonly nodeId: string; readonly attemptId: string;
@@ -33,8 +38,12 @@ interface ActiveExecution {
 
 function validateExecutionResult(value: SchedulerExecutionResult): void {
   if (!value || typeof value !== "object") throw new Error("Worker executor returned no result");
-  if (value.status === "suspended") {
-    if (!Array.isArray(value.dependencyTaskIds) || value.dependencyTaskIds.length === 0) throw new Error("Suspended worker returned no dependency tasks");
+  if (value.status === "suspended" || value.status === "continuation") {
+    const dependencies = value.status === "suspended" && Array.isArray(value.dependencyTaskIds) ? value.dependencyTaskIds : [];
+    const questions = Array.isArray(value.questionIds) ? value.questionIds : [];
+    if (!dependencies.length && !questions.length) throw new Error(value.status === "continuation" ? "Continuing worker returned no durable question IDs" : "Suspended worker returned no dependency tasks or question IDs");
+    if (dependencies.length && questions.length) throw new Error("Suspended worker must return exactly one dependency or question set");
+    if ([...dependencies, ...questions].some((id) => typeof id !== "string" || !id || Buffer.byteLength(id, "utf8") > 256) || new Set([...dependencies, ...questions]).size !== dependencies.length + questions.length) throw new Error("Worker suspension/continuation returned invalid or duplicate durable IDs");
     return;
   }
   if (value.status !== "completed" && value.status !== "blocked" && value.status !== "failed" && value.status !== "cancelled") {
@@ -64,7 +73,7 @@ export function selectNextDelegationTask(runtime: DelegationRuntime, activeNodes
   for (const [nodeId, queue] of nodeQueues) {
     if (activeNodes.has(nodeId)) continue;
     const head = queue.sort((a, b) => a.creationSequence - b.creationSequence || compare(a.taskId, b.taskId))[0];
-    if (head?.queueState === "queued" || (head?.queueState === "active" && head.resumedByResultSequence !== undefined)) eligible.push(head);
+    if (head?.queueState === "queued" || (head && isDelegationResumeReady(head))) eligible.push(head);
   }
   return eligible.sort((a, b) =>
     (lastDispatched.get(a.targetNodeId) ?? 0) - (lastDispatched.get(b.targetNodeId) ?? 0)
@@ -81,6 +90,7 @@ export class DurableDelegationScheduler {
   private reason = "Scheduler stopped";
   private runPromise?: Promise<void>;
   private recoveryComplete = false;
+  private yieldRequested = false;
 
   constructor(options: DurableDelegationSchedulerOptions) {
     if (!Number.isSafeInteger(options.maxParallel) || options.maxParallel < 1 || options.maxParallel > 1_024) {
@@ -106,7 +116,7 @@ export class DurableDelegationScheduler {
 
   private async reconcileTakeover(): Promise<void> {
     if (this.recoveryComplete) return;
-    const hasActive = Object.values(this.options.runtime.restore().tasks).some((task) => task.queueState === "active" && task.resumedByResultSequence === undefined);
+    const hasActive = Object.values(this.options.runtime.restore().tasks).some((task) => task.queueState === "active" && !isDelegationResumeReady(task));
     if (hasActive) {
       if (!this.options.verifiedTakeover || !await this.options.verifiedTakeover()) throw new Error("Journal-active delegation tasks require verified takeover before recovery");
       this.options.runtime.reconcileActiveAfterTakeover(true);
@@ -164,6 +174,7 @@ export class DurableDelegationScheduler {
     if (!current || current.queueState === "terminal") return;
     const pendingDependencies = current.suspendedOn?.filter((dependencyId) => currentState.tasks[dependencyId]?.resultAcceptedSequence === undefined) ?? [];
     if (controller.signal.aborted && this.paused && !this.closing) {
+      if ((current.queueState === "suspended" && current.suspendedOnQuestionIds?.length) || isDelegationResumeReady(current)) return;
       if (pendingDependencies.length) this.options.runtime.suspend(task.taskId, [...current.suspendedOn!]);
       else this.options.runtime.interrupt(task.taskId, this.reason);
       return;
@@ -172,12 +183,39 @@ export class DurableDelegationScheduler {
     if (pendingDependencies.length && !this.closing) {
       settledResult = Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...current.suspendedOn!]) });
       this.options.runtime.suspend(task.taskId, [...current.suspendedOn!]);
-    } else if (result.status === "suspended") {
-      this.options.runtime.suspend(task.taskId, [...result.dependencyTaskIds]);
-    } else {
-      this.options.runtime.recordResult(task.taskId, result);
+    } else if (result.status === "continuation") {
       const durable = this.options.runtime.restore().tasks[task.taskId];
-      if (durable) await this.options.onResultDurable?.(durable);
+      if (durable?.queueState !== "active" || durable.resumedByQuestionSequence === undefined || durable.result) throw new Error("Question answer continuation does not match a durable resume-ready task");
+      // A continuation that did not consume its pre-bound answer must receive a
+      // fresh durable model-turn identity. The delegation attempt/transcript
+      // stay immutable, while a known failed containing attempt is never
+      // replayed as the next provider dispatch.
+      this.options.runtime.advanceQuestionContinuationTurn(task.taskId, attemptId, result.questionIds);
+      this.yieldRequested = true;
+    } else if (result.status === "suspended" && result.questionIds?.length) {
+      const durable = this.options.runtime.restore().tasks[task.taskId];
+      if (durable?.queueState !== "suspended" || !durable.suspendedOnQuestionIds
+        || durable.suspendedOnQuestionIds.length !== result.questionIds.length
+        || durable.suspendedOnQuestionIds.some((id) => !result.questionIds!.includes(id))) throw new Error("Question suspension does not match journal-first pending state");
+    } else if (result.status === "suspended") {
+      this.options.runtime.suspend(task.taskId, [...result.dependencyTaskIds!]);
+    } else {
+      try {
+        this.options.runtime.recordResult(task.taskId, result);
+        const durable = this.options.runtime.restore().tasks[task.taskId];
+        if (durable) await this.options.onResultDurable?.(durable);
+      } catch (error) {
+        const durable = this.options.runtime.restore().tasks[task.taskId];
+        const questionIds = durable?.resumedQuestionIds ?? [];
+        if (!durable || !isDelegationResumeReady(durable) || durable.attempts.at(-1)?.attemptId !== attemptId || durable.result || !questionIds.length) throw error;
+        // Terminal publication can lose to the undelivered-answer guard (for
+        // example after node-budget denial). Publish a fresh durable turn
+        // identity before yielding; a volatile continuation alone would leave
+        // the same resume-ready state in a scheduler hot loop.
+        this.options.runtime.advanceQuestionContinuationTurn(task.taskId, attemptId, questionIds);
+        this.yieldRequested = true;
+        settledResult = Object.freeze({ status: "continuation" as const, questionIds: Object.freeze([...questionIds]) });
+      }
     }
     await this.options.hooks?.onAttemptSettled?.(task, attemptId, settledResult);
   }
@@ -185,8 +223,8 @@ export class DurableDelegationScheduler {
   private async runLoop(): Promise<void> {
     await this.reconcileTakeover();
     for (;;) {
-      if (!this.closing && !this.paused) {
-        while (this.active.size < this.options.maxParallel) {
+      if (!this.yieldRequested && !this.closing && !this.paused && (this.options.canLaunch?.() ?? true)) {
+        while (this.active.size < this.options.maxParallel && (this.options.canLaunch?.() ?? true)) {
           const task = selectNextDelegationTask(this.options.runtime, this.activeNodes());
           if (!task) break;
           this.launch(task);
@@ -199,6 +237,7 @@ export class DurableDelegationScheduler {
 
   runUntilSettled(): Promise<void> {
     if (this.runPromise) return this.runPromise;
+    this.yieldRequested = false;
     const running = this.runLoop();
     const tracked = running.finally(() => {
       if (this.runPromise === tracked) this.runPromise = undefined;
@@ -229,7 +268,7 @@ export class DurableDelegationScheduler {
     if (temporarilyPaused) this.options.runtime.pauseAdmission(summary);
     try {
       for (const task of Object.values(this.options.runtime.restore().tasks)
-        .filter((candidate) => candidate.queueState === "queued" || candidate.queueState === "suspended")
+        .filter((candidate) => candidate.queueState === "queued" || candidate.queueState === "suspended" || isDelegationResumeReady(candidate))
         .sort((left, right) => left.creationSequence - right.creationSequence || compare(left.taskId, right.taskId))) {
         this.options.runtime.recordResult(task.taskId, { status: "cancelled", summary, outputRefs: [], evidenceRefs: [], data: { budgetExhausted: true } });
       }

--- a/src/workflows/tools.ts
+++ b/src/workflows/tools.ts
@@ -12,6 +12,7 @@ import type { RunLifecycleState } from "./runs";
 import type { HandoffPacket } from "./handoff";
 import type { WorkerTrustedDispatch } from "./workers";
 import { boundedJson } from "./values";
+import { QUESTION_LIMITS, normalizeQuestionDefinition } from "./question-validation";
 
 export const TOOL_CONTRACT_VERSION = "pi-hive-prompt-tool-contract-v1" as const;
 export const TOOL_CONTRACT_LIMITS = Object.freeze({
@@ -61,6 +62,21 @@ const EvidenceReference = Type.Object({
   toolCallId: Type.Optional(Type.String({ minLength: 1, maxLength: 2_048 })),
   claim: Type.String({ minLength: 1, maxLength: 2_048 }),
 }, strict);
+const SAFE_QUESTION_TEXT_PATTERN = "^[^\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F]*$";
+const QuestionChoice = Type.Object({
+  value: Type.String({ minLength: 1, maxLength: QUESTION_LIMITS.choiceValueBytes, pattern: SAFE_QUESTION_TEXT_PATTERN }),
+  label: Type.String({ minLength: 1, maxLength: QUESTION_LIMITS.choiceLabelBytes, pattern: SAFE_QUESTION_TEXT_PATTERN }),
+}, strict);
+const QuestionTextValidation = Type.Object({
+  minLength: Type.Optional(Type.Integer({ minimum: 0, maximum: QUESTION_LIMITS.textAnswerBytes })),
+  maxLength: Type.Optional(Type.Integer({ minimum: 0, maximum: QUESTION_LIMITS.textAnswerBytes })),
+  pattern: Type.Optional(Type.String({ minLength: 1, maxLength: QUESTION_LIMITS.patternBytes })),
+}, strict);
+const QuestionMultiValidation = Type.Object({
+  minItems: Type.Optional(Type.Integer({ minimum: 0, maximum: QUESTION_LIMITS.choices })),
+  maxItems: Type.Optional(Type.Integer({ minimum: 0, maximum: QUESTION_LIMITS.choices })),
+}, strict);
+const QuestionPrompt = Type.String({ minLength: 1, maxLength: QUESTION_LIMITS.promptBytes, pattern: SAFE_QUESTION_TEXT_PATTERN });
 
 export const GENERIC_WORKFLOW_TOOL_SCHEMAS = Object.freeze({
   route_agent: Type.Object({
@@ -94,6 +110,12 @@ export const GENERIC_WORKFLOW_TOOL_SCHEMAS = Object.freeze({
     arguments: Type.Record(Type.String({ minLength: 1, maxLength: TOOL_CONTRACT_LIMITS.idCharacters }), Type.Unknown()),
     expectedWorkspaceHash: Type.Optional(Type.String({ pattern: "^sha256:[0-9a-f]{64}$", maxLength: 71 })),
   }, strict),
+  human_question: Type.Union([
+    Type.Object({ prompt: QuestionPrompt, kind: Type.Literal("single"), choices: Type.Array(QuestionChoice, { minItems: 1, maxItems: QUESTION_LIMITS.choices }), required: Type.Boolean() }, strict),
+    Type.Object({ prompt: QuestionPrompt, kind: Type.Literal("multi"), choices: Type.Array(QuestionChoice, { minItems: 1, maxItems: QUESTION_LIMITS.choices }), validation: Type.Optional(QuestionMultiValidation), required: Type.Boolean() }, strict),
+    Type.Object({ prompt: QuestionPrompt, kind: Type.Literal("text"), validation: Type.Optional(QuestionTextValidation), required: Type.Boolean() }, strict),
+    Type.Object({ prompt: QuestionPrompt, kind: Type.Literal("confirm"), required: Type.Boolean() }, strict),
+  ]),
   workflow_finish: Type.Object({
     status: Type.Union([Type.Literal("completed"), Type.Literal("blocked"), Type.Literal("failed")]),
     summary: Type.String({ minLength: 1, maxLength: 8_192 }),
@@ -121,6 +143,7 @@ export interface WorkflowToolRuntimeBindingInput {
   readonly workflowStatus: (input: WorkflowStatusRequest) => WorkflowStatusPage;
   readonly artifactStatus?: (input: { readonly limit?: number; readonly cursor?: string }, signal?: AbortSignal) => Promise<unknown>;
   readonly artifactAction?: (input: { readonly actionId: string; readonly arguments: Readonly<Record<string, unknown>>; readonly expectedWorkspaceHash?: string }, attemptId: string, signal?: AbortSignal) => Promise<unknown>;
+  readonly question?: (input: unknown, toolCallId: string, signal?: AbortSignal, batchCallIds?: readonly string[]) => Promise<unknown>;
   readonly finish: (input: unknown, toolBatch: readonly string[]) => Promise<unknown>;
 }
 export interface WorkflowToolRuntimeBinding {
@@ -132,6 +155,7 @@ export interface WorkflowToolRuntimeBinding {
   readonly workflowStatus: WorkflowToolRuntimeBindingInput["workflowStatus"];
   readonly artifactStatus?: WorkflowToolRuntimeBindingInput["artifactStatus"];
   readonly artifactAction?: WorkflowToolRuntimeBindingInput["artifactAction"];
+  readonly question?: WorkflowToolRuntimeBindingInput["question"];
   readonly finish: WorkflowToolRuntimeBindingInput["finish"];
 }
 interface ActiveWorkflowToolRuntime { readonly binding: WorkflowToolRuntimeBinding }
@@ -188,6 +212,7 @@ function assertByteBounds(name: GenericWorkflowToolName, input: Record<string, u
     boundedJson(input.arguments, "artifact_action arguments", { bytes: 65_536, depth: 16, nodes: 4_096, rootRecord: true });
     if (input.expectedWorkspaceHash !== undefined) assertUtf8(input.expectedWorkspaceHash, "artifact_action expectedWorkspaceHash", 71);
   }
+  if (name === "human_question") normalizeQuestionDefinition(input);
   if (name === "workflow_finish") {
     assertUtf8(input.summary, "workflow_finish summary", 8_192);
     for (const [index, raw] of ((input.artifactRefs ?? []) as Array<Record<string, unknown>>).entries()) {
@@ -269,30 +294,44 @@ function schemaInput(name: GenericWorkflowToolName, value: unknown): Record<stri
   return input;
 }
 
-function assistantToolBatch(ctx: ExtensionContext, toolCallId: string): readonly string[] {
+interface AssistantToolBatch {
+  readonly names: readonly string[];
+  readonly callIds: readonly string[];
+}
+function assistantToolBatch(ctx: ExtensionContext, toolCallId: string): AssistantToolBatch {
   const manager = ctx?.sessionManager;
   if (!manager || typeof manager.getBranch !== "function") throw new Error("Trusted Pi session context is required for workflow tools");
-  const matches: string[][] = [];
+  const matches: AssistantToolBatch[] = [];
   for (const entry of manager.getBranch()) {
     if (!entry || entry.type !== "message" || !entry.message || entry.message.role !== "assistant" || !Array.isArray(entry.message.content)) continue;
     const calls = entry.message.content.filter((part) => Boolean(part) && typeof part === "object" && !Array.isArray(part) && (part as { type?: unknown }).type === "toolCall") as Array<{ id?: unknown; toolCallId?: unknown; name?: unknown; toolName?: unknown }>;
     if (!calls.some((part) => part.id === toolCallId || part.toolCallId === toolCallId)) continue;
     const names = calls.map((part) => part.name ?? part.toolName);
-    if (!names.length || names.some((value) => typeof value !== "string" || !value || Buffer.byteLength(value, "utf8") > 128)) throw new Error("Trusted Pi assistant tool-call batch is invalid");
-    matches.push(names as string[]);
+    const identifierKey = calls.some((part) => part.id === toolCallId) ? "id" : "toolCallId";
+    const callIds = calls.map((part) => part[identifierKey]);
+    if (!names.length || names.some((value) => typeof value !== "string" || !value || Buffer.byteLength(value, "utf8") > 128)
+      || callIds.some((value) => typeof value !== "string" || !value || Buffer.byteLength(value, "utf8") > TOOL_CONTRACT_LIMITS.idBytes)
+      || new Set(callIds).size !== callIds.length) throw new Error("Trusted Pi assistant tool-call batch is invalid");
+    matches.push(Object.freeze({ names: Object.freeze(names as string[]), callIds: Object.freeze(callIds as string[]) }));
   }
-  if (matches.length !== 1 || matches[0].length > TOOL_CONTRACT_LIMITS.toolBatch) throw new Error("Workflow tool call is not bound to one trusted Pi assistant tool-call batch");
-  return Object.freeze([...matches[0]]);
+  if (matches.length !== 1 || matches[0].names.length > TOOL_CONTRACT_LIMITS.toolBatch) throw new Error("Workflow tool call is not bound to one trusted Pi assistant tool-call batch");
+  return matches[0];
 }
 
 async function executeTool(name: GenericWorkflowToolName, toolCallId: string, raw: unknown, ctx: ExtensionContext, signal?: AbortSignal): Promise<{ content: Array<{ type: "text"; text: string }>; details: object }> {
   const runtime = currentRuntime();
   const toolBatch = assistantToolBatch(ctx, toolCallId);
+  if (toolBatch.names.includes("delegate_agent") && toolBatch.names.includes("human_question")) {
+    // Both calls observe the complete immutable assistant batch before either
+    // reaches trusted dispatch, so sequential and concurrent execution orders
+    // reject without publishing a child task or a durable question.
+    throw new Error("delegate_agent and human_question cannot be sibling calls in one assistant tool batch");
+  }
   const input = schemaInput(name, raw);
   const descriptor = classifyTrustedTool(name);
   if (!descriptor || classifyTrustedToolRegistration(name, descriptor) !== descriptor) throw new Error(`Tool ${name} lacks trusted package registration identity`);
   const enabled = authorityTools(runtime.binding).includes(name);
-  const soleFinish = name !== "workflow_finish" || (toolBatch.length === 1 && toolBatch[0] === "workflow_finish");
+  const soleFinish = name !== "workflow_finish" || (toolBatch.names.length === 1 && toolBatch.names[0] === "workflow_finish");
   const team = runtime.binding.snapshot.payload.workflow.team as { nodes?: unknown[] } | undefined;
   const callerNode = Array.isArray(team?.nodes)
     ? team.nodes.find((entry) => entry && typeof entry === "object" && !Array.isArray(entry) && (entry as { id?: unknown }).id === runtime.binding.nodeId) as { memberIds?: unknown } | undefined
@@ -312,6 +351,7 @@ async function executeTool(name: GenericWorkflowToolName, toolCallId: string, ra
     policyOutcome: allowed ? "allowed" : "denied",
     ...(allowed ? {} : { denialReason }),
     ...(name === "workflow_finish" && allowed ? { finalization: true } : {}),
+    ...(name === "human_question" ? { questionBatchCallIds: toolBatch.callIds, questionBatchCurrentCallId: toolCallId } : {}),
     dispatch: async (attemptContext) => {
       if (name === "route_agent") return runtime.binding.team.route(input as never);
       if (name === "delegate_agent") return runtime.binding.team.delegate(input as never);
@@ -331,7 +371,11 @@ async function executeTool(name: GenericWorkflowToolName, toolCallId: string, ra
         if (!runtime.binding.artifactAction) throw Object.assign(new Error("Artifact action subsystem is not bound for this run"), { effectNotApplied: true });
         return runtime.binding.artifactAction(input as { actionId: string; arguments: Readonly<Record<string, unknown>>; expectedWorkspaceHash?: string }, attemptContext.attemptId, signal);
       }
-      return runtime.binding.finish(input, toolBatch);
+      if (name === "human_question") {
+        if (!runtime.binding.question) throw Object.assign(new Error("Human question subsystem is not bound for this run"), { effectNotApplied: true });
+        return runtime.binding.question(input, toolCallId, signal, toolBatch.callIds);
+      }
+      return runtime.binding.finish(input, toolBatch.names);
     },
   });
   if (name === "workflow_finish" && result && typeof result === "object" && "ok" in result && (result as { ok: boolean }).ok === false) {
@@ -379,6 +423,7 @@ export const GENERIC_WORKFLOW_TOOL_CONTRACTS: readonly ToolDefinition<any, objec
   contract("workflow_status", "Workflow Status", "Read bounded cursor-paginated workflow/run status and authority-derived terminal refs."),
   contract("artifact_status", "Artifact Status", "Read the active profile's bounded trusted workspace/checkpoint/action view."),
   contract("artifact_action", "Artifact Action", "Invoke one exact active-profile action; workspace and operation identity come only from trusted run state."),
+  contract("human_question", "Human Question", "Persist one bounded typed human question. Pending questions suspend the current task rather than blocking an in-memory promise."),
   contract("workflow_finish", "Workflow Finish", "Root-only sole-call request for a validated terminal workflow outcome."),
 ]);
 

--- a/src/workflows/workers.ts
+++ b/src/workflows/workers.ts
@@ -27,11 +27,15 @@ import {
 } from "./delegation";
 import type { RouteDirectMembersInput, RouteRecommendation } from "./routing";
 import type { MutationAccountingRecorder } from "./change-accounting";
+import type { AttemptConsumerReceiptBinding } from "./attempts";
+import type { AcceptedQuestionForTask, QuestionService, TaskQuestionAnswerDelivery } from "./questions";
 import { deepFreeze, utf8Prefix } from "./values";
 import {
   assembleWorkerWorkflowPrompt,
   assertCompactionPreservation,
+  assertLosslessDynamicPromptInputs,
   buildCompactionPreservationBlock,
+  losslessDynamicPromptInputs,
   type DynamicPromptInput,
 } from "./prompts";
 
@@ -45,6 +49,7 @@ export interface WorkerPromptTaskContract {
   readonly deliverables: readonly string[]; readonly provenance: PersistedDelegationTask["provenance"];
   readonly creationSequence: number; readonly createdAt: string;
   readonly deliveredResults: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[];
+  readonly acceptedAnswers: readonly AcceptedQuestionForTask[];
 }
 export interface WorkerPromptContext {
   readonly snapshotHash: string; readonly workflowId: string; readonly nodeId: string; readonly agentId: string;
@@ -79,6 +84,9 @@ export interface WorkerTrustedToolExecutionContext {
 export interface WorkerTrustedToolDispatchRequest<T> {
   readonly correlationId: string; readonly toolName: string; readonly operation: string; readonly input: unknown;
   readonly policyOutcome: "allowed" | "denied"; readonly denialReason?: string; readonly finalization?: boolean;
+  /** Package-validated call IDs for the containing trusted assistant batch. */
+  readonly questionBatchCallIds?: readonly string[];
+  readonly questionBatchCurrentCallId?: string;
   readonly commandMetadata?: unknown; readonly dispatch: (context: WorkerTrustedToolExecutionContext) => T | Promise<T>;
 }
 export interface WorkerTrustedDispatch {
@@ -106,6 +114,11 @@ export interface WorkerSessionHandle {
 export type WorkerSessionFactory = (input: WorkerSessionFactoryInput) => WorkerSessionHandle | Promise<WorkerSessionHandle>;
 export interface WorkerModelDispatchInput {
   readonly task: PersistedDelegationTask; readonly text: string; readonly signal?: AbortSignal; readonly invocation: WorkerPromptInvocation;
+  readonly questionDeliveryIds: readonly string[]; readonly promptHash: string; readonly transcriptRef: string;
+  /** Includes live-tool deliveries created while this exact provider attempt is running. */
+  readonly resolveQuestionDeliveryIds: () => readonly string[];
+  readonly onConsumerSuccess: (modelAttemptId: string, binding: AttemptConsumerReceiptBinding) => void;
+  readonly questionContinuationReady: () => boolean;
   readonly invoke: () => string | WorkerPromptResponse | Promise<string | WorkerPromptResponse>;
 }
 export type WorkerModelDispatcher = (input: WorkerModelDispatchInput) => string | WorkerPromptResponse | Promise<string | WorkerPromptResponse>;
@@ -114,8 +127,11 @@ export interface WorkerSessionPoolOptions {
   readonly snapshot: ActivationSnapshotFileV1; readonly factory: WorkerSessionFactory; readonly resultSummaryBytes?: number;
   readonly dispatchModel?: WorkerModelDispatcher;
   readonly dispatchTool?: <T>(task: PersistedDelegationTask, input: WorkerTrustedToolDispatchRequest<T>) => Promise<T>;
+  readonly questions?: Pick<QuestionService, "pendingForTask" | "prepareTaskAnswerDeliveries" | "preparedTaskAnswerDeliveries" | "recordTaskAnswerDeliveryReceipt" | "taskAnswerDeliveryReturnedByTool" | "acceptTaskAnswerDelivery" | "markTaskConsumerReplaySettled">;
 }
-export type WorkerExecutionResult = WorkerResultInput | Readonly<{ status: "suspended"; dependencyTaskIds: readonly string[] }>;
+export type WorkerExecutionResult = WorkerResultInput
+  | Readonly<{ status: "suspended"; dependencyTaskIds?: readonly string[]; questionIds?: readonly string[] }>
+  | Readonly<{ status: "continuation"; questionIds: readonly string[] }>;
 
 interface WorkerExecutionConfig {
   readonly agentId: string; readonly modelId: string; readonly thinking: string; readonly tools: readonly string[];
@@ -231,6 +247,7 @@ export function deriveWorkerPromptContext(
   task: PersistedDelegationTask,
   deliveredResults: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[] = [],
   sessionId = task.runId,
+  acceptedAnswers: readonly AcceptedQuestionForTask[] = [],
 ): WorkerPromptContext {
   const workflow = snapshot.payload.workflow;
   const team = plainRecord(workflow.team) ? workflow.team : undefined;
@@ -269,6 +286,7 @@ export function deriveWorkerPromptContext(
     creationSequence: task.creationSequence,
     createdAt: task.createdAt,
     deliveredResults: structuredClone(deliveredResults),
+    acceptedAnswers: structuredClone(acceptedAnswers),
   });
   const promptRefs: DynamicPromptInput[] = task.contextRefs.map((entry) => {
     const source = entry.ref.kind === "artifact" || entry.ref.kind === "knowledge" || entry.ref.kind === "repository"
@@ -287,6 +305,12 @@ export function deriveWorkerPromptContext(
     content: delivered.result,
     ref: `run:${task.runId}/task:${delivered.taskId}/result`,
   });
+  const answerPromptInputs = acceptedAnswers.flatMap((accepted) => losslessDynamicPromptInputs({
+    provenance: `human-answer:${accepted.questionId}:${accepted.answer.channel}:${accepted.answer.identity}`,
+    content: { questionId: accepted.questionId, definition: accepted.definition, answer: accepted.answer },
+    ref: accepted.transcriptRef,
+  }));
+  promptRefs.push(...answerPromptInputs);
   const assembled = assembleWorkerWorkflowPrompt({
     snapshot,
     nodeId: task.targetNodeId,
@@ -294,6 +318,7 @@ export function deriveWorkerPromptContext(
     runId: task.runId,
     task: { taskId: task.taskId, parentNodeId: task.parentNodeId, objective: task.objective, deliverables: task.deliverables, refs: promptRefs },
   });
+  assertLosslessDynamicPromptInputs(assembled, answerPromptInputs);
   return deepFreeze({
     snapshotHash: snapshot.snapshotHash,
     workflowId: typeof workflow.id === "string" ? workflow.id : "",
@@ -314,6 +339,28 @@ export function deriveWorkerPromptContext(
     compactionPreservation: buildCompactionPreservationBlock(assembled),
     validateCompactionPreservation: (value: string) => assertCompactionPreservation(value, assembled),
   });
+}
+
+function selectTaskAnswerPromptPage(
+  snapshot: ActivationSnapshotFileV1,
+  task: PersistedDelegationTask,
+  deliveredResults: readonly Readonly<{ taskId: string; result: PersistedWorkerResult }>[],
+  sessionId: string,
+  prepared: readonly TaskQuestionAnswerDelivery[],
+): Readonly<{ deliveries: readonly TaskQuestionAnswerDelivery[]; promptContext: WorkerPromptContext }> {
+  const selected: TaskQuestionAnswerDelivery[] = [];
+  let promptContext = deriveWorkerPromptContext(snapshot, task, deliveredResults, sessionId);
+  for (const delivery of prepared) {
+    try {
+      const candidate = [...selected, delivery];
+      promptContext = deriveWorkerPromptContext(snapshot, task, deliveredResults, sessionId, candidate.flatMap((entry) => entry.answers));
+      selected.push(delivery);
+    } catch (error) {
+      if (!selected.length || !String(error instanceof Error ? error.message : error).includes("Authority-relevant prompt data was omitted or truncated")) throw error;
+      break;
+    }
+  }
+  return Object.freeze({ deliveries: Object.freeze(selected), promptContext });
 }
 
 export class WorkerSessionPool {
@@ -400,7 +447,38 @@ export class WorkerSessionPool {
       deliverResults: (deliveryId: string, options: { limit?: number } = {}) => services.deliverResults(deliveryId, options),
       runWithToolRuntime: <T>(callback: () => T): T => services.runWithToolRuntime(callback),
     }) satisfies WorkerDelegationServices : undefined;
-    const promptContext = deriveWorkerPromptContext(this.options.snapshot, task, deliveredResults, this.options.sessionId);
+    const preparedAnswerDeliveries: readonly TaskQuestionAnswerDelivery[] = this.options.questions?.prepareTaskAnswerDeliveries(task.taskId) ?? [];
+    const answerPage = selectTaskAnswerPromptPage(this.options.snapshot, task, deliveredResults, this.options.sessionId, preparedAnswerDeliveries);
+    const answerDeliveries = answerPage.deliveries;
+    const promptContext = answerPage.promptContext;
+    const promptHash = createHash("sha256").update(promptContext.assembledPrompt).digest("hex");
+    const transcriptRef = `run:${task.runId}/node:${task.targetNodeId}/task:${task.taskId}/transcript`;
+    const consumedDeliveryIds = new Set<string>();
+    let consumerCompletionObserved = false;
+    let recoveredConsumerReplay = false;
+    const markRecoveredContinuation = (questionIds: readonly string[]): void => {
+      if (!recoveredConsumerReplay) return;
+      const taskAttemptId = task.attempts.at(-1)?.attemptId;
+      if (!taskAttemptId) throw new Error("Recovered worker continuation is missing its immutable task attempt");
+      this.options.questions?.markTaskConsumerReplaySettled(task.taskId, taskAttemptId, questionIds);
+    };
+    const recordConsumerSuccess = (attemptId: string, binding: AttemptConsumerReceiptBinding): void => {
+      consumerCompletionObserved = true;
+      if (binding.transcriptRef !== transcriptRef) throw new Error("Worker consumer settlement transcript does not match the task transcript");
+      if (binding.promptHash !== promptHash) recoveredConsumerReplay = true;
+      const boundDeliveryIds = new Set(binding.deliveryIds);
+      const prepared = this.options.questions?.preparedTaskAnswerDeliveries(task.taskId) ?? answerDeliveries;
+      for (const delivery of prepared) {
+        if (!boundDeliveryIds.has(delivery.deliveryId)) continue;
+        try { this.options.questions?.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: binding.promptHash, attemptId, transcriptRef: binding.transcriptRef }); }
+        catch {
+          // A completed containing attempt is retryable control settlement. A
+          // second publication attempt never re-invokes the provider.
+          this.options.questions?.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: binding.promptHash, attemptId, transcriptRef: binding.transcriptRef });
+        }
+        consumedDeliveryIds.add(delivery.deliveryId);
+      }
+    };
     const dispatch: WorkerTrustedDispatch | undefined = this.options.dispatchTool ? Object.freeze({
       schemaVersion: 1 as const,
       tool: <T>(input: WorkerTrustedToolDispatchRequest<T>) => this.options.dispatchTool!(task, input),
@@ -420,9 +498,31 @@ export class WorkerSessionPool {
           preservation: promptContext.compactionPreservation,
           validate: promptContext.validateCompactionPreservation,
         }));
+        let consumerReceiptRecorded = false;
         const response = await (this.options.dispatchModel
-          ? this.options.dispatchModel({ task, text, signal, invocation, invoke: () => pooled.session.prompt(text, signal, invocation) })
+          ? this.options.dispatchModel({
+            task, text, signal, invocation, promptHash, transcriptRef,
+            questionDeliveryIds: answerDeliveries.map((delivery) => delivery.deliveryId),
+            resolveQuestionDeliveryIds: () => {
+              const deliveries = this.options.questions?.preparedTaskAnswerDeliveries(task.taskId) ?? answerDeliveries;
+              return [...new Set(deliveries.filter((delivery) => answerDeliveries.some((candidate) => candidate.deliveryId === delivery.deliveryId)
+                || this.options.questions?.taskAnswerDeliveryReturnedByTool(delivery)).map((delivery) => delivery.deliveryId))];
+            },
+            onConsumerSuccess: (attemptId, binding) => { recordConsumerSuccess(attemptId, binding); consumerReceiptRecorded = true; },
+            questionContinuationReady: () => {
+              const pending = this.options.questions?.pendingForTask(task.taskId) ?? [];
+              const prepared = this.options.questions?.prepareTaskAnswerDeliveries(task.taskId) ?? [];
+              return pending.length === 0 && prepared.some((delivery) => !answerDeliveries.some((included) => included.deliveryId === delivery.deliveryId));
+            },
+            invoke: () => pooled.session.prompt(text, signal, invocation),
+          })
           : pooled.session.prompt(text, signal, invocation));
+        if (!consumerReceiptRecorded) {
+          const prepared = this.options.questions?.preparedTaskAnswerDeliveries(task.taskId) ?? answerDeliveries;
+          const deliveryIds = prepared.filter((delivery) => answerDeliveries.some((candidate) => candidate.deliveryId === delivery.deliveryId)
+            || this.options.questions?.taskAnswerDeliveryReturnedByTool(delivery)).map((delivery) => delivery.deliveryId);
+          recordConsumerSuccess(task.attempts.at(-1)?.attemptId ?? `task-${task.taskId}-transcript`, { deliveryIds, promptHash, transcriptRef });
+        }
         let output: string;
         if (plainRecord(response)) {
           if (typeof response.output !== "string") throw new Error("Worker prompt response output is invalid");
@@ -435,6 +535,27 @@ export class WorkerSessionPool {
             || !Number.isSafeInteger(response.usage.outputTokens) || Number(response.usage.outputTokens) < 0
             || (response.usage.precision !== "estimated" && response.usage.precision !== "provider-confirmed"))) throw new Error("Worker provider usage is invalid");
         } else output = String(response ?? "");
+        for (const delivery of this.options.questions?.preparedTaskAnswerDeliveries(task.taskId) ?? answerDeliveries) {
+          if (!consumedDeliveryIds.has(delivery.deliveryId)) continue;
+          try { this.options.questions?.acceptTaskAnswerDelivery(delivery); }
+          catch {
+            // A before-publication acceptance fault is safe to retry because the
+            // exact consumer receipt is already authoritative and idempotent.
+            this.options.questions?.acceptTaskAnswerDelivery(delivery);
+          }
+        }
+        const pendingQuestionIds = this.options.questions?.pendingForTask(task.taskId).map((question) => question.questionId) ?? [];
+        const newlyPrepared = this.options.questions?.prepareTaskAnswerDeliveries(task.taskId) ?? [];
+        const continuationQuestionIds = newlyPrepared.filter((delivery) => !consumedDeliveryIds.has(delivery.deliveryId)).flatMap((delivery) => delivery.questionIds);
+        if (delegatedTaskIds.length && (pendingQuestionIds.length || continuationQuestionIds.length)) throw new Error("Worker turn cannot suspend on delegation dependencies and human questions simultaneously");
+        if (pendingQuestionIds.length && !signal?.aborted && !this.closed) {
+          return Object.freeze({ status: "suspended" as const, questionIds: Object.freeze([...new Set(pendingQuestionIds)]) });
+        }
+        if (continuationQuestionIds.length && !signal?.aborted && !this.closed) {
+          const questionIds = Object.freeze([...new Set(continuationQuestionIds)]);
+          markRecoveredContinuation(questionIds);
+          return Object.freeze({ status: "continuation" as const, questionIds });
+        }
         if (delegatedTaskIds.length && !signal?.aborted && !this.closed) {
           return Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...new Set(delegatedTaskIds)]) });
         }
@@ -446,10 +567,37 @@ export class WorkerSessionPool {
           data: { linkedSessionId: pooled.session.linkedSessionId },
         };
       } catch (error) {
-        if (delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+        const detail = error && typeof error === "object" ? error as Record<string, unknown> : {};
+        const pendingQuestionIds = this.options.questions?.pendingForTask(task.taskId).map((question) => question.questionId) ?? [];
+        let continuationQuestionIds: readonly string[] = [];
+        try {
+          continuationQuestionIds = (this.options.questions?.prepareTaskAnswerDeliveries(task.taskId) ?? [])
+            .filter((delivery) => !answerDeliveries.some((included) => included.deliveryId === delivery.deliveryId) || consumedDeliveryIds.has(delivery.deliveryId))
+            .flatMap((delivery) => delivery.questionIds);
+        } catch {
+          continuationQuestionIds = (this.options.questions?.preparedTaskAnswerDeliveries(task.taskId) ?? [])
+            .filter((delivery) => consumedDeliveryIds.has(delivery.deliveryId))
+            .flatMap((delivery) => delivery.questionIds);
+        }
+        if (pendingQuestionIds.length && !delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+          return Object.freeze({ status: "suspended" as const, questionIds: Object.freeze([...new Set(pendingQuestionIds)]) });
+        }
+        const providerKnownNotApplied = detail.effectNotApplied === true
+          || (detail.assistantOutputObserved === false && detail.toolCallObserved === false);
+        if (providerKnownNotApplied && !detail.policyDenied && !Array.isArray(detail.budgetExhausted) && !consumerCompletionObserved
+          && answerDeliveries.length && !delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+          // Keep the answer undelivered: scheduler settlement advances only the
+          // durable continuation-turn identity, never this failed consumer.
+          return Object.freeze({ status: "continuation" as const, questionIds: Object.freeze([...new Set(answerDeliveries.flatMap((delivery) => delivery.questionIds))]) });
+        }
+        if ((continuationQuestionIds.length || (consumerCompletionObserved && answerDeliveries.length)) && !delegatedTaskIds.length && !signal?.aborted && !this.closed) {
+          const ids = Object.freeze([...new Set(continuationQuestionIds.length ? continuationQuestionIds : answerDeliveries.flatMap((delivery) => delivery.questionIds))]);
+          markRecoveredContinuation(ids);
+          return Object.freeze({ status: "continuation" as const, questionIds: ids });
+        }
+        if (delegatedTaskIds.length && !pendingQuestionIds.length && !continuationQuestionIds.length && !signal?.aborted && !this.closed) {
           return Object.freeze({ status: "suspended" as const, dependencyTaskIds: Object.freeze([...new Set(delegatedTaskIds)]) });
         }
-        const detail = error && typeof error === "object" ? error as Record<string, unknown> : {};
         const budgetExhausted = Array.isArray(detail.budgetExhausted) ? detail.budgetExhausted.filter((item): item is string => typeof item === "string").slice(0, 32) : [];
         return {
           status: signal?.aborted || this.closed ? "cancelled" : budgetExhausted.length ? "blocked" : "failed",

--- a/tests/config/config-snapshot-builder.test.ts
+++ b/tests/config/config-snapshot-builder.test.ts
@@ -4,12 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { buildActivationSnapshot, buildActivationSummary } from "../../src/config/snapshot.ts";
+import { loadConfigCatalogs, loadConfigProject, resolveConfigWorkflows } from "../../src/config/index.ts";
 import { issueEffectiveAuthoritySnapshotForTest } from "../../src/config/snapshot-authority.ts";
 import { resolveWorkflowCapabilities } from "../../src/capabilities/resolve.ts";
 import { readActivationSnapshot, writeActivationSnapshot } from "../../src/config/snapshot-store.ts";
 import type { ValidWorkflowDefinition } from "../../src/config/resolver.ts";
 import type { ConfigCatalogResult } from "../../src/config/catalogs.ts";
 import type { ConfiguredProject } from "../../src/config/manifest.ts";
+import { copyWorkflowFixture } from "../helpers/workflow-fixtures.ts";
 
 function fixture() {
   const workflow = {
@@ -21,7 +23,7 @@ function fixture() {
   const project = { status: "configured", projectRoot: "/tmp/project", manifestPath: "/tmp/project/.pi/hive/hive-config.yaml", manifestSource: ".pi/hive/hive-config.yaml", rawSource: "manifest\n", manifest: { "schema-version": 1, agents: {}, workflows: {} }, sourceMap: {}, diagnostics: [], truncated: false, registries: { agents: [{ id: "agent", kind: "agents", status: "available", declaredPath: "agents/agent.md", projectPath: ".pi/hive/agents/agent.md", sourceRange: {} as never, diagnosticCodes: [], declaredData: "agents/agent.md", canonicalPath: "/tmp/project/.pi/hive/agents/agent.md" }], workflows: [{ id: "debug", kind: "workflows", status: "available", declaredPath: "workflows/debug.yaml", projectPath: ".pi/hive/workflows/debug.yaml", sourceRange: {} as never, diagnosticCodes: [], declaredData: "workflows/debug.yaml", canonicalPath: "/tmp/project/.pi/hive/workflows/debug.yaml" }], skills: [{ id: "skill", kind: "skills", status: "available", declaredPath: "skills/skill/", projectPath: ".pi/hive/skills/skill", sourceRange: {} as never, diagnosticCodes: [], declaredData: "skills/skill/", canonicalPath: "/tmp/project/.pi/hive/skills/skill" }], knowledge: [{ id: "knowledge", kind: "knowledge", status: "available", declaredPath: "knowledge/k/", projectPath: ".pi/hive/knowledge/k", sourceRange: {} as never, diagnosticCodes: [], declaredData: { provider: "okf", path: "knowledge/k/" }, canonicalPath: "/tmp/project/.pi/hive/knowledge/k" }] } } as unknown as ConfiguredProject;
   return { workflow, catalogs, project };
 }
-const models = { defaultModel: "provider/model", defaultThinking: "off", find: (id: string) => id === "provider/model" ? { id, contextWindow: 1_000_000, maxTokens: 8_000, thinking: ["off"] } : undefined, canActivate: () => true, estimateTokens: (text: string) => Buffer.byteLength(text) };
+const models = { defaultModel: "provider/model", defaultThinking: "off", find: (id: string) => id === "provider/model" ? { id, contextWindow: 1_000_000, maxTokens: 8_000, thinking: ["off", "medium"] } : undefined, canActivate: () => true, estimateTokens: (text: string) => Buffer.byteLength(text) };
 function authorityNode(nodeId = "root", model = "provider/model", thinking = "off") {
   return {
     nodeId,
@@ -114,6 +116,31 @@ test("snapshot identity consumes the exact resolver-issued effective authority",
   assert.notDeepEqual(fullSnapshot.payload.authority, narrowSnapshot.payload.authority);
   assert.notEqual(fullSnapshot.snapshotHash, narrowSnapshot.snapshotHash);
   assert.throws(() => buildActivationSnapshot({ ...full.base, authority: narrow.authority, models, packageVersion: "0.1.0" }), /exact resolved workflow authority/i);
+});
+
+test("configured human-input authority enables questions and survives snapshot persistence", () => {
+  const copied = copyWorkflowFixture("artifact-free-debug");
+  try {
+    const project = loadConfigProject(copied.projectRoot);
+    assert.equal(project.status, "configured");
+    if (project.status !== "configured") return;
+    const catalogs = loadConfigCatalogs(project);
+    const resolution = resolveConfigWorkflows(project, catalogs);
+    const workflow = resolution.workflows[0];
+    assert.equal(workflow.status, "valid");
+    if (workflow.status !== "valid") return;
+    const effective = workflow.authority.nodes[0].capabilities.effective as Readonly<Record<string, unknown>>;
+    assert.equal(effective["human-input"], true);
+    assert.equal(workflow.authority.nodes[0].tools.includes("human_question"), true);
+
+    const activation = buildActivationSnapshot({ project, workflow, catalogs, authority: workflow.authority, models, packageVersion: "0.1.0" });
+    writeActivationSnapshot(copied.projectRoot, activation);
+    const restored = readActivationSnapshot(copied.projectRoot, activation.snapshotHash);
+    assert.ok(restored);
+    const restoredNode = restored.payload.authority.nodes[0] as { tools: readonly string[]; capabilities: { effective: Readonly<Record<string, unknown>> } };
+    assert.equal(restoredNode.tools.includes("human_question"), true);
+    assert.equal(restoredNode.capabilities.effective["human-input"], true);
+  } finally { copied.cleanup(); }
 });
 
 test("resolver-produced activation snapshots round-trip through persistence with resolved team depths", () => {

--- a/tests/config/config-workflows.test.ts
+++ b/tests/config/config-workflows.test.ts
@@ -196,7 +196,7 @@ test("capability widening quarantines only its workflow while valid definitions 
       assert.equal(valid.result.workflows[0].authority.workflowId, "debug-chat");
       assert.deepEqual(valid.result.workflows[0].authority.nodes.map((node) => node.nodeId), valid.result.workflows[0].team.nodes.map((node) => node.id).sort());
       assert.equal(valid.result.workflows[0].policies.every((policy) => policy.tools.every((tool) => typeof tool === "string")), true);
-      assert.equal(valid.result.workflows[0].policies[0].tools.includes("human_question"), false, "later subsystem tools remain reserved but inactive");
+      assert.equal(valid.result.workflows[0].policies[0].tools.includes("human_question"), true, "W21 activates the question subsystem only for effective human-input authority");
     }
   } finally { valid.fixture.cleanup(); }
 

--- a/tests/workflows/workflow-attempts-recovery.test.ts
+++ b/tests/workflows/workflow-attempts-recovery.test.ts
@@ -41,6 +41,52 @@ test("completed same attempt ID replays its bounded result while different input
   assert.throws(() => runtime.begin({ attemptId: "attempt-1", correlationId: "correlation-1", nodeId: "worker", operation: "read", input: { path: "src/b.ts" }, descriptor: readonlyTool }), /different input|reuse/i);
 });
 
+test("successful model result atomically binds deliveries created during that exact attempt before receipt settlement", async () => {
+  const { projectRoot, runtime } = fixture();
+  let providerCalls = 0;
+  let receiptFaults = 0;
+  const input = {
+    correlationId: "dynamic-consumer", nodeId: "worker", operation: "provider.request", input: { promptHash: "a".repeat(64) },
+    descriptor: attemptDescriptorForModel(),
+    consumerReceipt: { deliveryIds: [], promptHash: "a".repeat(64), transcriptRef: "run:run-1/node:worker/task:task-1/transcript" },
+    consumerReceiptAfterDispatch: () => ({ deliveryIds: ["dynamic-delivery"], promptHash: "a".repeat(64), transcriptRef: "run:run-1/node:worker/task:task-1/transcript" }),
+    dispatch: async () => { providerCalls++; return "provider result"; },
+    onConsumerCompleted: () => { if (receiptFaults++ === 0) throw new Error("persistent process stop before receipt"); },
+  } as const;
+  await assert.rejects(() => executeWithConservativeRetry(runtime, input), /before receipt/i);
+  const completed = Object.values(runtime.restore().attempts)[0];
+  assert.equal(completed.status, "completed");
+  assert.deepEqual(completed.consumerReceipt?.deliveryIds, ["dynamic-delivery"]);
+  assert.deepEqual(completed.intentConsumerReceipt?.deliveryIds, []);
+
+  const restarted = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  assert.equal(await executeWithConservativeRetry(restarted, input), "provider result");
+  assert.equal(providerCalls, 1, "durable successful result must replay without provider redispatch");
+});
+
+test("completed consumer replay exposes only its exact durable final delivery binding to settlement", async () => {
+  const { projectRoot, runtime } = fixture();
+  const durableBinding = { deliveryIds: ["delivery-old"], promptHash: "a".repeat(64), transcriptRef: "run:run-1/node:worker/task:task-1/transcript" } as const;
+  runtime.begin({
+    attemptId: "consumer-replay", correlationId: "consumer-replay-correlation", nodeId: "worker", operation: "provider.request",
+    input: { promptHash: durableBinding.promptHash }, replayInput: { taskId: "task-1" }, descriptor: attemptDescriptorForModel(), consumerReceipt: durableBinding,
+  });
+  runtime.complete("consumer-replay", { ok: true, value: "old result" }, durableBinding);
+
+  let settledBinding: unknown;
+  const restarted = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  const result = await executeWithConservativeRetry(restarted, {
+    correlationId: "reused-correlation", nodeId: "worker", operation: "provider.request",
+    input: { promptHash: "b".repeat(64) }, replayInput: { taskId: "task-1" }, descriptor: attemptDescriptorForModel(),
+    recoveryAttemptId: "consumer-replay", recoveryConsumerReceipt: durableBinding,
+    consumerReceipt: { deliveryIds: ["delivery-old", "delivery-new"], promptHash: "b".repeat(64), transcriptRef: durableBinding.transcriptRef },
+    dispatch: async () => "must not run",
+    onConsumerCompleted: (_attemptId, binding) => { settledBinding = binding; },
+  });
+  assert.equal(result, "old result");
+  assert.deepEqual(settledBinding, durableBinding);
+});
+
 test("model retries at most twice only before output/tool calls and every provider attempt is durable", async () => {
   const { runtime } = fixture();
   let calls = 0;

--- a/tests/workflows/workflow-orchestration.test.ts
+++ b/tests/workflows/workflow-orchestration.test.ts
@@ -8,6 +8,8 @@ import { DelegationRuntime } from "../../src/workflows/delegation.ts";
 import { RunOrchestrationService, type RunOrchestrationServiceOptions } from "../../src/workflows/orchestration.ts";
 import { acquireRuntimeOwnership } from "../../src/workflows/ownership.ts";
 import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
 import type { WorkerSessionFactory } from "../../src/workflows/workers.ts";
 import type { EffectiveRuntimeBudgetLimits } from "../../src/workflows/budgets.ts";
 import { analyzeCommand } from "../../src/capabilities/command.ts";
@@ -595,6 +597,78 @@ test("root finalization reserve remains usable after its bounded response crosse
   assert.equal(await root.dispatch.tool({ correlationId: "finalization-overage-tool", toolName: "workflow_finish", operation: "finish", input: {}, finalization: true, policyOutcome: "allowed", dispatch: async () => "ok" }), "ok");
   await assert.rejects(() => root.dispatch.model({ correlationId: "ordinary-after-finalization", operation: "root.prompt", input: {}, dispatch: async () => "must not run" }), /budget|token/i);
   assert.equal(service.lifecycle.restore().latestRun?.terminal?.data.failureCode, "budget_exhausted");
+});
+
+test("run-wide budget preparation freezes questions before descendant cancellation across answer and restart races", async () => {
+  for (const answerWins of [false, true]) {
+    const active = snapshot() as any;
+    active.payload.workflow.team.nodes[0].memberIds = ["worker", "other"];
+    active.payload.workflow.team.nodes.push({ id: "other", agentId: "other-agent", parentId: "root", memberIds: [], depth: 2, role: "Other", responsibilities: [] });
+    active.payload.authority.nodes[0].capabilities.directMemberIds = ["worker", "other"];
+    active.payload.authority.nodes.push({ nodeId: "other", capabilities: { effective: {} }, tools: [], model: "other-model", thinking: "low" });
+    active.payload.agents.push({ id: "other-agent", name: "Other", tags: [], prompt: "other" });
+    active.payload.models.push({ nodeId: "other", modelId: "other-model", thinking: "low", staticTokens: 1, dynamicReserve: 1, contextWindow: 10 });
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    const limits: EffectiveRuntimeBudgetLimits = {
+      run: { maxParallel: 1, maxDelegations: 4, maxToolCalls: 20, tokenBudget: 10_000, activeWallTimeMs: 10_000 },
+      nodes: {
+        root: { maxAgentTurns: 4, maxToolCalls: 20, tokenBudget: 10_000, activeWallTimeMs: 10_000 },
+        worker: { maxAgentTurns: 4, maxToolCalls: 20, tokenBudget: 10_000, activeWallTimeMs: 10_000 },
+        leaf: { maxAgentTurns: 4, maxToolCalls: 20, tokenBudget: 10_000, activeWallTimeMs: 10_000 },
+        other: { maxAgentTurns: 4, maxToolCalls: 20, tokenBudget: 10_000, activeWallTimeMs: 10_000 },
+      },
+    };
+    const holder: { service?: RunOrchestrationService; questionId?: string; answered?: boolean } = {};
+    const built = fixture(async (input) => ({ linkedSessionId: `budget-${answerWins}-${input.nodeId}`, async prompt() {
+      if (input.nodeId === "worker") {
+        holder.questionId = holder.service!.questionControls().create({ nodeId: "worker", taskId: "task-1", definition: { prompt: "Budget race?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: `budget-question-${answerWins}` } }).questionId;
+        return "suspend on question";
+      }
+      return { output: "run budget exhausted", usage: { inputTokens: 20_000, outputTokens: 1, precision: "provider-confirmed" as const } };
+    }, dispose() {} }), {
+      snapshot: active,
+      budgetLimits: limits,
+      questionControl: { authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined },
+      completion: { projectState: () => {
+        if (answerWins && !holder.answered && holder.questionId) {
+          holder.answered = true;
+          holder.service!.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: holder.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "budget-race-answer" });
+        }
+        return { state: "satisfied" as const, fileChanges: [], changeCoverage: "recorded" };
+      } },
+    });
+    holder.service = built.service;
+    deliverInitial(built.service, `budget-question-${answerWins}`);
+    const root = built.service.rootServices();
+    const suspended = root.delegate({ targetNodeId: "worker", objective: "wait on question", deliverables: [] });
+    const exhausted = root.delegate({ targetNodeId: "other", objective: "exhaust run budget", deliverables: [] });
+    await assert.rejects(() => built.service.runWorkers(), /budget|token|question/i);
+    const run = built.service.lifecycle.restore().latestRun!;
+    assert.equal(run.status, "failed");
+    assert.equal(run.terminal?.data.failureCode, "budget_exhausted");
+    assert.deepEqual(run.terminal?.closedQuestionIds, answerWins ? [] : [holder.questionId]);
+    const delegation = built.service.delegationState();
+    assert.equal(delegation.schedulerStatus, "closed");
+    assert.equal(delegation.tasks[suspended.taskId].result?.status, "cancelled");
+    assert.equal(delegation.tasks[exhausted.taskId].queueState, "terminal");
+    assert.equal(Object.values(delegation.tasks).some((task) => task.queueState !== "terminal"), false);
+    const question = new QuestionService({ projectRoot: built.projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: active, authenticateControl: (request) => request.claimedIdentity }).restore().questions[holder.questionId!];
+    assert.equal(question.state, answerWins ? "answered" : "closed");
+    assert.equal(question.taskDeliveryAcceptedSequence, undefined);
+    const ordered = readWorkflowJournal(built.projectRoot, "session-1");
+    const preparedSequence = ordered.find((event) => event.type === "run.terminal.prepared")!.sequence;
+    const cancelledSequence = ordered.find((event) => event.type === "task.result.recorded" && (event.payload as any).taskId === suspended.taskId)!.sequence;
+    assert.ok(preparedSequence < cancelledSequence);
+    if (!answerWins) {
+      const closedSequence = ordered.find((event) => event.type === "question.transition" && (event.payload as any).operation === "close-pending")!.sequence;
+      assert.ok(preparedSequence < closedSequence && closedSequence < cancelledSequence);
+    }
+    const replayed = await new RunOrchestrationService(built.options).lifecycle.failBudgetExhaustion("restart replay");
+    assert.equal(replayed.ok, true);
+    if (replayed.ok) assert.equal(replayed.envelope.terminalEventHash, run.terminal?.terminalEventHash);
+  }
 });
 
 test("post-response token overage produces a budget-blocked worker result and closes ordinary admission", async () => {

--- a/tests/workflows/workflow-question-validation.test.ts
+++ b/tests/workflows/workflow-question-validation.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  QUESTION_LIMITS,
+  normalizeQuestionDefinition,
+  parseCommandAnswer,
+  validateQuestionAnswer,
+} from "../../src/workflows/question-validation.ts";
+
+const single = normalizeQuestionDefinition({
+  prompt: "Which database?",
+  kind: "single",
+  choices: [
+    { value: "postgres", label: "PostgreSQL" },
+    { value: "sqlite", label: "SQLite" },
+  ],
+  required: true,
+});
+const multi = normalizeQuestionDefinition({
+  prompt: "Select targets",
+  kind: "multi",
+  choices: [
+    { value: "api", label: "API" },
+    { value: "web", label: "Web" },
+    { value: "cli", label: "CLI" },
+  ],
+  validation: { minItems: 1, maxItems: 2 },
+  required: true,
+});
+const text = normalizeQuestionDefinition({
+  prompt: "Name the release",
+  kind: "text",
+  validation: { minLength: 3, maxLength: 12, pattern: "^[a-z-]+$" },
+  required: true,
+});
+const confirm = normalizeQuestionDefinition({ prompt: "Proceed?", kind: "confirm", required: true });
+
+test("question definitions are exact, typed, bounded, and reject executable UI fields", () => {
+  assert.equal(single.kind, "single");
+  assert.equal(Object.isFrozen(single.choices), true);
+  for (const malformed of [
+    { prompt: "x", kind: "single", choices: [{ value: "a", label: "A" }], required: true, html: "<script>" },
+    { prompt: "x", kind: "single", choices: [{ value: "a", label: "A", action: "run" }], required: true },
+    { prompt: "x", kind: "single", choices: [{ value: "a", label: "A" }, { value: "a", label: "Again" }], required: true },
+    { prompt: "x", kind: "single", choices: [], required: true },
+    { prompt: "x", kind: "text", choices: [{ value: "a", label: "A" }], required: true },
+    { prompt: "x", kind: "confirm", validation: { minLength: 1 }, required: true },
+    { prompt: "x", kind: "text", validation: { pattern: "^(a|aa)+$" }, required: true },
+    { prompt: "x", kind: "multi", choices: [{ value: "a", label: "A" }], validation: { minItems: 2, maxItems: 1 }, required: true },
+    { prompt: "x", kind: "unknown", required: true },
+    { prompt: "x".repeat(QUESTION_LIMITS.promptBytes + 1), kind: "text", required: true },
+    { prompt: "x", kind: "single", choices: Array.from({ length: QUESTION_LIMITS.choices + 1 }, (_, index) => ({ value: String(index), label: String(index) })), required: true },
+  ]) assert.throws(() => normalizeQuestionDefinition(malformed), /question|choice|validation|unknown|limit|kind/i);
+});
+
+test("text patterns use an anchored linear-time grammar under maximum adversarial input", () => {
+  const beganRejection = performance.now();
+  for (const pattern of ["a{32768}b", "^a*a*a*a*a*b$", "^(a|aa)+$", "^(a+)+$", "^([a-z]+|[a-z0-9]+)+$"]) {
+    assert.throws(() => normalizeQuestionDefinition({ prompt: "safe?", kind: "text", validation: { pattern }, required: true }), /pattern|anchor|complexity/i);
+  }
+  assert.ok(performance.now() - beganRejection < 50, "high-cost unanchored patterns must reject without attempting a maximum answer match");
+
+  const safe = normalizeQuestionDefinition({ prompt: "release", kind: "text", validation: { pattern: "^a{32768}b$" }, required: true });
+  const beganMatch = performance.now();
+  assert.throws(() => validateQuestionAnswer(safe, "a".repeat(QUESTION_LIMITS.textAnswerBytes)), /pattern/i);
+  assert.ok(performance.now() - beganMatch < 100, "maximum-size anchored failure must remain strictly bounded");
+});
+
+test("question text rejects unsafe C0 controls while preserving bounded structured whitespace", () => {
+  for (const unsafe of ["\u0000", "\u0001", "\u0008", "\u000b", "\u000c", "\u001f"]) {
+    assert.throws(() => normalizeQuestionDefinition({ prompt: `unsafe${unsafe}`, kind: "text", required: true }), /invalid|limit|control/i);
+  }
+  const whitespace = normalizeQuestionDefinition({ prompt: `${"\n".repeat(QUESTION_LIMITS.promptBytes - 1)}x`, kind: "text", required: true });
+  assert.equal(Buffer.byteLength(whitespace.prompt, "utf8"), QUESTION_LIMITS.promptBytes);
+  assert.equal(validateQuestionAnswer(whitespace, "\t\n\r"), "\t\n\r");
+  assert.throws(() => validateQuestionAnswer(whitespace, `safe\u0001unsafe`), /control|type|length/i);
+});
+
+test("all answer kinds validate exact typed values and optional questions accept only explicit null", () => {
+  assert.equal(validateQuestionAnswer(single, "postgres"), "postgres");
+  assert.deepEqual(validateQuestionAnswer(multi, ["web", "api"]), ["api", "web"]);
+  assert.equal(validateQuestionAnswer(text, "release-one"), "release-one");
+  assert.equal(validateQuestionAnswer(confirm, true), true);
+  for (const [definition, answer] of [
+    [single, "mysql"], [single, ["postgres"]], [multi, []], [multi, ["api", "api"]],
+    [multi, ["api", "web", "cli"]], [text, "UP"], [text, "way-too-long-release"], [confirm, "yes"],
+  ] as const) assert.throws(() => validateQuestionAnswer(definition, answer), /answer|choice|validation|type|length|selection/i);
+  assert.throws(() => validateQuestionAnswer(text, null), /required/i);
+  const optional = normalizeQuestionDefinition({ prompt: "Anything else?", kind: "text", required: false });
+  assert.equal(validateQuestionAnswer(optional, null), null);
+  assert.throws(() => validateQuestionAnswer(optional, undefined), /answer|undefined/i);
+});
+
+test("command answers parse by durable kind without treating ordinary prose as an implicit answer", () => {
+  assert.equal(parseCommandAnswer(single, "postgres"), "postgres");
+  assert.deepEqual(parseCommandAnswer(multi, "api, web"), ["api", "web"]);
+  assert.deepEqual(parseCommandAnswer(multi, '["web","api"]'), ["api", "web"]);
+  assert.equal(parseCommandAnswer(confirm, "yes"), true);
+  assert.equal(parseCommandAnswer(confirm, "false"), false);
+  assert.equal(parseCommandAnswer(text, "release-one"), "release-one");
+  assert.throws(() => parseCommandAnswer(confirm, "maybe"), /confirm|answer/i);
+  assert.throws(() => parseCommandAnswer(text, ""), /value|required/i);
+});
+
+test("command answers encode explicit null, literal null, and empty text without ambiguity for every optional kind", () => {
+  const optionalSingle = normalizeQuestionDefinition({
+    prompt: "Single?", kind: "single", choices: [{ value: "null", label: "Literal null" }, { value: "other", label: "Other" }], required: false,
+  });
+  const optionalMulti = normalizeQuestionDefinition({
+    prompt: "Multi?", kind: "multi", choices: [{ value: "null", label: "Literal null" }, { value: "other", label: "Other" }], required: false,
+  });
+  const optionalText = normalizeQuestionDefinition({ prompt: "Text?", kind: "text", required: false });
+  const optionalConfirm = normalizeQuestionDefinition({ prompt: "Confirm?", kind: "confirm", required: false });
+
+  for (const definition of [optionalSingle, optionalMulti, optionalText, optionalConfirm]) {
+    assert.equal(parseCommandAnswer(definition, "null"), null);
+    assert.throws(() => parseCommandAnswer(definition, ""), /explicit|null|value|required/i);
+  }
+  assert.equal(parseCommandAnswer(optionalSingle, '"null"'), "null");
+  assert.deepEqual(parseCommandAnswer(optionalMulti, '["null"]'), ["null"]);
+  assert.deepEqual(parseCommandAnswer(optionalMulti, "[]"), []);
+  assert.equal(parseCommandAnswer(optionalText, '"null"'), "null");
+  assert.equal(parseCommandAnswer(optionalText, '""'), "");
+  assert.equal(parseCommandAnswer(optionalConfirm, "false"), false);
+  assert.throws(() => parseCommandAnswer(optionalConfirm, '"null"'), /confirm|answer/i);
+});

--- a/tests/workflows/workflow-questions.test.ts
+++ b/tests/workflows/workflow-questions.test.ts
@@ -1,0 +1,691 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs.ts";
+import { DelegationRuntime } from "../../src/workflows/delegation.ts";
+import { QUESTION_LIMITS, validateQuestionAnswer } from "../../src/workflows/question-validation.ts";
+import { AttemptRuntime, attemptDescriptorForModel } from "../../src/workflows/attempts.ts";
+import {
+  LOSSLESS_DYNAMIC_DELIVERY_LIMITS,
+  ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS,
+  losslessDynamicPromptInputs,
+  measureLosslessDynamicPromptDelivery,
+} from "../../src/workflows/prompts.ts";
+import {
+  QuestionService,
+  deriveQuestionRunStatus,
+  type QuestionAnswerRequest,
+} from "../../src/workflows/questions.ts";
+
+function snapshot(humanInput = true): ActivationSnapshotFileV1 {
+  return { snapshotHash: "q".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." },
+    workflow: { id: "delivery", team: { rootId: "root", nodes: [
+      { id: "root", agentId: "lead", memberIds: ["worker"], depth: 1 },
+      { id: "worker", agentId: "builder", parentId: "root", memberIds: [], depth: 2 },
+    ] } },
+    authority: { capabilityContractVersion: 1, nodes: [
+      { nodeId: "root", capabilities: { effective: { "human-input": humanInput } }, tools: humanInput ? ["human_question"] : [] },
+      { nodeId: "worker", capabilities: { effective: { "human-input": humanInput } }, tools: humanInput ? ["human_question"] : [] },
+    ] },
+    agents: [{ id: "lead", name: "Lead", prompt: "lead" }, { id: "builder", name: "Builder", prompt: "builder" }],
+    skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function fixture(options: { humanInput?: boolean; createQuestionId?: () => string } = {}) {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-questions-"));
+  let tick = 0;
+  if (options.humanInput ?? true) {
+    const runtime = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot(true), createTaskId: () => "task-1" });
+    runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "worker", objective: "question fixture", deliverables: [] });
+    runtime.start("task-1", "attempt-1");
+  }
+  const service = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1",
+    snapshot: snapshot(options.humanInput ?? true), createQuestionId: options.createQuestionId ?? (() => "question-1"),
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)).toISOString(),
+    authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  return { projectRoot, service };
+}
+
+const definition = { prompt: "Which database?", kind: "single" as const, choices: [
+  { value: "postgres", label: "PostgreSQL" }, { value: "sqlite", label: "SQLite" },
+], required: true };
+const create = (service: QuestionService, overrides: Record<string, unknown> = {}) => service.create({
+  nodeId: "worker", taskId: "task-1", definition,
+  provenance: { source: "human_question", toolCallId: "call-1" }, ...overrides,
+});
+const answer = (overrides: Partial<QuestionAnswerRequest> = {}): QuestionAnswerRequest => ({
+  projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending",
+  value: "postgres", channel: "dashboard", claimedIdentity: "human@example.test", credential: "secret", operationId: "answer-1", ...overrides,
+});
+
+test("questions require immutable human-input capability and persist full typed pending identity", () => {
+  const denied = fixture({ humanInput: false });
+  assert.throws(() => create(denied.service), /human-input|capability|not enabled/i);
+  assert.equal(readWorkflowJournal(denied.projectRoot, "session-1").length, 0);
+
+  const f = fixture();
+  const question = create(f.service);
+  assert.deepEqual({ projectId: question.projectId, sessionId: question.sessionId, runId: question.runId, nodeId: question.nodeId, taskId: question.taskId, state: question.state }, {
+    projectId: "project-1", sessionId: "session-1", runId: "run-1", nodeId: "worker", taskId: "task-1", state: "pending",
+  });
+  assert.equal(question.definition.kind, "single");
+  assert.deepEqual(question.provenance, { source: "human_question", toolCallId: "call-1", agentId: "builder" });
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").at(-1)?.type, "question.transition");
+});
+
+test("root and worker answers enforce the exact post-escaping N/N+1 delivery bound before persistence across restart", () => {
+  const prompt = "\"".repeat(QUESTION_LIMITS.promptBytes);
+  for (const scope of ["root", "worker"] as const) {
+    const deliveryLimits = scope === "root" ? ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS : LOSSLESS_DYNAMIC_DELIVERY_LIMITS;
+    const deliveryMeasurement = (answerLength: number) => measureLosslessDynamicPromptDelivery(losslessDynamicPromptInputs({
+      provenance: "human-answer:question-1:dashboard:human@example.test",
+      content: {
+        questionId: "question-1",
+        definition: { prompt, kind: "text", required: true },
+        answer: {
+          value: "\"".repeat(answerLength), channel: "dashboard", identity: "human@example.test", operationId: "answer-1",
+          inputHash: `sha256:${"0".repeat(64)}`, answeredAt: "2026-01-01T00:00:01.000Z",
+        },
+      },
+      ref: scope === "root"
+        ? "run:run-1/node:root/question:question-1"
+        : "run:run-1/node:worker/task:task-1/question:question-1",
+    }));
+    let low = 0;
+    let high = QUESTION_LIMITS.textAnswerBytes;
+    while (low < high) {
+      const candidate = Math.ceil((low + high) / 2);
+      if (deliveryMeasurement(candidate).encodedBytes <= deliveryLimits.encodedBytes) low = candidate;
+      else high = candidate - 1;
+    }
+    assert.ok(deliveryMeasurement(low).encodedBytes <= deliveryLimits.encodedBytes, "N must fit the exact encoded-byte limit");
+    assert.ok(deliveryMeasurement(low + 1).encodedBytes > deliveryLimits.encodedBytes, "N+1 must cross the exact post-escaping limit");
+    assert.equal(deliveryMeasurement(low + 1).encodedBytes - deliveryMeasurement(low).encodedBytes, 4);
+
+    const accepted = fixture();
+    accepted.service.create({
+      nodeId: scope, ...(scope === "worker" ? { taskId: "task-1" } : {}),
+      definition: { prompt, kind: "text", required: true }, provenance: { source: "human_question", toolCallId: `bound-${scope}` },
+    });
+    const acceptedAnswer = accepted.service.answer(answer({ value: "\"".repeat(low) }));
+    assert.equal(acceptedAnswer.state, "answered");
+    const acceptedRestart = new QuestionService({ ...accepted.service.options });
+    assert.equal(acceptedRestart.restore().questions["question-1"].answer?.value, "\"".repeat(low));
+
+    const rejected = fixture();
+    rejected.service.create({
+      nodeId: scope, ...(scope === "worker" ? { taskId: "task-1" } : {}),
+      definition: { prompt, kind: "text", required: true }, provenance: { source: "human_question", toolCallId: `bound-over-${scope}` },
+    });
+    const before = readWorkflowJournal(rejected.projectRoot, "session-1").length;
+    assert.throws(() => rejected.service.answer(answer({ value: "\"".repeat(low + 1) })), /lossless delivery page bound|encoded bytes/i);
+    assert.equal(readWorkflowJournal(rejected.projectRoot, "session-1").length, before, "N+1 rejection must append no answer event");
+    const rejectedRestart = new QuestionService({ ...rejected.service.options });
+    assert.equal(rejectedRestart.restore().questions["question-1"].state, "pending");
+  }
+});
+
+test("task delivery preparation, receipt, and acceptance reject a newer delegation attempt", () => {
+  const moveToNewAttempt = (projectRoot: string): void => {
+    const runtime = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot() });
+    runtime.pauseAdmission("force stale question attempt");
+    runtime.interrupt("task-1", "force stale question attempt");
+    runtime.resumeAdmission();
+    runtime.start("task-1", "attempt-2");
+  };
+  const answered = (): ReturnType<typeof fixture> => {
+    const f = fixture();
+    create(f.service);
+    f.service.answer(answer());
+    return f;
+  };
+
+  const beforePreparation = answered();
+  moveToNewAttempt(beforePreparation.projectRoot);
+  assert.throws(() => beforePreparation.service.prepareTaskAnswerDeliveries("task-1"), /attempt|stale|exact/i);
+
+  const beforeReceipt = answered();
+  const [receiptDelivery] = beforeReceipt.service.prepareTaskAnswerDeliveries("task-1");
+  moveToNewAttempt(beforeReceipt.projectRoot);
+  assert.throws(() => beforeReceipt.service.recordTaskAnswerDeliveryReceipt(receiptDelivery, {
+    promptHash: "1".repeat(64), attemptId: "consumer-attempt", transcriptRef: "run:run-1/node:worker/task:task-1/transcript",
+  }), /attempt|stale|exact/i);
+
+  const beforeAcceptance = answered();
+  const [acceptedDelivery] = beforeAcceptance.service.prepareTaskAnswerDeliveries("task-1");
+  beforeAcceptance.service.recordTaskAnswerDeliveryReceipt(acceptedDelivery, {
+    promptHash: "2".repeat(64), attemptId: "consumer-attempt", transcriptRef: "run:run-1/node:worker/task:task-1/transcript",
+  });
+  moveToNewAttempt(beforeAcceptance.projectRoot);
+  assert.throws(() => beforeAcceptance.service.acceptTaskAnswerDelivery(acceptedDelivery), /attempt|stale|exact/i);
+});
+
+test("task-bound creation rejects stale task identities and paused task races before publication", () => {
+  const f = fixture();
+  const before = readWorkflowJournal(f.projectRoot, "session-1").length;
+  for (const overrides of [{ taskId: "missing-task" }, { nodeId: "root" }]) {
+    assert.throws(() => create(f.service, overrides), /task|active|node|admission|exact/i);
+    assert.equal(readWorkflowJournal(f.projectRoot, "session-1").length, before);
+  }
+
+  const runtime = new DelegationRuntime({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot() });
+  runtime.pauseAdmission("pause won create CAS");
+  const pausedCount = readWorkflowJournal(f.projectRoot, "session-1").length;
+  assert.throws(() => create(f.service), /paused|admission|active|scheduler/i);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").length, pausedCount);
+  assert.doesNotThrow(() => runtime.restore(), "rejected question creation must not poison delegation replay");
+});
+
+test("multiple questions on one task remain suspended until every answer across restart", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `question-${++next}` });
+  const first = create(f.service, { provenance: { source: "human_question", toolCallId: "call-first" } });
+  const second = create(f.service, { provenance: { source: "human_question", toolCallId: "call-second" } });
+  const replayed = new DelegationRuntime({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot() });
+  assert.deepEqual(replayed.restore().tasks["task-1"].suspendedOnQuestionIds, [first.questionId, second.questionId]);
+  f.service.answer(answer({ questionId: second.questionId, operationId: "answer-second" }));
+  assert.equal(new DelegationRuntime(replayed.options).restore().tasks["task-1"].queueState, "suspended");
+  f.service.answer(answer({ questionId: first.questionId, operationId: "answer-first" }));
+  const resumed = new DelegationRuntime(replayed.options).restore().tasks["task-1"];
+  assert.equal(resumed.queueState, "active");
+  assert.equal(resumed.resumedByQuestionSequence !== undefined, true);
+  assert.deepEqual(resumed.suspendedOnQuestionIds, undefined);
+});
+
+test("pending is durable before live presentation, restart-safe, and a live answer records provenance", async () => {
+  const f = fixture();
+  let pendingSeen = false;
+  const result = await f.service.createAndPresent({
+    nodeId: "worker", taskId: "task-1", definition,
+    provenance: { source: "human_question", toolCallId: "call-live" },
+  }, async (pending) => {
+    pendingSeen = f.service.restore().questions[pending.questionId]?.state === "pending";
+    return { value: "sqlite", claimedIdentity: "tui-user", credential: "secret", operationId: "live-1" };
+  });
+  assert.equal(pendingSeen, true);
+  assert.equal(result.state, "answered");
+  assert.deepEqual({ ...result.answer, inputHash: undefined }, { value: "sqlite", channel: "live", identity: "tui-user", operationId: "live-1", inputHash: undefined, answeredAt: "2026-01-01T00:00:01.000Z" });
+  assert.match(result.answer?.inputHash ?? "", /^sha256:[0-9a-f]{64}$/u);
+
+  const restarted = new QuestionService({ ...f.service.options, createQuestionId: () => "question-2" });
+  assert.equal(restarted.restore().questions["question-1"].answer?.value, "sqlite");
+});
+
+test("a dashboard winner aborts and settles a losing non-cooperative live presenter with the durable answer", async () => {
+  const f = fixture();
+  let presented!: (questionId: string) => void;
+  const started = new Promise<string>((resolve) => { presented = resolve; });
+  const live = f.service.createAndPresent({
+    nodeId: "worker", taskId: "task-1", definition,
+    provenance: { source: "human_question", toolCallId: "call-live-race" },
+  }, async (question) => {
+    presented(question.questionId);
+    return new Promise(() => {});
+  });
+  const questionId = await started;
+  const winner = f.service.answer(answer({ questionId, operationId: "dashboard-winner" }));
+  assert.equal(winner.answer?.channel, "dashboard");
+  const settled = await Promise.race([
+    live,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("losing live presenter did not settle")), 100)),
+  ]);
+  assert.equal(settled.answer?.operationId, "dashboard-winner");
+  assert.equal(f.service.hasLiveHandles(), false);
+});
+
+test("a separately constructed dashboard service settles a live runtime presenter from the durable winner", async () => {
+  const f = fixture();
+  const dashboard = new QuestionService({ ...f.service.options });
+  let presented!: (questionId: string) => void;
+  const started = new Promise<string>((resolve) => { presented = resolve; });
+  const live = f.service.createAndPresent({
+    nodeId: "worker", taskId: "task-1", definition,
+    provenance: { source: "human_question", toolCallId: "cross-instance-live-race" },
+  }, async (question) => {
+    presented(question.questionId);
+    return new Promise(() => {});
+  });
+  const questionId = await started;
+  dashboard.answer(answer({ questionId, operationId: "cross-instance-dashboard-winner" }));
+  const settled = await Promise.race([
+    live,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("cross-instance live presenter did not observe durable settlement")), 250)),
+  ]);
+  assert.equal(settled.answer?.operationId, "cross-instance-dashboard-winner");
+  assert.equal(f.service.hasLiveHandles(), false);
+  assert.equal(dashboard.hasLiveHandles(), false);
+});
+
+test("published question and answer events reconcile after an after-rename fault without duplicate effects", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-questions-fault-"));
+  let faults = 2;
+  const service = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: snapshot(),
+    createQuestionId: () => "question-1", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+    journalFault: (_type, stage) => { if (stage === "afterRename" && faults-- > 0) throw new Error("simulated crash after publication"); },
+  });
+  const pending = create(service, { nodeId: "root", taskId: undefined });
+  assert.equal(pending.state, "pending");
+  const request = answer();
+  const answered = service.answer(request);
+  assert.equal(answered.state, "answered");
+  assert.deepEqual(service.answer(request), answered, "a client retry after durable publication replays the recorded operation");
+  assert.equal(readWorkflowJournal(projectRoot, "session-1").filter((event) => event.type === "question.transition").length, 2);
+});
+
+test("invalid or unauthenticated answers append nothing and first valid live/dashboard/command CAS wins", async () => {
+  const f = fixture(); create(f.service);
+  const before = readWorkflowJournal(f.projectRoot, "session-1").length;
+  assert.throws(() => f.service.answer(answer({ credential: "wrong" })), /authenticate|authorized/i);
+  assert.throws(() => f.service.answer(answer({ value: "mysql", operationId: "invalid" })), /choice|answer/i);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").length, before);
+
+  const contenders = [
+    answer({ channel: "live", value: "sqlite", claimedIdentity: "tui", operationId: "live" }),
+    answer({ channel: "dashboard", value: "postgres", claimedIdentity: "web", operationId: "dashboard" }),
+    answer({ channel: "command", value: "sqlite", claimedIdentity: "cli", operationId: "command" }),
+  ];
+  const settled = await Promise.allSettled(contenders.map(async (request) => f.service.answer(request)));
+  assert.equal(settled.filter((entry) => entry.status === "fulfilled").length, 1);
+  assert.equal(settled.filter((entry) => entry.status === "rejected").length, 2);
+  const durable = f.service.restore().questions["question-1"];
+  assert.equal(durable.state, "answered");
+  assert.equal(["live", "dashboard", "command"].includes(durable.answer!.channel), true);
+  assert.deepEqual(f.service.answer(contenders.find((request) => request.operationId === durable.answer!.operationId)!), durable, "the exact winning operation is replay-safe");
+});
+
+test("answer controls bind exact durable identity and expected state with replay-safe input hashes", () => {
+  const f = fixture();
+  const authenticated: any[] = [];
+  const service = new QuestionService({
+    ...f.service.options,
+    authenticateControl: (request) => {
+      authenticated.push(request);
+      return request.credential === "secret" ? request.claimedIdentity : undefined;
+    },
+  });
+  create(service);
+  const exact = {
+    projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending",
+    value: "postgres", channel: "dashboard", claimedIdentity: "human@example.test", credential: "secret", operationId: "answer-replay",
+  } as const;
+  const answered = service.answer(exact);
+  assert.match(answered.answer?.inputHash ?? "", /^sha256:[0-9a-f]{64}$/u);
+  assert.deepEqual(service.answer(exact), answered, "an after-publication client retry returns the immutable recorded answer");
+  assert.deepEqual(
+    { projectId: authenticated[0].projectId, sessionId: authenticated[0].sessionId, runId: authenticated[0].runId, questionId: authenticated[0].questionId, expectedState: authenticated[0].expectedState },
+    { projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending" },
+  );
+  for (const changed of [
+    { ...exact, projectId: "other" },
+    { ...exact, sessionId: "other" },
+    { ...exact, runId: "other" },
+    { ...exact, expectedState: "answered" },
+    { ...exact, value: "sqlite" },
+    { ...exact, channel: "command" },
+  ]) assert.throws(() => service.answer(changed as any), /identity|expected|operation|input|state|reuse/i);
+  assert.throws(() => service.answer({ ...exact, operationId: "late-other-channel", channel: "command" }), /answered|pending|late|CAS/i);
+});
+
+test("stale run services cannot create or answer questions against a different current run", () => {
+  const f = fixture();
+  const lifecycle = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", snapshotId: "snapshot-1", rootNodeId: "root", createRunId: () => "run-current" });
+  lifecycle.recordUserInput({ inputId: "input-current", text: "work", source: "interactive" });
+  const stale = new QuestionService({ ...f.service.options, runId: "run-stale", createQuestionId: () => "stale-question" });
+  assert.throws(() => create(stale), /current run|stale|identity/i);
+  assert.equal(stale.restore().questions["stale-question"], undefined);
+});
+
+test("ordinary root chat remains steering and cannot satisfy a structured question", () => {
+  const f = fixture(); create(f.service);
+  const lifecycle = new WorkflowRunLifecycle({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", snapshotId: "snapshot-1", rootNodeId: "root", createRunId: () => "run-1" });
+  lifecycle.recordUserInput({ inputId: "chat-1", text: "postgres", source: "interactive" });
+  assert.equal(f.service.restore().questions["question-1"].state, "pending");
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").some((event) => event.type === "run.input.recorded" || event.type === "run.started"), true);
+});
+
+test("terminal close and late answer race serialize atomically and retain an auditable closure", async () => {
+  for (const closeFirst of [true, false]) {
+    const f = fixture(); create(f.service);
+    const close = async () => f.service.closePending({ reason: "run cancelled", operationId: "terminal-1" });
+    const submit = async () => f.service.answer(answer());
+    const results = closeFirst ? await Promise.allSettled([close(), submit()]) : await Promise.allSettled([submit(), close()]);
+    const question = f.service.restore().questions["question-1"];
+    assert.equal(question.state === "closed" || question.state === "answered", true);
+    if (question.state === "closed") {
+      assert.equal(question.closure?.reason, "run cancelled");
+      assert.equal(results.some((entry) => entry.status === "rejected"), true);
+      assert.throws(() => f.service.answer(answer({ operationId: "late" })), /closed|pending|late/i);
+    } else {
+      assert.equal(question.answer?.value, "postgres");
+      assert.deepEqual(f.service.closePending({ reason: "run cancelled", operationId: "terminal-2" }).closedQuestionIds, []);
+    }
+  }
+});
+
+test("terminal closure replay is idempotent only for the exact operation, IDs, and reason", () => {
+  const f = fixture();
+  create(f.service);
+  const expectedQuestionIds = ["question-1"];
+  assert.deepEqual(f.service.closePending({ reason: "run failed", operationId: "terminal-retry", expectedQuestionIds }).closedQuestionIds, expectedQuestionIds);
+  assert.deepEqual(f.service.closePending({ reason: "run failed", operationId: "terminal-retry", expectedQuestionIds }).closedQuestionIds, expectedQuestionIds);
+  assert.throws(() => f.service.closePending({ reason: "different", operationId: "terminal-retry", expectedQuestionIds }), /conflict|reason|closure/i);
+  assert.throws(() => f.service.closePending({ reason: "run failed", operationId: "other-operation", expectedQuestionIds }), /conflict|operation|closure/i);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").filter((event) => event.type === "question.transition" && (event.payload as any).operation === "close-pending").length, 1);
+});
+
+test("a live root tool answer is prepared but not acknowledged before its containing transcript turn", async () => {
+  const f = fixture();
+  const answered = await f.service.createAndPresent({
+    nodeId: "root", definition: { prompt: "Proceed?", kind: "confirm", required: true },
+    provenance: { source: "human_question", toolCallId: "root-live" },
+  }, async () => ({ value: true, claimedIdentity: "root-user", credential: "secret", operationId: "root-live-answer" }));
+  assert.equal(answered.answer?.value, true);
+  const prepared = f.service.prepareRootAnswerDelivery("root");
+  assert.deepEqual(prepared?.questionIds, [answered.questionId], "tool completion alone must leave a durable delivery for containing-turn acceptance");
+  f.service.recordRootAnswerDeliveryReceipt(prepared!, { promptHash: "a".repeat(64), attemptId: "root-attempt", transcriptRef: "run:run-1/node:root/transcript" });
+  f.service.acceptRootAnswerDelivery(prepared!);
+  assert.equal(f.service.prepareRootAnswerDelivery("root"), undefined, "containing transcript acceptance excludes later duplicate injection");
+});
+
+test("delivery preparation and containing-turn acceptance reconcile after publication faults without duplicate markers", () => {
+  const f = fixture();
+  const question = create(f.service);
+  f.service.answer(answer());
+  let faults = 2;
+  const faulted = new QuestionService({
+    ...f.service.options,
+    journalFault: (_eventType, stage) => {
+      if (stage === "afterRename" && faults-- > 0) throw new Error("simulated delivery marker publication fault");
+    },
+  });
+  const [prepared] = faulted.prepareTaskAnswerDeliveries("task-1");
+  assert.deepEqual(prepared.questionIds, [question.questionId]);
+  faulted.recordTaskAnswerDeliveryReceipt(prepared, { promptHash: "b".repeat(64), attemptId: "task-attempt", transcriptRef: "run:run-1/node:worker/task:task-1/transcript" });
+  faulted.acceptTaskAnswerDelivery(prepared);
+  assert.deepEqual(new QuestionService({ ...f.service.options }).prepareTaskAnswerDeliveries("task-1"), []);
+  const operations = readWorkflowJournal(f.projectRoot, "session-1")
+    .filter((event) => event.type === "question.transition")
+    .map((event) => (event.payload as any).operation);
+  assert.equal(operations.filter((operation) => operation === "task-delivery-prepared").length, 1);
+  assert.equal(operations.filter((operation) => operation === "task-delivery-accepted").length, 1);
+});
+
+test("completion gate includes answered-undelivered descendant task questions until their exact transcript accepts them", () => {
+  const f = fixture();
+  const question = create(f.service);
+  f.service.answer(answer());
+  const blocked = f.service.completionGate();
+  assert.equal(blocked.state, "unsatisfied");
+  assert.match(blocked.issues?.join(" ") ?? "", /owning.*task transcript|answered/i);
+  const [delivery] = f.service.prepareTaskAnswerDeliveries("task-1");
+  f.service.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: "c".repeat(64), attemptId: "attempt-1", transcriptRef: "run:run-1/node:worker/task:task-1/transcript" });
+  f.service.acceptTaskAnswerDelivery(delivery);
+  assert.deepEqual(f.service.completionGate(), { state: "satisfied" });
+  assert.ok(f.service.restore().questions[question.questionId].taskDeliveryAcceptedSequence);
+});
+
+test("completed worker attempt reconstructs a missing before-publication receipt across service restart", () => {
+  const f = fixture();
+  const question = create(f.service);
+  f.service.answer(answer());
+  const [delivery] = f.service.prepareTaskAnswerDeliveries("task-1");
+  const attempts = new AttemptRuntime({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  attempts.begin({
+    attemptId: "containing-attempt", correlationId: "containing-correlation", nodeId: "worker", operation: "worker.provider.prompt",
+    input: { taskId: "task-1" }, descriptor: attemptDescriptorForModel(),
+    consumerReceipt: { deliveryIds: [delivery.deliveryId], promptHash: "f".repeat(64), transcriptRef: "run:run-1/node:worker/task:task-1/transcript" },
+  });
+  attempts.complete("containing-attempt", { ok: true, value: "provider completed" });
+  let faulted = false;
+  const interrupted = new QuestionService({ ...f.service.options, journalFault: (_type, stage) => {
+    if (!faulted && stage === "beforeRename") { faulted = true; throw new Error("worker receipt before-publication fault"); }
+  } });
+  assert.throws(() => interrupted.reconcileAnswerDeliveryReceipts(), /before-publication/i);
+  assert.equal(f.service.restore().questions[question.questionId].taskDeliveryReceipt, undefined);
+
+  const restarted = new QuestionService({ ...f.service.options });
+  restarted.reconcileAnswerDeliveryReceipts();
+  const restored = restarted.restore().questions[question.questionId];
+  assert.equal(restored.taskDeliveryReceipt?.attemptId, "containing-attempt");
+  assert.ok(restored.taskDeliveryAcceptedSequence);
+});
+
+test("answer delivery paginates beyond 64 questions and preserves a maximum UTF-8 answer losslessly", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `page-question-${++next}` });
+  const questions = [];
+  for (let index = 0; index < 65; index++) {
+    questions.push(f.service.create({
+      nodeId: "worker", taskId: "task-1",
+      definition: index === 64
+        ? { prompt: "界".repeat(Math.floor(QUESTION_LIMITS.promptBytes / 3)), kind: "text", validation: { maxLength: QUESTION_LIMITS.textAnswerBytes }, required: true }
+        : { prompt: `Question ${index}?`, kind: "confirm", required: true },
+      provenance: { source: "human_question", toolCallId: `page-call-${index}` },
+    }));
+  }
+  for (let index = 0; index < questions.length; index++) {
+    f.service.answer({
+      projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: questions[index].questionId, expectedState: "pending",
+      value: index === 64 ? "界".repeat(Math.floor(QUESTION_LIMITS.textAnswerBytes / 3)) : true,
+      channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `page-answer-${index}`,
+    });
+  }
+
+  const first = f.service.prepareTaskAnswerDeliveries("task-1");
+  assert.equal(first.length, 1);
+  assert.equal(first[0].questionIds.length, 1, "one lossless answer page must not acknowledge omitted answers");
+  f.service.recordTaskAnswerDeliveryReceipt(first[0], { promptHash: "d".repeat(64), attemptId: "page-attempt-1", transcriptRef: "run:run-1/node:worker/task:task-1/transcript" });
+  f.service.acceptTaskAnswerDelivery(first[0]);
+  let restored = f.service.restore();
+  assert.equal(Object.values(restored.questions).filter((question) => question.taskDeliveryAcceptedSequence !== undefined).length, 1);
+  assert.equal(f.service.acceptedAnswersForTask("task-1").length, 64, "the 64 omitted values remain resumable and unconsumed");
+
+  const [second] = f.service.prepareTaskAnswerDeliveries("task-1");
+  assert.equal(second.questionIds.length, 1);
+  assert.notEqual(second.questionIds[0], first[0].questionIds[0], "the continuation page must progress");
+  restored = f.service.restore();
+  assert.equal(Object.values(restored.questions).filter((question) => question.taskDeliveryAcceptedSequence !== undefined).length, 1);
+  assert.equal(restored.questions[questions[64].questionId].answer?.value, "界".repeat(Math.floor(QUESTION_LIMITS.textAnswerBytes / 3)));
+});
+
+test("terminal closure replay requires equality with the complete original operation set", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `question-${++next}` });
+  create(f.service, { provenance: { source: "human_question", toolCallId: "close-1" } });
+  create(f.service, { provenance: { source: "human_question", toolCallId: "close-2" } });
+  assert.deepEqual(f.service.closePending({ reason: "run failed", operationId: "close-all", expectedQuestionIds: ["question-1", "question-2"] }).closedQuestionIds, ["question-1", "question-2"]);
+  assert.throws(
+    () => f.service.closePending({ reason: "run failed", operationId: "close-all", expectedQuestionIds: ["question-1"] }),
+    /exact|set|operation|conflict/i,
+  );
+});
+
+test("offline dashboard append never invokes a model and owner resume data targets the same task/transcript", () => {
+  const f = fixture(); create(f.service);
+  let modelExecutions = 0;
+  f.service.answer(answer());
+  assert.equal(modelExecutions, 0, "answer persistence has no model callback");
+  const resumable = f.service.acceptedAnswersForTask("task-1");
+  assert.equal(resumable.length, 1);
+  assert.deepEqual({ taskId: resumable[0].taskId, questionId: resumable[0].questionId, value: resumable[0].answer.value }, { taskId: "task-1", questionId: "question-1", value: "postgres" });
+  assert.equal(resumable[0].transcriptRef, "run:run-1/node:worker/task:task-1/question:question-1");
+  modelExecutions += 0;
+});
+
+test("waiting status treats root steering as runnable only when the root transcript is not question-suspended", () => {
+  assert.equal(deriveQuestionRunStatus({ pendingQuestions: 1, activeExecutions: 0, runnableTasks: 0, pendingRootInputs: 0, rootQuestionSuspended: true }), "waiting_for_human");
+  assert.equal(deriveQuestionRunStatus({ pendingQuestions: 1, activeExecutions: 0, runnableTasks: 0, pendingRootInputs: 1, rootQuestionSuspended: true }), "waiting_for_human", "ordinary steering cannot run through a root-local question gate");
+  for (const input of [
+    { pendingQuestions: 1, activeExecutions: 1, runnableTasks: 0, pendingRootInputs: 1, rootQuestionSuspended: true },
+    { pendingQuestions: 1, activeExecutions: 0, runnableTasks: 1, pendingRootInputs: 1, rootQuestionSuspended: true },
+    { pendingQuestions: 1, activeExecutions: 0, runnableTasks: 0, pendingRootInputs: 1, rootQuestionSuspended: false },
+    { pendingQuestions: 0, activeExecutions: 0, runnableTasks: 0, pendingRootInputs: 0, rootQuestionSuspended: false },
+  ]) assert.equal(deriveQuestionRunStatus(input), "running");
+});
+
+test("question count is bounded before append so terminal closure cannot poison replay", () => {
+  let id = 0;
+  const f = fixture({ createQuestionId: () => `bounded-${++id}` });
+  for (let index = 0; index < QUESTION_LIMITS.questions; index++) create(f.service, { provenance: { source: "human_question", toolCallId: `bounded-call-${index}` } });
+  const before = readWorkflowJournal(f.projectRoot, "session-1").length;
+  assert.throws(
+    () => create(f.service, { provenance: { source: "human_question", toolCallId: "overflow" } }),
+    /questions.*limit|limit.*questions/i,
+  );
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").length, before);
+  assert.equal(f.service.closePending({ reason: "run cancelled", operationId: "close-bounded" }).closedQuestionIds.length, QUESTION_LIMITS.questions);
+});
+
+test("bounded exact detail DTO exposes enough definition data to answer every kind without identity leakage", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `detail-${++next}` });
+  const definitions = [
+    definition,
+    { prompt: "Select targets", kind: "multi" as const, choices: [{ value: "api", label: "API" }, { value: "web", label: "Web" }], validation: { minItems: 1, maxItems: 2 }, required: true },
+    { prompt: "Release name", kind: "text" as const, validation: { minLength: 3, maxLength: 12, pattern: "^[a-z-]+$" }, required: true },
+    { prompt: "Proceed?", kind: "confirm" as const, required: true },
+  ];
+  const values = ["postgres", ["api"], "release-one", true] as const;
+  for (const [index, input] of definitions.entries()) {
+    const question = create(f.service, { definition: input, provenance: { source: "human_question", toolCallId: `detail-call-${index}` } });
+    const pages: any[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = (f.service as any).detail({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, ...(cursor ? { cursor } : {}) });
+      assert.ok(Buffer.byteLength(JSON.stringify(page), "utf8") <= QUESTION_LIMITS.dtoBytes);
+      assert.equal(JSON.stringify(page).includes("human@example.test"), false);
+      assert.equal("answer" in page, false);
+      pages.push(page);
+      cursor = page.nextCursor;
+    } while (cursor);
+    const reconstructed = {
+      prompt: pages.map((page) => page.promptChunk).join(""), kind: pages[0].kind,
+      ...(pages.some((page) => page.choices.length) ? { choices: pages.flatMap((page) => page.choices) } : {}),
+      ...(pages[0].validation ? { validation: pages[0].validation } : {}), required: pages[0].required,
+    };
+    assert.deepEqual(reconstructed, input);
+    assert.doesNotThrow(() => validateQuestionAnswer(reconstructed as any, values[index]));
+  }
+  assert.throws(() => (f.service as any).detail({ projectId: "other", sessionId: "session-1", runId: "run-1", questionId: "detail-1" }), /identity|project/i);
+  assert.throws(() => (f.service as any).detail({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "detail-1", cursor: "999:0:0" }), /cursor|stale/i);
+});
+
+test("status and detail pagination progress under worst-case UTF-8 and escaping bounds", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `q-${String(++next).padStart(3, "0")}-${"i".repeat(220)}` });
+  const large = {
+    prompt: `${"😀\"".repeat(2_000)}tail`, kind: "single" as const,
+    choices: Array.from({ length: 32 }, (_, index) => ({ value: `v${index}-${"\\\"".repeat(80)}`, label: `L${index}-${"😀\"".repeat(80)}` })), required: true,
+  };
+  for (let index = 0; index < 40; index++) create(f.service, { definition: large, provenance: { source: "human_question", toolCallId: `worst-${index}` } });
+  let cursor: string | undefined;
+  let seen = 0;
+  do {
+    const page = f.service.status({ limit: 40, ...(cursor ? { cursor } : {}) });
+    assert.ok(page.items.length > 0);
+    assert.ok(Buffer.byteLength(JSON.stringify(page), "utf8") <= QUESTION_LIMITS.dtoBytes);
+    seen += page.items.length;
+    cursor = page.nextCursor;
+  } while (cursor);
+  assert.equal(seen, 40);
+  assert.throws(() => f.service.status({ limit: 40, cursor: "999" }), /cursor|stale/i);
+
+  const id = f.service.status({ limit: 1 }).items[0].questionId;
+  const first = (f.service as any).detail({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: id, choiceLimit: 4 });
+  assert.ok(first.nextCursor, "large prompt/choices require a progressing bounded cursor");
+});
+
+test("filtered question status cursor remains stable when an earlier queue item changes state", () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `question-${++next}` });
+  create(f.service, { provenance: { source: "human_question", toolCallId: "cursor-1" } });
+  create(f.service, { provenance: { source: "human_question", toolCallId: "cursor-2" } });
+  create(f.service, { provenance: { source: "human_question", toolCallId: "cursor-3" } });
+  const first = f.service.status({ state: "pending", limit: 1 });
+  assert.equal(first.items[0].questionId, "question-1");
+  f.service.answer(answer({ questionId: "question-1", operationId: "cursor-answer" }));
+  const second = f.service.status({ state: "pending", limit: 1, cursor: first.nextCursor });
+  assert.equal(second.items[0].questionId, "question-2", "queue mutation must not shift q2 behind the cursor");
+  assert.throws(() => f.service.status({ state: "answered", limit: 1, cursor: first.nextCursor }), /cursor|filter|stale/i, "a cursor is bound to its filter");
+});
+
+test("non-cooperative presentation settles on shutdown and handle truth remains live until settlement", async () => {
+  let next = 0;
+  const f = fixture({ createQuestionId: () => `noncoop-${++next}` });
+  const toolPromise = f.service.createAndPresent({ nodeId: "worker", taskId: "task-1", definition, provenance: { source: "human_question", toolCallId: "noncoop" } }, async () => new Promise(() => {}));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(f.service.hasLiveHandles(), true);
+  let shutdownResolved = false;
+  const shuttingDown = f.service.shutdown().then(() => { shutdownResolved = true; });
+  assert.equal(f.service.hasLiveHandles(), true, "shutdown must report the tracked wrapper until its abort race settles");
+  assert.equal(shutdownResolved, false);
+  await Promise.race([
+    shuttingDown,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("question shutdown timed out")), 250)),
+  ]);
+  const result = await Promise.race([
+    toolPromise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("question tool did not settle")), 250)),
+  ]);
+  assert.equal(result.state, "pending");
+  assert.equal(f.service.hasLiveHandles(), false);
+});
+
+test("a pre-aborted non-cooperative presenter settles and cannot hang shutdown", async () => {
+  const f = fixture();
+  const caller = new AbortController();
+  caller.abort("already cancelled");
+  const presentation = f.service.createAndPresent({
+    nodeId: "worker", taskId: "task-1", definition,
+    provenance: { source: "human_question", toolCallId: "pre-aborted" },
+  }, async () => new Promise(() => {}), caller.signal);
+  await new Promise((resolve) => setImmediate(resolve));
+  await Promise.race([
+    f.service.shutdown(),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("pre-aborted shutdown timed out")), 100)),
+  ]);
+  const restored = await presentation;
+  assert.equal(restored.state, "pending");
+  assert.equal(f.service.hasLiveHandles(), false);
+});
+
+test("question queue DTO is cursor-paginated and bounded and shutdown clears presentation handles", async () => {
+  let id = 0;
+  const f = fixture({ createQuestionId: () => `question-${++id}` });
+  for (let index = 0; index < 45; index++) create(f.service, { provenance: { source: "human_question", toolCallId: `call-${index}` } });
+  const first = f.service.status({ state: "pending", limit: 40 });
+  assert.equal(first.items.length, 40);
+  assert.deepEqual(
+    { projectId: first.items[0].projectId, sessionId: first.items[0].sessionId, runId: first.items[0].runId },
+    { projectId: "project-1", sessionId: "session-1", runId: "run-1" },
+    "dashboard controls need every exact durable identity, not only the object ID",
+  );
+  assert.equal(first.total, 45);
+  assert.match(first.nextCursor ?? "", /^pending:[1-9][0-9]*$/u);
+  assert.ok(Buffer.byteLength(JSON.stringify(first), "utf8") <= 65_536);
+  const second = f.service.status({ state: "pending", limit: 40, cursor: first.nextCursor });
+  assert.equal(second.items.length, 5);
+
+  let releasePresenter!: () => void;
+  const presenterGate = new Promise<void>((resolve) => { releasePresenter = resolve; });
+  const presentation = f.service.createAndPresent({ nodeId: "worker", taskId: "task-1", definition, provenance: { source: "human_question", toolCallId: "shutdown" } }, async () => {
+    await presenterGate; // deliberately ignores AbortSignal
+    return undefined;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(f.service.hasLiveHandles(), true);
+  await f.service.shutdown();
+  const settled = await Promise.race([presentation.then(() => true), new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25))]);
+  assert.equal(settled, true, "shutdown must settle the tool promise even when the UI presenter ignores abort");
+  assert.equal(f.service.hasLiveHandles(), false);
+  releasePresenter();
+});

--- a/tests/workflows/workflow-run-cancel.test.ts
+++ b/tests/workflows/workflow-run-cancel.test.ts
@@ -7,13 +7,24 @@ import { test } from "node:test";
 import { killProcessTree, spawnManaged } from "../../src/engine/process.ts";
 import { readWorkflowJournal } from "../../src/workflows/journal.ts";
 import { acquireRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
 import {
   CANCELLATION_TIMING,
   WorkflowRunLifecycle,
   type CancellationCoordinator,
+  type CompletionValidationHooks,
 } from "../../src/workflows/runs.ts";
 
-function fixture() {
+function questionSnapshot(): ActivationSnapshotFileV1 {
+  return { snapshotHash: "q".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." }, workflow: { id: "w", team: { rootId: "root", nodes: [{ id: "root", agentId: "lead", memberIds: [], depth: 1 }] } },
+    authority: { capabilityContractVersion: 1, nodes: [{ nodeId: "root", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }] },
+    agents: [{ id: "lead", name: "Lead", prompt: "lead" }], skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function fixture(completion?: CompletionValidationHooks, journalFault?: (eventType: string, stage: string) => void) {
   const projectRoot = mkdtempSync(join(tmpdir(), "hive-run-cancel-"));
   let tick = 0;
   const options = {
@@ -25,6 +36,8 @@ function fixture() {
     runtimeOwnerNonce: "owner-1",
     createRunId: () => "run-1",
     now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)).toISOString(),
+    ...(completion ? { completion } : {}),
+    ...(journalFault ? { journalFault: journalFault as any } : {}),
   };
   const lifecycle = new WorkflowRunLifecycle(options);
   lifecycle.recordUserInput({ inputId: "initial", text: "mutate files", source: "interactive" });
@@ -54,6 +67,72 @@ test("two-phase idle cancellation settles before final capture without rollback 
   assert.deepEqual(JSON.parse(result.rendered), result.envelope);
   assert.deepEqual(readWorkflowJournal(f.projectRoot, "session-1").slice(-2).map((event) => event.type), ["run.cancel.requested", "terminal.recorded"]);
   assert.deepEqual(CANCELLATION_TIMING, { settleGraceMs: 2_000, killSettleMs: 1_000, coordinatorStepMs: 2_000 });
+});
+
+test("cancellation persists the exact pending question closure IDs", async () => {
+  const f = fixture({ questions: async () => ({ state: "unsatisfied", issues: ["pending"], pendingQuestionIds: ["q-cancel"] }) });
+  const result = await f.lifecycle.cancel("cancel with question", { waitForSettlement: async () => true });
+  assert.deepEqual(result.envelope.closedQuestionIds, ["q-cancel"]);
+  assert.deepEqual((readWorkflowJournal(f.projectRoot, "session-1").find((event) => event.type === "terminal.recorded")!.payload as any).closedQuestionIds, ["q-cancel"]);
+});
+
+test("cancellation retry after closure preserves its originally prepared question IDs", async () => {
+  let gateCalls = 0;
+  let fault = true;
+  const f = fixture({ questions: async () => gateCalls++ === 0
+    ? ({ state: "unsatisfied", issues: ["pending"], pendingQuestionIds: ["q-retry"] })
+    : ({ state: "satisfied" }) }, (eventType, stage) => {
+    if (fault && eventType === "terminal.recorded" && stage === "beforeRename") { fault = false; throw new Error("cancel terminal fault"); }
+  });
+  await assert.rejects(() => f.lifecycle.cancel("retry cancellation", { waitForSettlement: async () => true }), /cancel terminal fault/i);
+  const retried = await new WorkflowRunLifecycle(f.lifecycle.options).cancel("retry cancellation", { waitForSettlement: async () => true });
+  assert.deepEqual(retried.envelope.closedQuestionIds, ["q-retry"]);
+});
+
+test("cancellation freezes the exact real question set in its journal CAS for both answer race outcomes and restart", async () => {
+  for (const answerWins of [true, false]) {
+    const projectRoot = mkdtempSync(join(tmpdir(), "hive-cancel-question-race-"));
+    const question = new QuestionService({
+      projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: questionSnapshot(), createQuestionId: () => "question-1",
+      authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+    });
+    let raced = false;
+    const completion: CompletionValidationHooks = {
+      questions: () => {
+        const gate = question.completionGate();
+        if (answerWins && !raced) {
+          raced = true;
+          question.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-before-cancel" });
+        }
+        return gate;
+      },
+      validateQuestionSet: (events, expected) => question.assertPendingSet(events, expected),
+    } as CompletionValidationHooks;
+    const options = {
+      projectRoot, projectId: "project-1", sessionId: "session-1", snapshotId: "snapshot-1", rootNodeId: "root",
+      runtimeOwnerNonce: "owner-1", createRunId: () => "run-1", completion,
+    };
+    const lifecycle = new WorkflowRunLifecycle(options);
+    lifecycle.recordUserInput({ inputId: "initial", text: "work", source: "interactive" });
+    assert.equal(acquireRuntimeOwnership(projectRoot, "session-1", { nonce: "owner-1" }).ok, true);
+    question.create({ nodeId: "root", definition: { prompt: "Proceed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "cancel-race" } });
+    let losingAnswerRejected = false;
+    const result = await lifecycle.cancel("stop", {
+      rejectNewWork: () => {
+        if (!answerWins) {
+          try { question.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-after-cancel" }); }
+          catch { losingAnswerRejected = true; }
+        }
+      },
+      waitForSettlement: async () => true,
+      releaseLeases: () => { question.closePending({ reason: "stop", operationId: "cancel-run-1", expectedQuestionIds: lifecycle.restore().latestRun?.cancellationQuestionIds ?? [] }); },
+    });
+    assert.deepEqual(result.envelope.closedQuestionIds, answerWins ? [] : ["question-1"]);
+    assert.equal(question.restore().questions["question-1"].state, answerWins ? "answered" : "closed");
+    assert.equal(losingAnswerRejected, !answerWins);
+    const restarted = await new WorkflowRunLifecycle(options).cancel("retry", { waitForSettlement: async () => true });
+    assert.deepEqual(restarted.envelope, result.envelope);
+  }
 });
 
 test("concurrent cancellation callers share one settlement without releasing leases during capture", async () => {

--- a/tests/workflows/workflow-run-chat.test.ts
+++ b/tests/workflows/workflow-run-chat.test.ts
@@ -54,6 +54,16 @@ test("idle input creates one run, later input steers it, duplicate callbacks are
   assert.deepEqual(replayedBeforeProvider.pendingInputs(), []);
 });
 
+test("run input rejects unsafe C0 controls before persistence while preserving structured whitespace", () => {
+  const f = fixture();
+  const lifecycle = new WorkflowRunLifecycle(f.options);
+  assert.throws(() => lifecycle.recordUserInput({ inputId: "unsafe", text: "unsafe\u0001input", source: "interactive" }), /unsafe|control|input/i);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").length, 0);
+  const accepted = lifecycle.recordUserInput({ inputId: "whitespace", text: "line one\nline two\tend", source: "interactive" });
+  assert.equal(accepted.input.text, "line one\nline two\tend");
+  assert.equal(new WorkflowRunLifecycle(f.options).restore().latestRun?.inputs[0].text, accepted.input.text);
+});
+
 test("a crash fault after publishing delivery preparation is reconciled from the durable request", () => {
   const f = fixture();
   const lifecycle = new WorkflowRunLifecycle(f.options);

--- a/tests/workflows/workflow-run-finish.test.ts
+++ b/tests/workflows/workflow-run-finish.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { readWorkflowJournal } from "../../src/workflows/journal.ts";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
 import {
   WorkflowRunLifecycle,
   terminalEnvelopeFromEvent,
@@ -12,7 +14,15 @@ import {
   type FinishResult,
 } from "../../src/workflows/runs.ts";
 
-function fixture(hooks: CompletionValidationHooks = {}) {
+function questionSnapshot(): ActivationSnapshotFileV1 {
+  return { snapshotHash: "q".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
+    project: { projectId: "project-1", rootRef: "." }, workflow: { id: "w", team: { rootId: "root", nodes: [{ id: "root", agentId: "lead", memberIds: [], depth: 1 }] } },
+    authority: { capabilityContractVersion: 1, nodes: [{ nodeId: "root", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }] },
+    agents: [{ id: "lead", name: "Lead", prompt: "lead" }], skills: [], knowledge: [], models: [], sources: [], versions: {} as never,
+  } } as unknown as ActivationSnapshotFileV1;
+}
+
+function fixture(hooks: CompletionValidationHooks = {}, journalFault?: (eventType: string, stage: string) => void) {
   const projectRoot = mkdtempSync(join(tmpdir(), "hive-run-finish-"));
   let run = 0;
   let tick = 0;
@@ -25,6 +35,7 @@ function fixture(hooks: CompletionValidationHooks = {}) {
     createRunId: () => `run-${++run}`,
     now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)).toISOString(),
     completion: hooks,
+    journalFault: journalFault as any,
   });
   return { projectRoot, lifecycle };
 }
@@ -174,6 +185,94 @@ test("terminal settlement intent makes question closure and lease release replay
   assert.equal(operationIds.length, 2);
   assert.equal(operationIds[0], operationIds[1], "retries must reuse the durable idempotency key");
   assert.deepEqual(readWorkflowJournal(f.projectRoot, "session-1").slice(-2).map((event) => event.type), ["run.terminal.prepared", "terminal.recorded"]);
+});
+
+test("fault after question closure but before terminal publication retries one closure and one terminal", async () => {
+  let closureEffects = 0;
+  let failCommit = true;
+  const operationIds: string[] = [];
+  const f = fixture({
+    questions: async () => ({ state: "unsatisfied", issues: ["question pending"], pendingQuestionIds: ["q-1"] }),
+    evidence: async () => ({ state: "satisfied" }),
+    settleTerminal: async (settlement) => {
+      operationIds.push(settlement.operationId);
+      if (closureEffects === 0) closureEffects++;
+      else assert.equal(settlement.operationId, operationIds[0], "closure retry must reconcile the same durable operation");
+    },
+  }, (eventType, stage) => {
+    if (failCommit && eventType === "terminal.recorded" && stage === "beforeRename") {
+      failCommit = false;
+      throw new Error("crash after closure before terminal publication");
+    }
+  });
+  startAndDeliver(f.lifecycle);
+  const failed = { ...request, status: "failed" as const, evidenceRefs: [{ kind: "test", claim: "failure evidence" }] };
+  const first = await f.lifecycle.finish(failed, rootBatch);
+  assert.equal(first.ok, false);
+  assert.match(issuesOf(first), /crash after closure/i);
+  const second = await new WorkflowRunLifecycle(f.lifecycle.options).finish(failed, rootBatch);
+  assert.equal(second.ok, true, issuesOf(second));
+  assert.equal(closureEffects, 1);
+  assert.deepEqual(operationIds, [operationIds[0], operationIds[0]]);
+  assert.equal(readWorkflowJournal(f.projectRoot, "session-1").filter((event) => event.type === "terminal.recorded").length, 1);
+});
+
+test("automatic budget failure persists and settles exact pending question IDs", async () => {
+  const settlements: any[] = [];
+  const f = fixture({
+    questions: async () => ({ state: "unsatisfied", issues: ["pending"], pendingQuestionIds: ["q-budget"] }),
+    settleTerminal: async (settlement) => { settlements.push(settlement); },
+  });
+  f.lifecycle.recordUserInput({ inputId: "budget-input", text: "work", source: "interactive" });
+  const result = await f.lifecycle.failBudgetExhaustion("tokens exhausted");
+  assert.equal(result.ok, true, issuesOf(result));
+  if (!result.ok) return;
+  assert.deepEqual(result.envelope.closedQuestionIds, ["q-budget"]);
+  assert.deepEqual(settlements[0].closedQuestionIds, ["q-budget"]);
+  assert.deepEqual(f.lifecycle.restore().latestRun?.terminal?.closedQuestionIds, ["q-budget"]);
+});
+
+test("budget failure freezes the exact real question set in its preparation CAS for both answer race outcomes and restart", async () => {
+  for (const answerWins of [true, false]) {
+    const projectRoot = mkdtempSync(join(tmpdir(), "hive-budget-question-race-"));
+    const question = new QuestionService({
+      projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: questionSnapshot(), createQuestionId: () => "question-1",
+      authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+    });
+    let raced = false;
+    let losingAnswerRejected = false;
+    const hooks: CompletionValidationHooks = {
+      questions: () => {
+        const gate = question.completionGate();
+        if (answerWins && !raced) {
+          raced = true;
+          question.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-before-budget" });
+        }
+        return gate;
+      },
+      validateQuestionSet: (events, expected) => question.assertPendingSet(events, expected),
+      settleTerminal: (settlement) => {
+        if (!answerWins) {
+          try { question.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "answer-after-budget" }); }
+          catch { losingAnswerRejected = true; }
+        }
+        question.closePending({ reason: "run failed", operationId: settlement.operationId, expectedQuestionIds: settlement.closedQuestionIds });
+      },
+    } as CompletionValidationHooks;
+    const options = { projectRoot, projectId: "project-1", sessionId: "session-1", snapshotId: "snapshot-1", rootNodeId: "root", createRunId: () => "run-1", completion: hooks };
+    const lifecycle = new WorkflowRunLifecycle(options);
+    lifecycle.recordUserInput({ inputId: "initial", text: "work", source: "interactive" });
+    question.create({ nodeId: "root", definition: { prompt: "Proceed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "budget-race" } });
+    const result = await lifecycle.failBudgetExhaustion("tokens exhausted");
+    assert.equal(result.ok, true, issuesOf(result));
+    if (!result.ok) continue;
+    assert.deepEqual(result.envelope.closedQuestionIds, answerWins ? [] : ["question-1"]);
+    assert.equal(question.restore().questions["question-1"].state, answerWins ? "answered" : "closed");
+    assert.equal(losingAnswerRejected, !answerWins);
+    const restarted = await new WorkflowRunLifecycle(options).failBudgetExhaustion("retry");
+    assert.equal(restarted.ok, true, issuesOf(restarted));
+    if (restarted.ok) assert.deepEqual(restarted.envelope, result.envelope);
+  }
 });
 
 test("strict terminal validation runs before append so malformed subsystem records cannot corrupt replay", async () => {

--- a/tests/workflows/workflow-run-state.test.ts
+++ b/tests/workflows/workflow-run-state.test.ts
@@ -102,6 +102,43 @@ function terminalPayload(status: "completed" | "blocked" | "failed" | "cancelled
   };
 }
 
+test("multiple approval requests and a question wait settle independently by request identity", () => {
+  const approvalA = reduceRunLifecycle(stateWith("running"), event("approval.recorded", {
+    subsystem: "checkpoint-approval", operation: "request", requestId: "approval-a",
+  }, 1, runId, "harness"));
+  const approvalB = reduceRunLifecycle(approvalA, event("approval.recorded", {
+    subsystem: "checkpoint-approval", operation: "request", requestId: "approval-b",
+  }, 2, runId, "harness"));
+  assert.equal(approvalB.latestRun?.status, "waiting_for_human");
+  assert.deepEqual(approvalB.latestRun?.pendingApprovalRequestIds, ["approval-a", "approval-b"]);
+  assert.deepEqual(approvalB.latestRun?.waitCauses, ["approval"]);
+
+  const simultaneous = reduceRunLifecycle(approvalB, event("run.transition", {
+    from: "waiting_for_human", to: "waiting_for_human", reason: "question pending", waitCause: "question", waitOperation: "add",
+  }, 3));
+  assert.deepEqual(simultaneous.latestRun?.waitCauses, ["approval", "question"]);
+
+  const decidedA = reduceRunLifecycle(simultaneous, event("approval.recorded", {
+    subsystem: "checkpoint-approval", operation: "decision", requestId: "approval-a",
+  }, 4, runId, "dashboard"));
+  assert.equal(decidedA.latestRun?.status, "waiting_for_human");
+  assert.deepEqual(decidedA.latestRun?.pendingApprovalRequestIds, ["approval-b"]);
+  assert.deepEqual(decidedA.latestRun?.waitCauses, ["approval", "question"]);
+
+  const answered = reduceRunLifecycle(decidedA, event("run.transition", {
+    from: "waiting_for_human", to: "waiting_for_human", reason: "question answered", waitCause: "question", waitOperation: "remove",
+  }, 5));
+  assert.equal(answered.latestRun?.status, "waiting_for_human");
+  assert.deepEqual(answered.latestRun?.waitCauses, ["approval"]);
+
+  const approved = reduceRunLifecycle(answered, event("approval.recorded", {
+    subsystem: "checkpoint-approval", operation: "decision", requestId: "approval-b",
+  }, 6, runId, "dashboard"));
+  assert.equal(approved.latestRun?.status, "running");
+  assert.deepEqual(approved.latestRun?.pendingApprovalRequestIds, []);
+  assert.deepEqual(approved.latestRun?.waitCauses, []);
+});
+
 test("run reducer rejects ordinary transitions once cancellation or terminal settlement begins", () => {
   const cancelling = { ...stateWith("running"), latestRun: { ...stateWith("running").latestRun!, cancellationRequested: true } };
   assert.throws(() => reduceRunLifecycle(cancelling, event("run.transition", { from: "running", to: "paused", resumeStatus: "running", pauseState: {} })), /cancel|immutable|final/i);
@@ -129,6 +166,18 @@ test("run reducer enforces authoritative producers and cancellation/delivery ter
   const cancelling = { ...stateWith("running"), latestRun: { ...stateWith("running").latestRun!, cancellationRequested: true } };
   assert.throws(() => reduceRunLifecycle(cancelling, event("terminal.recorded", terminalPayload("completed"), 1, runId, "harness")), /cancel/i);
   assert.equal(reduceRunLifecycle(cancelling, event("terminal.recorded", terminalPayload("cancelled"), 1, runId, "harness")).latestRun?.status, "cancelled");
+});
+
+test("cancelled terminal replay must equal the question set frozen by cancellation", () => {
+  const cancelling = {
+    ...stateWith("running"),
+    latestRun: { ...stateWith("running").latestRun!, cancellationRequested: true, cancellationQuestionIds: ["q-frozen"] },
+  };
+  assert.throws(
+    () => reduceRunLifecycle(cancelling, event("terminal.recorded", { ...terminalPayload("cancelled"), closedQuestionIds: [] }, 1, runId, "harness")),
+    /question|closure|cancel|frozen|match/i,
+  );
+  assert.equal(reduceRunLifecycle(cancelling, event("terminal.recorded", { ...terminalPayload("cancelled"), closedQuestionIds: ["q-frozen"] }, 1, runId, "harness")).latestRun?.status, "cancelled");
 });
 
 test("terminal envelopes are strictly and semantically validated during replay", () => {

--- a/tests/workflows/workflow-scheduler.test.ts
+++ b/tests/workflows/workflow-scheduler.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +7,7 @@ import { test } from "node:test";
 import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
 import { DelegationRuntime, type WorkerResultInput } from "../../src/workflows/delegation.ts";
 import { DurableDelegationScheduler } from "../../src/workflows/scheduler.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
 
 function snapshot(): ActivationSnapshotFileV1 {
   return { snapshotHash: "c".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
@@ -197,6 +199,238 @@ test("a durable resume-ready task continues the same attempt after scheduler res
   assert.deepEqual(replayed.restore().tasks[parentId].attempts.map((attempt) => attempt.attemptId), ["attempt-parent"]);
 });
 
+test("human question suspension releases the slot and an answer resumes the same task attempt", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-question-"));
+  let taskNumber = 0;
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const runtime = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => `task-${++taskNumber}` });
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "ask then resume", deliverables: [] }).taskId;
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot,
+    createQuestionId: () => "question-1", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  let executions = 0;
+  const scheduler = new DurableDelegationScheduler({
+    runtime, maxParallel: 1, createAttemptId: () => "attempt-1",
+    execute: async (task) => {
+      if (executions++ === 0) {
+        const question = questions.create({ nodeId: task.targetNodeId, taskId: task.taskId, definition: { prompt: "Proceed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "call-1" } });
+        return { status: "suspended", questionIds: [question.questionId] };
+      }
+      assert.equal(questions.acceptedAnswersForTask(task.taskId)[0].answer.value, true);
+      return completed("resumed same task");
+    },
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(scheduler.activeCount, 0, "waiting questions must not occupy max-parallel slots");
+  assert.equal(runtime.restore().tasks[taskId].queueState, "suspended");
+  assert.deepEqual(runtime.restore().tasks[taskId].attempts.map((attempt) => attempt.attemptId), ["attempt-1"]);
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-1" });
+  await scheduler.runUntilSettled();
+  assert.equal(runtime.restore().tasks[taskId].result?.summary, "resumed same task");
+  assert.deepEqual(runtime.restore().tasks[taskId].attempts.map((attempt) => attempt.attemptId), ["attempt-1"], "question resume must preserve the task attempt");
+});
+
+test("offline question answer resumes after scheduler restart without takeover", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-question-restart-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const options = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "task-question-restart" };
+  const runtime = new DelegationRuntime(options);
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "resume after owner restart", deliverables: [] }).taskId;
+  runtime.start(taskId, "attempt-question-restart");
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot,
+    createQuestionId: () => "question-restart", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  questions.create({ nodeId: "a", taskId, definition: { prompt: "Proceed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "call-restart" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-restart", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-restart" });
+
+  let takeoverChecks = 0;
+  const replayed = new DelegationRuntime(options);
+  const scheduler = new DurableDelegationScheduler({
+    runtime: replayed, maxParallel: 1,
+    verifiedTakeover: () => { takeoverChecks++; return false; },
+    execute: async (_task, control) => {
+      assert.equal(control.attemptId, "attempt-question-restart");
+      return completed("continued after offline answer");
+    },
+  });
+  await scheduler.runUntilSettled();
+  assert.equal(takeoverChecks, 0);
+  assert.equal(replayed.restore().tasks[taskId].result?.summary, "continued after offline answer");
+  assert.deepEqual(replayed.restore().tasks[taskId].attempts.map((attempt) => attempt.attemptId), ["attempt-question-restart"]);
+});
+
+test("mixed takeover preserves question and consumed-receipt resume-ready attempts", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-mixed-takeover-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [
+    { nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] },
+    { nodeId: "b", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] },
+  ];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  let taskNumber = 0;
+  const options = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => `mixed-${++taskNumber}` };
+  const runtime = new DelegationRuntime(options);
+  const root = runtime.rootExecutionContext();
+  const unknown = runtime.accept(root, { targetNodeId: "a", objective: "unknown active", deliverables: [] }).taskId;
+  const resume = runtime.accept(root, { targetNodeId: "b", objective: "question resume", deliverables: [] }).taskId;
+  runtime.start(unknown, "attempt-unknown");
+  runtime.start(resume, "attempt-resume");
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot,
+    createQuestionId: () => "mixed-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  questions.create({ nodeId: "b", taskId: resume, definition: { prompt: "Resume?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "mixed-call" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "mixed-question", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "mixed-answer" });
+  const [delivery] = questions.prepareTaskAnswerDeliveries(resume);
+  questions.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: "a".repeat(64), attemptId: "attempt-resume", transcriptRef: `run:run-1/node:b/task:${resume}/transcript` });
+
+  const recovered = new DelegationRuntime(options);
+  recovered.reconcileActiveAfterTakeover(true);
+  assert.equal(recovered.restore().tasks[unknown].queueState, "queued");
+  assert.equal(recovered.restore().tasks[resume].queueState, "active");
+  assert.equal(recovered.restore().tasks[resume].attempts[0].interruptedSequence, undefined);
+});
+
+test("task start admission CAS leaves queued work unchanged when approval wins the race", () => {
+  const f = fixture();
+  const runtime = new DelegationRuntime({
+    ...f.runtime.options,
+    startAuthority: { admit: () => ({ ok: false as const, reason: "approval wait won admission" }) },
+  });
+  assert.throws(() => runtime.start(f.ids.a1, "attempt-raced"), /approval wait/i);
+  assert.equal(runtime.restore().tasks[f.ids.a1].queueState, "queued");
+  assert.equal(runtime.restore().tasks[f.ids.a1].attempts.length, 0);
+});
+
+test("worker terminal publication loses to an answered undelivered question and preserves the attempt", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-terminal-question-cas-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const base = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "terminal-race" };
+  const runtime = new DelegationRuntime(base);
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "terminal race", deliverables: [] }).taskId;
+  runtime.start(taskId, "attempt-terminal-race");
+  const questions = new QuestionService({ ...base, createQuestionId: () => "terminal-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  questions.create({ nodeId: "a", taskId, definition: { prompt: "Late?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "terminal-call" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "terminal-question", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "terminal-answer" });
+  const guarded = new DelegationRuntime({ ...base, terminalAuthority: { assertTaskMayTerminal: (events: any, id: string) => questions.assertTaskMayTerminal(events, id) } });
+  assert.throws(() => guarded.recordResult(taskId, completed("must lose")), /undelivered|unaccepted|answer/i);
+  const preserved = guarded.restore().tasks[taskId];
+  assert.equal(preserved.queueState, "active");
+  assert.equal(preserved.resumedByQuestionSequence !== undefined, true);
+  assert.deepEqual(preserved.attempts.map((attempt) => attempt.attemptId), ["attempt-terminal-race"]);
+});
+
+test("ordinary worker terminal publication rejects pending task questions and preserves the exact attempt across restart", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-pending-terminal-cas-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const base = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "pending-terminal-task" };
+  const questions = new QuestionService({ ...base, createQuestionId: () => "pending-terminal-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const runtime = new DelegationRuntime({ ...base, terminalAuthority: { assertTaskMayTerminal: (events, id) => questions.assertTaskMayTerminal(events, id) } });
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "pending terminal", deliverables: [] }).taskId;
+  runtime.start(taskId, "pending-terminal-attempt");
+  questions.create({ nodeId: "a", taskId, definition: { prompt: "Still needed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "pending-terminal-call" } });
+
+  assert.throws(() => runtime.recordResult(taskId, completed("must not publish")), /pending|question|undelivered/i);
+  const restarted = new DelegationRuntime(runtime.options).restore().tasks[taskId];
+  assert.equal(restarted.queueState, "suspended");
+  assert.deepEqual(restarted.attempts.map((attempt) => attempt.attemptId), ["pending-terminal-attempt"]);
+});
+
+test("task-bound answer rejects a terminal exact task attempt without creating an answered orphan", () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-terminal-first-answer-cas-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const base = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "terminal-first-task" };
+  const runtime = new DelegationRuntime(base);
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "terminal first", deliverables: [] }).taskId;
+  runtime.start(taskId, "terminal-first-attempt");
+  const questions = new QuestionService({ ...base, createQuestionId: () => "terminal-first-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const question = questions.create({ nodeId: "a", taskId, definition: { prompt: "Too late?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "terminal-first-call" } });
+  runtime.recordResult(taskId, completed("terminal won without the production guard"));
+
+  assert.throws(() => questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "terminal-first-answer" }), /task|attempt|terminal|live|late/i);
+  const restored = new QuestionService({ ...questions.options }).restore().questions[question.questionId];
+  assert.equal(restored.state, "pending");
+  assert.equal(restored.answer, undefined);
+});
+
+test("cross-process answer and ordinary terminal publication serialize through the journal CAS", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-question-cross-process-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const base = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "cross-task" };
+  const runtime = new DelegationRuntime(base);
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "cross process race", deliverables: [] }).taskId;
+  runtime.start(taskId, "cross-attempt");
+  const questions = new QuestionService({ ...base, createQuestionId: () => "cross-question", authenticateControl: (request) => request.claimedIdentity });
+  questions.create({ nodeId: "a", taskId, definition: { prompt: "Race?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "cross-call" } });
+  const common = `const projectRoot=${JSON.stringify(projectRoot)}; const snapshot=${JSON.stringify(authoritySnapshot)};`;
+  const scripts = [
+    `${common} const {QuestionService}=await import('./src/workflows/questions.ts'); const q=new QuestionService({projectRoot,projectId:'project-1',sessionId:'session-1',runId:'run-1',snapshot,authenticateControl:r=>r.claimedIdentity}); q.answer({projectId:'project-1',sessionId:'session-1',runId:'run-1',questionId:'cross-question',expectedState:'pending',value:true,channel:'dashboard',claimedIdentity:'human',operationId:'cross-answer'});`,
+    `${common} const [{DelegationRuntime},{QuestionService}]=await Promise.all([import('./src/workflows/delegation.ts'),import('./src/workflows/questions.ts')]); const q=new QuestionService({projectRoot,projectId:'project-1',sessionId:'session-1',runId:'run-1',snapshot,authenticateControl:r=>r.claimedIdentity}); const d=new DelegationRuntime({projectRoot,projectId:'project-1',sessionId:'session-1',runId:'run-1',snapshot,terminalAuthority:{assertTaskMayTerminal:(events,id)=>q.assertTaskMayTerminal(events,id)}}); d.recordResult('cross-task',{status:'completed',summary:'race terminal',outputRefs:[],evidenceRefs:[]});`,
+  ];
+  const run = (script: string) => new Promise<number | null>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], { cwd: process.cwd(), env: { ...process.env, NODE_V8_COVERAGE: "" }, stdio: ["ignore", "ignore", "ignore"] });
+    child.once("error", reject); child.once("exit", resolve);
+  });
+  const codes = await Promise.all(scripts.map(run));
+  assert.equal(codes.filter((code) => code === 0).length, 1);
+  const restoredTask = new DelegationRuntime(base).restore().tasks[taskId];
+  const restoredQuestion = new QuestionService({ ...questions.options }).restore().questions["cross-question"];
+  assert.equal(restoredTask.queueState, "active");
+  assert.equal(restoredQuestion.state, "answered");
+  assert.deepEqual(restoredTask.attempts.map((attempt) => attempt.attemptId), ["cross-attempt"]);
+});
+
+test("scheduler terminal CAS loses to a late answer and continues the same attempt", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-scheduler-late-answer-"));
+  const authoritySnapshot = snapshot() as any;
+  authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+  authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+  const base = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "late-task" };
+  const questions = new QuestionService({ ...base, createQuestionId: () => "late-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const runtime = new DelegationRuntime({ ...base, terminalAuthority: { assertTaskMayTerminal: (events, id) => questions.assertTaskMayTerminal(events, id) } });
+  const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "late answer", deliverables: [] }).taskId;
+  let executions = 0;
+  const scheduler = new DurableDelegationScheduler({
+    runtime, maxParallel: 1, createAttemptId: () => "late-attempt",
+    execute: async () => {
+      executions++;
+      if (executions === 1) {
+        questions.create({ nodeId: "a", taskId, definition: { prompt: "Late?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "late-call" } });
+        questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "late-question", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "late-answer" });
+        return completed("stale terminal result");
+      }
+      const [delivery] = questions.prepareTaskAnswerDeliveries(taskId);
+      questions.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: "e".repeat(64), attemptId: "late-attempt", transcriptRef: `run:run-1/node:a/task:${taskId}/transcript` });
+      questions.acceptTaskAnswerDelivery(delivery);
+      return completed("continued after late answer");
+    },
+  });
+  await scheduler.runUntilSettled();
+  const yielded = runtime.restore().tasks[taskId];
+  assert.equal(executions, 1, "terminal CAS loss durably yields instead of relaunching in the same scheduler drain");
+  assert.equal(yielded.result, undefined);
+  assert.equal(yielded.questionContinuationTurn, 1);
+  await scheduler.runUntilSettled();
+  const terminal = runtime.restore().tasks[taskId];
+  assert.equal(executions, 2);
+  assert.equal(terminal.result?.summary, "continued after late answer");
+  assert.deepEqual(terminal.attempts.map((attempt) => attempt.attemptId), ["late-attempt"]);
+});
+
 test("verified takeover interrupts and requeues journal-active tasks", async () => {
   const f = fixture();
   f.runtime.start(f.ids.a1, "crashed-attempt");
@@ -272,6 +506,60 @@ test("pause aborts cooperative work and restart resumes queued tasks", async () 
   assert.equal(releases, 1);
   assert.equal(Object.values(f.runtime.restore().tasks).every((task) => task.queueState === "queued"), true);
   scheduler.resume();
+});
+
+test("answer and pause in either order preserve question resume-ready work on the same attempt across restart", async () => {
+  for (const answerFirst of [true, false]) {
+    const projectRoot = mkdtempSync(join(tmpdir(), `hive-scheduler-answer-pause-${answerFirst ? "answer-first" : "pause-first"}-`));
+    const authoritySnapshot = snapshot() as any;
+    authoritySnapshot.payload.authority.nodes = [{ nodeId: "a", capabilities: { effective: { "human-input": true } }, tools: ["human_question"] }];
+    authoritySnapshot.payload.agents = [{ id: "shared", name: "Shared", prompt: "worker" }];
+    const options = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: authoritySnapshot, createTaskId: () => "pause-question-task" };
+    const runtime = new DelegationRuntime(options);
+    const taskId = runtime.accept(runtime.rootExecutionContext(), { targetNodeId: "a", objective: "pause answer race", deliverables: [] }).taskId;
+    const questions = new QuestionService({ ...options, createQuestionId: () => "pause-question", authenticateControl: (request) => request.claimedIdentity });
+    let questionCreated!: () => void;
+    const created = new Promise<void>((resolve) => { questionCreated = resolve; });
+    const scheduler = new DurableDelegationScheduler({
+      runtime, maxParallel: 1, createAttemptId: () => "immutable-attempt",
+      execute: async (_task, control) => {
+        questions.create({ nodeId: "a", taskId, definition: { prompt: "Resume?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "pause-call" } });
+        questionCreated();
+        if (!control.signal.aborted) await new Promise<void>((resolve) => control.signal.addEventListener("abort", () => resolve(), { once: true }));
+        return completed("aborted containing turn");
+      },
+    });
+    const running = scheduler.runUntilSettled();
+    await created;
+    const answer = () => questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "pause-question", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", operationId: `pause-answer-${answerFirst}` });
+    if (answerFirst) answer();
+    scheduler.pauseAdmission("process shutdown");
+    scheduler.abortOwnedWork("process shutdown");
+    if (!answerFirst) answer();
+    assert.equal(await scheduler.waitForSettlement(500), true);
+    await running;
+
+    const pausedTask = runtime.restore().tasks[taskId];
+    assert.equal(pausedTask.queueState, "active");
+    assert.equal(pausedTask.resumedByQuestionSequence !== undefined, true);
+    assert.deepEqual(pausedTask.attempts.map((attempt) => attempt.attemptId), ["immutable-attempt"]);
+
+    const replayed = new DelegationRuntime(options);
+    const restarted = new DurableDelegationScheduler({
+      runtime: replayed, maxParallel: 1, createAttemptId: () => "must-not-create",
+      execute: async (_task, control) => {
+        assert.equal(control.attemptId, "immutable-attempt");
+        const [delivery] = questions.prepareTaskAnswerDeliveries(taskId);
+        questions.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: "f".repeat(64), attemptId: control.attemptId, transcriptRef: `run:run-1/node:a/task:${taskId}/transcript` });
+        questions.acceptTaskAnswerDelivery(delivery);
+        return completed("resumed after restart");
+      },
+    });
+    restarted.resume();
+    await restarted.runUntilSettled();
+    assert.equal(replayed.restore().tasks[taskId].result?.summary, "resumed after restart");
+    assert.deepEqual(replayed.restore().tasks[taskId].attempts.map((attempt) => attempt.attemptId), ["immutable-attempt"]);
+  }
 });
 
 test("cancellation settles interrupted queued work without claiming its stale attempt", async () => {

--- a/tests/workflows/workflow-tools.test.ts
+++ b/tests/workflows/workflow-tools.test.ts
@@ -1,12 +1,22 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdtempSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { Value } from "typebox/value";
 import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
 import { RunOrchestrationService } from "../../src/workflows/orchestration.ts";
-import type { WorkerSessionFactory, WorkerPromptInvocation } from "../../src/workflows/workers.ts";
+import { deriveWorkerPromptContext, type WorkerSessionFactory, type WorkerPromptInvocation } from "../../src/workflows/workers.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
+import { QUESTION_LIMITS } from "../../src/workflows/question-validation.ts";
+import {
+  ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS,
+  losslessDynamicPromptInputs,
+  measureLosslessDynamicPromptDelivery,
+} from "../../src/workflows/prompts.ts";
+import { createHandoffPacket, type HandoffPacket } from "../../src/workflows/handoff.ts";
 import {
   GENERIC_WORKFLOW_TOOL_CONTRACTS,
   GENERIC_WORKFLOW_TOOL_SCHEMAS,
@@ -14,6 +24,10 @@ import {
   genericWorkflowToolContractsForNode,
 } from "../../src/workflows/tools.ts";
 import { acquireRuntimeOwnership } from "../../src/workflows/ownership.ts";
+import { appendWorkflowEvent, readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { createWorkflowEvent } from "../../src/workflows/events.ts";
+import { AttemptRuntime, attemptDescriptorForModel, executeWithConservativeRetry } from "../../src/workflows/attempts.ts";
+import type { EffectiveRuntimeBudgetLimits } from "../../src/workflows/budgets.ts";
 
 function snapshot(): ActivationSnapshotFileV1 {
   return { snapshotHash: "b".repeat(64), createdAt: "2026-01-01T00:00:00.000Z", payload: {
@@ -55,7 +69,40 @@ async function call(name: string, input: unknown, batch: readonly string[] = [na
   return tool(name).execute(toolCallId, input as never, undefined, undefined, ctx as never);
 }
 
-function fixture(factoryOverride?: WorkerSessionFactory, snapshotOverride: ActivationSnapshotFileV1 = snapshot()) {
+async function callSequentialQuestionBatch(inputs: readonly unknown[]): Promise<readonly any[]> {
+  const batchId = `call-human-question-batch-${++toolCallSequence}`;
+  const calls = inputs.map((input, index) => ({ id: `${batchId}-${index}`, input }));
+  const content = calls.map(({ id, input }) => ({ type: "toolCall", id, name: "human_question", arguments: input }));
+  const ctx = { sessionManager: { getBranch: () => [{ type: "message", message: { role: "assistant", content } }] } };
+  const results = [];
+  for (const entry of calls) results.push(await tool("human_question").execute(entry.id, entry.input as never, undefined, undefined, ctx as never));
+  return results;
+}
+
+async function callMixedSuspensionBatch(order: readonly ["delegate_agent" | "human_question", "delegate_agent" | "human_question"], concurrent: boolean): Promise<readonly PromiseSettledResult<any>[]> {
+  const batchId = `call-mixed-suspension-${++toolCallSequence}`;
+  const calls = order.map((name, index) => ({
+    id: `${batchId}-${index}`,
+    name,
+    input: name === "delegate_agent"
+      ? { targetNodeId: "worker", objective: "must not publish", deliverables: [] }
+      : { prompt: "Must not publish?", kind: "confirm", required: true },
+  }));
+  const content = calls.map(({ id, name, input }) => ({ type: "toolCall", id, name, arguments: input }));
+  const ctx = { sessionManager: { getBranch: () => [{ type: "message", message: { role: "assistant", content } }] } };
+  const invoke = (entry: (typeof calls)[number]) => tool(entry.name).execute(entry.id, entry.input as never, undefined, undefined, ctx as never);
+  if (concurrent) return Promise.allSettled(calls.map(invoke));
+  const results: PromiseSettledResult<any>[] = [];
+  for (const entry of calls) results.push(...await Promise.allSettled([invoke(entry)]));
+  return results;
+}
+
+function fixture(
+  factoryOverride?: WorkerSessionFactory,
+  snapshotOverride: ActivationSnapshotFileV1 = snapshot(),
+  presentLive?: any,
+  overrides: { runId?: string; initialInputText?: string; stagedHandoff?: HandoffPacket; cancellationReleaseLeases?: () => void | Promise<void>; questionJournalFault?: (eventType: "question.transition", stage: "beforeWrite" | "afterFileFsync" | "beforeRename" | "afterRename" | "beforeDirFsync") => void; budgetLimits?: EffectiveRuntimeBudgetLimits } = {},
+) {
   const projectRoot = mkdtempSync(join(tmpdir(), "hive-tools-"));
   const ownerNonce = "owner-1";
   assert.equal(acquireRuntimeOwnership(projectRoot, "session-1", { nonce: ownerNonce }).ok, true);
@@ -63,17 +110,24 @@ function fixture(factoryOverride?: WorkerSessionFactory, snapshotOverride: Activ
   const factory: WorkerSessionFactory = factoryOverride ?? (async (input) => ({
     linkedSessionId: `linked-${input.nodeId}`, prompt: async () => "ok", dispose() {},
   }));
-  const service = new RunOrchestrationService({
+  const options = {
     projectRoot, projectId: "project-1", sessionId: "session-1", snapshot: snapshotOverride, runtimeOwnerNonce: ownerNonce,
-    maxParallel: 1, workerFactory: factory, createRunId: () => "run-1", createTaskId: () => `task-${++task}`, createAttemptId: () => `attempt-${task}`,
+    maxParallel: 1, workerFactory: factory, createRunId: () => overrides.runId ?? "run-1", createTaskId: () => `task-${++task}`, createAttemptId: () => `attempt-${task}`,
+    ...(overrides.budgetLimits ? { budgetLimits: overrides.budgetLimits } : {}),
     pauseAuthority: { captureState: () => ({}), releaseLeases: () => {}, releaseOwnership: () => {} },
     resumeAuthority: { acquireOwnership: () => {}, acquireLeases: () => {}, revalidateHashes: () => true, rollbackAuthority: () => {} },
-    cancellationAuthority: { terminateProcessTrees: () => {}, capturePartialState: () => ({}), releaseLeases: () => {} },
-  });
-  service.lifecycle.recordUserInput({ inputId: "input-1", text: "deliver", source: "interactive" });
+    cancellationAuthority: { terminateProcessTrees: () => {}, capturePartialState: () => ({}), releaseLeases: overrides.cancellationReleaseLeases ?? (() => {}) },
+    questionControl: { authenticateControl: (request: any) => request.credential === "secret" ? request.claimedIdentity : undefined, ...(presentLive ? { presentLive } : {}), ...(overrides.questionJournalFault ? { journalFault: overrides.questionJournalFault } : {}) },
+  } as const;
+  const service = new RunOrchestrationService(options);
+  if (overrides.stagedHandoff) appendWorkflowEvent(projectRoot, createWorkflowEvent({
+    projectId: "project-1", sessionId: "session-1", type: "handoff.recorded", producer: "harness",
+    payload: { formatVersion: 1, operation: "stage", packet: overrides.stagedHandoff } as never,
+  }));
+  service.lifecycle.recordUserInput({ inputId: "input-1", text: overrides.initialInputText ?? "deliver", source: "interactive" });
   const delivery = service.lifecycle.prepareInputDelivery("delivery-1");
   service.lifecycle.confirmInputDelivery(delivery.requestId);
-  return { projectRoot, service };
+  return { projectRoot, service, options };
 }
 
 test("generic TypeBox schemas are exact and reject unknown or oversized fields", () => {
@@ -99,7 +153,19 @@ test("generic tool exposure follows frozen topology and reserves inactive subsys
   assert.equal(GENERIC_WORKFLOW_TOOL_CONTRACTS.some((entry) => entry.name === "artifact_status"), true);
   assert.equal(GENERIC_WORKFLOW_TOOL_CONTRACTS.some((entry) => entry.name === "artifact_action"), true);
   assert.equal(GENERIC_WORKFLOW_TOOL_CONTRACTS.some((entry) => entry.name === "knowledge_read"), false);
-  assert.equal(GENERIC_WORKFLOW_TOOL_CONTRACTS.some((entry) => entry.name === "human_question"), false);
+  assert.equal(GENERIC_WORKFLOW_TOOL_CONTRACTS.some((entry) => entry.name === "human_question"), true, "the generic contract is registered while immutable authority still controls exposure");
+  assert.equal(Value.Check((GENERIC_WORKFLOW_TOOL_SCHEMAS as any).human_question, {
+    prompt: "Which database?", kind: "single", choices: [{ value: "postgres", label: "PostgreSQL" }], required: true,
+  }), true);
+  assert.equal(Value.Check((GENERIC_WORKFLOW_TOOL_SCHEMAS as any).human_question, {
+    prompt: "Which database?", kind: "single", choices: [{ value: "postgres", label: "PostgreSQL" }], required: true, html: "<b>unsafe</b>",
+  }), false);
+  assert.equal(Value.Check((GENERIC_WORKFLOW_TOOL_SCHEMAS as any).human_question, {
+    prompt: "unsafe\u0001control", kind: "text", required: true,
+  }), false);
+  assert.equal(Value.Check((GENERIC_WORKFLOW_TOOL_SCHEMAS as any).human_question, {
+    prompt: "structured\nwhitespace", kind: "text", required: true,
+  }), true);
 });
 
 test("artifact tools remain profile/capability gated and none exposes only bounded status", async () => {
@@ -137,6 +203,30 @@ test("tools require trusted async runtime identity and route/delegate only throu
   );
   const accepted = await root.runWithToolRuntime(() => call("delegate_agent", { targetNodeId: "worker", objective: "implement", deliverables: ["patch"] }));
   assert.match(accepted.content[0].text, /task-1/);
+});
+
+test("mixed delegate_agent and human_question sibling batches reject atomically in both orders and concurrently across restart", async () => {
+  for (const order of [["delegate_agent", "human_question"], ["human_question", "delegate_agent"]] as const) {
+    for (const concurrent of [false, true]) {
+      const active = snapshot() as any;
+      const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+      rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+      rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+      const built = fixture(undefined, active);
+      const results = await built.service.rootServices().runWithToolRuntime(() => callMixedSuspensionBatch(order, concurrent));
+      assert.equal(results.every((result) => result.status === "rejected"), true);
+      for (const result of results) {
+        if (result.status === "rejected") assert.match(String(result.reason), /delegate_agent.*human_question|sibling.*batch/i);
+      }
+      assert.deepEqual(Object.keys(built.service.delegationState().tasks), []);
+      assert.deepEqual(Object.keys(built.service.questionControls().restore().questions), []);
+      assert.equal(readWorkflowJournal(built.projectRoot, "session-1").some((event) => event.type === "task.accepted" || event.type === "question.transition"), false);
+
+      const restarted = new RunOrchestrationService(built.options);
+      assert.deepEqual(Object.keys(restarted.delegationState().tasks), []);
+      assert.deepEqual(Object.keys(restarted.questionControls().restore().questions), []);
+    }
+  }
 });
 
 test("accepted multiline delegation content remains delimited and assembles into a worker prompt", async () => {
@@ -183,6 +273,1288 @@ test("team and workflow status are bounded, cursor-paginated, and expose explici
   assert.equal(typeof details.items[0].readRef, "string");
   assert.ok(details.nextCursor);
   assert.ok(Buffer.byteLength(inputPage.content[0].text, "utf8") <= TOOL_CONTRACT_LIMITS.outputBytes);
+});
+
+test("human_question tool suspends headless work, releases the slot, and resumes only on explicit owner execution", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let prompts = 0;
+  let sessions = 0;
+  const { service } = fixture(async (input) => {
+    sessions++;
+    return {
+      linkedSessionId: `linked-${input.nodeId}`,
+      async prompt(_text, _signal, current) {
+        prompts++;
+        if (prompts === 1) {
+          const pending = await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+          assert.equal((pending.details as any).state, "pending");
+          return "turn ended for human";
+        }
+        assert.equal(current!.promptContext.taskContract.acceptedAnswers[0].answer.value, true);
+        return "resumed after human";
+      },
+      dispose() {},
+    };
+  }, active);
+  const root = service.rootServices();
+  root.delegate({ targetNodeId: "worker", objective: "ask before proceeding", deliverables: [] });
+  await service.runWorkers();
+  assert.equal(service.lifecycle.restore().latestRun?.status, "waiting_for_human");
+  assert.equal(service.activeWorkerCount(), 0);
+  const pending = service.questionControls().status({ state: "pending" });
+  assert.equal(pending.items.length, 1);
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.items[0].questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-1" });
+  assert.equal(prompts, 1, "offline answer append must never execute a model");
+  await service.runWorkers();
+  assert.equal(prompts, 2);
+  assert.equal(sessions, 1, "resume must reuse the same node/run transcript session");
+  assert.equal(service.lifecycle.restore().latestRun?.status, "running");
+});
+
+test("sequential sibling human_question calls persist one same-attempt batch and resume after both answer orders across restart", async () => {
+  for (const answerOrder of [[0, 1], [1, 0]] as const) {
+    const active = snapshot() as any;
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    let prompts = 0;
+    let sessions = 0;
+    const resumedAnswerPages: boolean[][] = [];
+    const factory: WorkerSessionFactory = async (input) => {
+      sessions++;
+      return {
+        linkedSessionId: `multi-question-${input.nodeId}-${sessions}`,
+        async prompt(_text, _signal, current) {
+          prompts++;
+          if (prompts === 1) {
+            const created = await current!.runWithToolRuntime!(() => callSequentialQuestionBatch([
+              { prompt: "First sibling?", kind: "confirm", required: true },
+              { prompt: "Second sibling?", kind: "confirm", required: true },
+            ]));
+            assert.deepEqual(created.map((entry) => entry.details.state), ["pending", "pending"]);
+            return "suspended for sibling questions";
+          }
+          const values = current!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.answer.value as boolean);
+          resumedAnswerPages.push(values);
+          return values.includes(false) ? "resumed after sibling answers" : "continue sibling answer delivery";
+        },
+        dispose() {},
+      };
+    };
+    const built = fixture(factory, active);
+    const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: "ask sibling questions", deliverables: [] });
+    await built.service.runWorkers();
+    const pending = built.service.questionControls().status({ state: "pending" }).items;
+    assert.equal(pending.length, 2);
+    assert.equal(built.service.activeWorkerCount(), 0, "one worker slot is released for the complete question batch");
+    const taskBeforeAnswers = built.service.delegationState().tasks[delegated.taskId];
+    assert.equal(taskBeforeAnswers.queueState, "suspended");
+    assert.equal(taskBeforeAnswers.suspendedOnQuestionIds?.length, 2);
+    assert.equal(new Set(Object.values(built.service.questionControls().restore().questions).map((question) => question.taskAttemptId)).size, 1);
+
+    const answer = (service: RunOrchestrationService, index: number) => service.questionControls().answer({
+      projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending[index].questionId,
+      expectedState: "pending", value: index === 0, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `sibling-answer-${answerOrder.join("-")}-${index}`,
+    });
+    answer(built.service, answerOrder[0]);
+    assert.equal(prompts, 1);
+    assert.equal(built.service.delegationState().tasks[delegated.taskId].queueState, "suspended", "one answer cannot resume a multi-question batch");
+
+    const restarted = new RunOrchestrationService(built.options);
+    await assert.rejects(() => restarted.runWorkers(), /running|human|question/i);
+    assert.equal(prompts, 1, "restart with one pending sibling cannot execute the provider");
+    answer(restarted, answerOrder[1]);
+    await restarted.runWorkers();
+    assert.equal(restarted.delegationState().tasks[delegated.taskId].result, undefined, "each bounded answer page yields to the owner before another model turn");
+    for (let turn = 0; turn < 3 && !restarted.delegationState().tasks[delegated.taskId].result; turn++) await restarted.runWorkers();
+    const completed = restarted.delegationState().tasks[delegated.taskId];
+    assert.equal(completed.result?.summary, "resumed after sibling answers");
+    assert.equal(completed.attempts.length, 1, "the sibling batch resumes the immutable delegation attempt");
+    assert.equal(prompts, 3, "bounded answer pages resume only after the complete sibling set is answered");
+    assert.deepEqual(resumedAnswerPages, [[true], [false]]);
+  }
+});
+
+test("a pre-bound offline answer advances a durable continuation turn after known provider rejection and is delivered once across restart", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let prompts = 0;
+  const seen: string[][] = [];
+  const built = fixture(async () => ({ linkedSessionId: "offline-known-failure", async prompt(_text, _signal, current) {
+    prompts++;
+    seen.push(current!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.questionId));
+    if (prompts === 1) {
+      await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Continue offline?", kind: "confirm", required: true }));
+      return "waiting";
+    }
+    return "answer consumed after safe continuation";
+  }, dispose() {} }), active);
+  const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: "offline known failure", deliverables: [] });
+  await built.service.runWorkers();
+  const pending = built.service.questionControls().status({ state: "pending" }).items[0];
+  built.service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId,
+    expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "offline-known-answer" });
+
+  const questionService = built.service.questionControls();
+  const delivery = questionService.prepareTaskAnswerDeliveries(delegated.taskId)[0];
+  const taskBeforeFailure = built.service.delegationState().tasks[delegated.taskId];
+  const promptContext = deriveWorkerPromptContext(active, taskBeforeFailure, [], "session-1", delivery.answers);
+  const promptHash = createHash("sha256").update(promptContext.assembledPrompt).digest("hex");
+  const transcriptRef = `run:run-1/node:worker/task:${delegated.taskId}/transcript`;
+  const failedCorrelation = `worker-model-${delegated.taskId}-${promptHash.slice(0, 24)}-turn-0`;
+  await assert.rejects(() => executeWithConservativeRetry(built.service.attemptRuntime(), {
+    correlationId: failedCorrelation, nodeId: "worker", operation: "worker.provider.prompt",
+    input: { requestInput: { taskId: delegated.taskId, promptHash, questionContinuationTurn: 0 }, consumerReceipt: { deliveryIds: [delivery.deliveryId], promptHash, transcriptRef } },
+    replayInput: { taskId: delegated.taskId }, descriptor: attemptDescriptorForModel(),
+    consumerReceipt: { deliveryIds: [delivery.deliveryId], promptHash, transcriptRef },
+    dispatch: async () => { throw Object.assign(new Error("known provider rejection"), {
+      effectNotApplied: true, transient: false, assistantOutputObserved: false, toolCallObserved: false,
+    }); },
+  }), /known provider rejection/i);
+
+  const restarted = new RunOrchestrationService(built.options);
+  await restarted.runWorkers();
+  assert.equal(prompts, 1, "replaying a durable known failure advances state and yields before a fresh provider turn");
+  await restarted.runWorkers();
+  const task = restarted.delegationState().tasks[delegated.taskId];
+  const question = restarted.questionControls().restore().questions[pending.questionId];
+  const attempts = Object.values(restarted.attemptRuntime().restore().attempts).filter((attempt) => attempt.operation === "worker.provider.prompt");
+  const failed = attempts.find((attempt) => attempt.correlationId === failedCorrelation);
+  const completed = attempts.find((attempt) => attempt.attemptId === question.taskDeliveryReceipt?.attemptId);
+  assert.equal(prompts, 2, "restart replays the known failure once, then makes one fresh bounded provider dispatch");
+  assert.deepEqual(seen.map((ids) => ids.length), [0, 1]);
+  assert.equal(task.result?.summary, "answer consumed after safe continuation");
+  assert.equal(task.attempts.length, 1, "continuation preserves the delegation attempt and transcript");
+  assert.equal(task.questionContinuationTurn, 1);
+  assert.ok(failed?.status === "failed" && completed?.status === "completed");
+  assert.notEqual(question.taskDeliveryReceipt?.attemptId, failed.attemptId, "a failed provider attempt cannot acknowledge the answer");
+  assert.equal(question.taskDeliveryReceipt?.attemptId, completed.attemptId);
+  assert.ok(question.taskDeliveryAcceptedSequence);
+});
+
+test("persistent known provider failures and budget denial yield bounded owner turns without false answer acknowledgement", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  const ampleNode = { maxAgentTurns: 10, maxToolCalls: 100, tokenBudget: 10_000_000, activeWallTimeMs: 60_000 };
+  const budgetLimits: EffectiveRuntimeBudgetLimits = {
+    run: { maxParallel: 1, maxDelegations: 10, maxToolCalls: 100, tokenBudget: 10_000_000, activeWallTimeMs: 60_000 },
+    nodes: { root: ampleNode, worker: { ...ampleNode, maxAgentTurns: 3 }, leaf: ampleNode },
+  };
+  let prompts = 0;
+  const built = fixture(async () => ({ linkedSessionId: "persistent-known-budget", async prompt(_text, _signal, current) {
+    prompts++;
+    if (prompts === 1) {
+      await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Continue until budget?", kind: "confirm", required: true }));
+      return "waiting";
+    }
+    throw Object.assign(new Error("persistent known provider rejection"), {
+      effectNotApplied: true, transient: false, assistantOutputObserved: false, toolCallObserved: false,
+    });
+  }, dispose() {} }), active, undefined, { budgetLimits });
+  const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: "persistent known failure", deliverables: [] });
+  await built.service.runWorkers();
+  const pending = built.service.questionControls().status({ state: "pending", limit: 1 }).items[0];
+  built.service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId,
+    expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "persistent-known-answer" });
+
+  const boundedRun = (owner: RunOrchestrationService) => Promise.race([
+    owner.runWorkers().then(() => "settled" as const),
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2_000)),
+  ]);
+  assert.equal(await boundedRun(built.service), "settled", "one known failure must return control without an automatic fresh turn");
+  assert.equal(await boundedRun(built.service), "settled", "a second explicit owner turn may retry once");
+  assert.equal(await boundedRun(built.service), "settled", "budget denial and terminal CAS loss must durably yield");
+  const restarted = new RunOrchestrationService(built.options);
+  assert.equal(await boundedRun(restarted), "settled", "restart at exhausted budget must remain finite");
+
+  const task = restarted.delegationState().tasks[delegated.taskId];
+  const question = restarted.questionControls().restore().questions[pending.questionId];
+  const modelAttempts = Object.values(restarted.attemptRuntime().restore().attempts).filter((attempt) => attempt.operation === "worker.provider.prompt");
+  const starts = readWorkflowJournal(built.projectRoot, "session-1").filter((event) => event.type === "task.started");
+  assert.equal(prompts, 3, "only the two explicitly requested post-answer provider turns run before budget exhaustion");
+  assert.equal(starts.length, 5, "each owner call starts the same attempt at most once");
+  assert.equal(modelAttempts.length, 5, "provider and denied model attempts remain finite across restart");
+  assert.equal(task.attempts.length, 1, "all continuations preserve the immutable delegation attempt");
+  assert.equal(task.queueState, "active");
+  assert.equal(task.questionContinuationTurn, 4);
+  assert.equal(question.taskDeliveryReceipt, undefined);
+  assert.equal(question.taskDeliveryAcceptedSequence, undefined);
+});
+
+test("a pre-bound offline answer with unknown provider effects pauses recovery across restart without acknowledgement or redispatch", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let prompts = 0;
+  const built = fixture(async () => ({ linkedSessionId: "offline-unknown-failure", async prompt(_text, _signal, current) {
+    prompts++;
+    if (prompts === 1) {
+      await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Continue offline?", kind: "confirm", required: true }));
+      return "waiting";
+    }
+    throw new Error("provider outcome unknown");
+  }, dispose() {} }), active);
+  const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: "offline unknown failure", deliverables: [] });
+  await built.service.runWorkers();
+  const pending = built.service.questionControls().status({ state: "pending" }).items[0];
+  built.service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId,
+    expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "offline-unknown-answer" });
+  await assert.rejects(() => built.service.runWorkers(), /unknown|recovery|paused|side effect/i);
+  assert.equal(prompts, 2);
+
+  const restarted = new RunOrchestrationService(built.options);
+  await assert.rejects(() => restarted.runWorkers(), /unknown|recovery|paused|side effect/i);
+  const task = restarted.delegationState().tasks[delegated.taskId];
+  const question = restarted.questionControls().restore().questions[pending.questionId];
+  const unresolved = Object.values(restarted.attemptRuntime().restore().attempts).filter((attempt) => attempt.status === "unknown_side_effect");
+  assert.equal(prompts, 2, "restart does not redispatch a recovery-required provider attempt");
+  assert.equal(unresolved.length, 1);
+  assert.equal(task.attempts.length, 1);
+  assert.equal(task.queueState, "active");
+  assert.equal(question.taskDeliveryReceipt, undefined, "unknown provider effects never acknowledge the answer");
+  assert.equal(question.taskDeliveryAcceptedSequence, undefined);
+  assert.equal(restarted.lifecycle.restore().latestRun?.status, "paused");
+});
+
+test("fast dashboard answers force same-attempt worker continuation before terminalization after provider return or failure", async () => {
+  for (const providerFailure of [false, true]) {
+    const active = snapshot() as any;
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    const holder: { service?: RunOrchestrationService } = {};
+    const seen: string[][] = [];
+    let prompts = 0;
+    const built = fixture(async () => ({ linkedSessionId: `fast-answer-${providerFailure}`, async prompt(_text, _signal, current) {
+      prompts++;
+      seen.push(current!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.questionId));
+      if (prompts === 1) {
+        const first = await current!.runWithToolRuntime!(() => call("human_question", { prompt: "First?", kind: "confirm", required: true }));
+        const second = holder.service!.questionControls().create({ nodeId: "worker", taskId: "task-1", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: `fast-second-${providerFailure}` } });
+        for (const [index, questionId] of [first.details.questionId, second.questionId].entries()) {
+          holder.service!.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId, expectedState: "pending", value: index === 0, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `fast-answer-${providerFailure}-${index}` });
+        }
+        if (providerFailure) throw new Error("provider failed after answered questions");
+        return "must not terminalize";
+      }
+      assert.deepEqual(current!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.answer.value), [true, false]);
+      return "continued after both answers";
+    }, dispose() {} }), active);
+    holder.service = built.service;
+    const service = built.service;
+    const delegated = service.rootServices().delegate({ targetNodeId: "worker", objective: "fast answer", deliverables: [] });
+    try {
+      await service.runWorkers();
+      for (let turn = 0; turn < 3 && !service.delegationState().tasks[delegated.taskId].result; turn++) await service.runWorkers();
+    } catch (error) {
+      const unresolved = Object.values(service.attemptRuntime().restore().attempts).filter((attempt) => !attempt.result).map((attempt) => ({ operation: attempt.operation, inputHash: attempt.inputHash, status: attempt.status, diagnostic: attempt.diagnostic }));
+      throw new Error(`fast-answer mode providerFailure=${providerFailure} failed: ${String(error instanceof Error ? error.message : error)}; unresolved=${JSON.stringify(unresolved)}`);
+    }
+    const task = service.delegationState().tasks[delegated.taskId];
+    assert.equal(task.result?.status, "completed");
+    assert.equal(task.result?.summary, "continued after both answers");
+    assert.equal(task.attempts.length, 1, "answer continuation preserves the durable worker attempt");
+    assert.deepEqual(seen.map((ids) => ids.length), [0, 2]);
+  }
+});
+
+test("pending root questions block only root dispatch while queued and active workers keep progressing", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let releaseWorker!: () => void;
+  let workerStarted!: () => void;
+  const workerGate = new Promise<void>((resolve) => { releaseWorker = resolve; });
+  const started = new Promise<void>((resolve) => { workerStarted = resolve; });
+  let workerPrompts = 0;
+  const { service } = fixture(async () => ({ linkedSessionId: "root-local-worker", async prompt() {
+    workerPrompts++;
+    workerStarted();
+    await workerGate;
+    return "worker progressed";
+  }, dispose() {} }), active);
+  const root = service.rootServices();
+  root.delegate({ targetNodeId: "worker", objective: "continue independently", deliverables: [] });
+  const first = service.questionControls().create({ nodeId: "root", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-pending-1" } });
+  const second = service.questionControls().create({ nodeId: "root", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-pending-2" } });
+  service.lifecycle.recordUserInput({ inputId: "root-pending-steering", text: "ordinary steering remains root-local", source: "interactive" });
+  assert.equal(service.lifecycle.restore().latestRun?.status, "running", "queued worker progress keeps the run-wide state running");
+  let rootDispatches = 0;
+  await assert.rejects(() => service.rootServices().dispatch.model({ correlationId: "root-blocked-queued", operation: "root.prompt", input: {}, dispatch: async () => { rootDispatches++; return "must not run"; } }), /root.*question|pending.*root|human/i);
+  const workers = service.runWorkers();
+  await started;
+  await assert.rejects(() => service.rootServices().dispatch.model({ correlationId: "root-blocked-active", operation: "root.prompt", input: {}, dispatch: async () => { rootDispatches++; return "must not run"; } }), /root.*question|pending.*root|human/i);
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: second.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "root-second-answer" });
+  await assert.rejects(() => service.rootServices().dispatch.model({ correlationId: "root-blocked-one-left", operation: "root.prompt", input: {}, dispatch: async () => { rootDispatches++; return "must not run"; } }), /root.*question|pending.*root|human/i);
+  releaseWorker();
+  await workers;
+  assert.equal(workerPrompts, 1);
+  assert.equal(rootDispatches, 0);
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: first.questionId, expectedState: "pending", value: false, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "root-first-answer" });
+  await service.rootServices().dispatch.model({ correlationId: "root-unblocked", operation: "root.prompt", input: {}, dispatch: async () => { rootDispatches++; return "ran"; } });
+  assert.equal(rootDispatches, 1);
+});
+
+test("ordinary root steering stays non-runnable while the root transcript is question-suspended", () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const { service } = fixture(undefined, active);
+  service.questionControls().create({ nodeId: "root", definition: { prompt: "Choose?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-steering-gate" } });
+  service.lifecycle.recordUserInput({ inputId: "root-steering-pending", text: "ordinary steering is not an answer", source: "interactive" });
+  service.rootServices();
+  assert.equal(service.lifecycle.restore().latestRun?.status, "waiting_for_human");
+  assert.equal(service.budgetState().paused, true, "active wall time pauses while no independent execution is runnable");
+});
+
+test("reused root correlation after restart never accepts a newer answer with the old successful attempt", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const built = fixture(undefined, active);
+  const q1 = built.service.questionControls().create({ nodeId: "root", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-reuse-q1" } });
+  built.service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q1.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "root-reuse-a1" });
+  let providerCalls = 0;
+  const first = await built.service.rootServices().dispatch.model({
+    correlationId: "root-reused-correlation", operation: "root.prompt", input: { stable: true },
+    dispatch: async () => { providerCalls++; return "old successful output"; },
+  });
+  assert.equal(first, "old successful output");
+
+  const q2 = built.service.questionControls().create({ nodeId: "root", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-reuse-q2" } });
+  built.service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q2.questionId, expectedState: "pending", value: false, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "root-reuse-a2" });
+
+  const restarted = new RunOrchestrationService(built.options);
+  const replayed = await restarted.rootServices().dispatch.model({
+    correlationId: "root-reused-correlation", operation: "root.prompt", input: { stable: true },
+    dispatch: async () => { providerCalls++; return "must not replace durable replay"; },
+  });
+  assert.equal(replayed, "old successful output");
+  assert.equal(providerCalls, 1);
+  let durableQ2 = restarted.questionControls().restore().questions[q2.questionId];
+  assert.equal(durableQ2.rootDeliveryReceipt, undefined, "old attempt must not receipt a delivery absent from its final binding");
+  assert.equal(durableQ2.rootDeliveryAcceptedSequence, undefined);
+
+  let deliveredQuestionIds: readonly string[] = [];
+  await restarted.rootServices().dispatch.model({
+    correlationId: "root-subsequent-continuation", operation: "root.prompt", input: { stable: true },
+    dispatch: async (invocation) => { providerCalls++; deliveredQuestionIds = (invocation.rootQuestionDeliveries ?? []).flatMap((delivery) => delivery.questionIds); return "new output"; },
+  });
+  durableQ2 = restarted.questionControls().restore().questions[q2.questionId];
+  assert.deepEqual(deliveredQuestionIds, [q2.questionId]);
+  assert.equal(providerCalls, 2);
+  assert.ok(durableQ2.rootDeliveryAcceptedSequence);
+});
+
+test("process kill after mixed pre-bound and live answers replays the exact successful root or worker attempt", async () => {
+  for (const scope of ["root", "worker"] as const) {
+    const projectRoot = mkdtempSync(join(tmpdir(), `hive-live-${scope}-kill-`));
+    const markerPath = join(projectRoot, `${scope}-provider-calls.txt`);
+    const active = snapshot() as any;
+    const authority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === scope);
+    authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+    authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+    const script = `
+      import { appendFileSync } from 'node:fs';
+      import { RunOrchestrationService } from './src/workflows/orchestration.ts';
+      import { acquireRuntimeOwnership } from './src/workflows/ownership.ts';
+      import { GENERIC_WORKFLOW_TOOL_CONTRACTS } from './src/workflows/tools.ts';
+      const projectRoot=${JSON.stringify(projectRoot)};
+      const snapshot=${JSON.stringify(active)};
+      const marker=${JSON.stringify(markerPath)};
+      const human=GENERIC_WORKFLOW_TOOL_CONTRACTS.find(entry=>entry.name==='human_question');
+      let callSequence=0;
+      const call=async(input)=>{ const id='kill-call-'+(++callSequence); const ctx={sessionManager:{getBranch:()=>[{type:'message',message:{role:'assistant',content:[{type:'toolCall',id,name:'human_question',arguments:{}}]}}]}}; return human.execute(id,input,undefined,undefined,ctx); };
+      acquireRuntimeOwnership(projectRoot,'session-1',{nonce:'owner-killed'});
+      let armed=false, armedWrites=0, seededWorker=false;
+      let service;
+      service=new RunOrchestrationService({
+        projectRoot,projectId:'project-1',sessionId:'session-1',snapshot,runtimeOwnerNonce:'owner-killed',maxParallel:1,
+        workerFactory:async()=>({linkedSessionId:'kill-worker',async prompt(_text,_signal,invocation){
+          if(!seededWorker){ seededWorker=true; service.questionControls().create({nodeId:'worker',taskId:'task-1',definition:{prompt:'Offline worker?',kind:'confirm',required:true},provenance:{source:'human_question',toolCallId:'worker-offline'}}); return 'worker waits offline'; }
+          appendFileSync(marker,'provider\\n'); armed=true; await invocation.runWithToolRuntime(()=>call({prompt:'Worker live?',kind:'confirm',required:true})); return 'worker result survived';
+        },dispose(){}}),
+        createRunId:()=> 'run-1',createTaskId:()=> 'task-1',createAttemptId:()=> 'attempt-task-1',
+        pauseAuthority:{captureState:()=>({}),releaseLeases:()=>{},releaseOwnership:()=>{}},resumeAuthority:{acquireOwnership:()=>{},acquireLeases:()=>{},revalidateHashes:()=>true,rollbackAuthority:()=>{}},
+        cancellationAuthority:{terminateProcessTrees:()=>{},capturePartialState:()=>({}),releaseLeases:()=>{}},
+        questionControl:{authenticateControl:r=>r.claimedIdentity,presentLive:async()=>({value:true,claimedIdentity:'human',operationId:'kill-live-answer'}),journalFault:(_type,stage)=>{if(armed&&stage==='beforeRename'&&++armedWrites>=5)process.exit(86);}},
+      });
+      service.lifecycle.recordUserInput({inputId:'input-1',text:'deliver',source:'interactive'}); const delivery=service.lifecycle.prepareInputDelivery('delivery-1'); service.lifecycle.confirmInputDelivery(delivery.requestId);
+      if(${JSON.stringify(scope)}==='root') {
+        const offline=service.questionControls().create({nodeId:'root',definition:{prompt:'Offline root?',kind:'confirm',required:true},provenance:{source:'human_question',toolCallId:'root-offline'}});
+        service.questionControls().answer({projectId:'project-1',sessionId:'session-1',runId:'run-1',questionId:offline.questionId,expectedState:'pending',value:false,channel:'dashboard',claimedIdentity:'human',operationId:'root-offline-answer'});
+        const root=service.rootServices(); await root.dispatch.model({correlationId:'root-kill',operation:'root.prompt',input:{stable:true},dispatch:async()=>{appendFileSync(marker,'provider\\n'); armed=true; await root.runWithToolRuntime(()=>call({prompt:'Root live?',kind:'confirm',required:true})); return 'root result survived';}});
+      } else {
+        service.rootServices().delegate({targetNodeId:'worker',objective:'worker kill',deliverables:[]}); await service.runWorkers();
+        const offline=service.questionControls().status({state:'pending'}).items[0]; service.questionControls().answer({projectId:'project-1',sessionId:'session-1',runId:'run-1',questionId:offline.questionId,expectedState:'pending',value:false,channel:'dashboard',claimedIdentity:'human',operationId:'worker-offline-answer'});
+        await service.runWorkers();
+      }
+    `;
+    const killed = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], { cwd: process.cwd(), env: { ...process.env, NODE_V8_COVERAGE: "" }, encoding: "utf8" });
+    assert.equal(killed.status, 86, killed.stderr);
+    const journalDir = join(projectRoot, ".pi", "hive", "sessions", "session-1", "journal");
+    for (const name of readdirSync(journalDir).filter((name) => name.startsWith("append.lock"))) unlinkSync(join(journalDir, name));
+
+    const attempts = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" }).restore();
+    const containing = Object.values(attempts.attempts).find((attempt) => attempt.operation === (scope === "root" ? "root.prompt" : "worker.provider.prompt") && attempt.consumerReceipt?.deliveryIds.length === 2);
+    assert.equal(containing?.status, "completed");
+    assert.equal(containing?.intentConsumerReceipt?.deliveryIds.length, 1);
+    assert.equal(containing?.consumerReceipt?.deliveryIds.length, 2);
+    const questions = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: active, authenticateControl: (request) => request.claimedIdentity });
+    const before = Object.values(questions.restore().questions);
+    assert.equal(before.length, 2);
+    assert.equal(before.some((question) => scope === "root" ? question.rootDeliveryReceipt === undefined : question.taskDeliveryReceipt === undefined), true);
+    questions.reconcileAnswerDeliveryReceipts();
+    const after = Object.values(questions.restore().questions);
+    assert.equal(after.every((question) => Boolean(scope === "root" ? question.rootDeliveryAcceptedSequence : question.taskDeliveryAcceptedSequence)), true);
+    assert.equal(readFileSync(markerPath, "utf8").trim().split("\n").length, 1);
+
+    if (scope === "worker") {
+      const restarted = new RunOrchestrationService({
+        projectRoot, projectId: "project-1", sessionId: "session-1", snapshot: active, runtimeOwnerNonce: "owner-killed", maxParallel: 1,
+        workerFactory: async () => ({ linkedSessionId: "restart-worker", async prompt() { appendFileSync(markerPath, "provider\n"); return "must not redispatch"; }, dispose() {} }),
+        createTaskId: () => "unused-task", createAttemptId: () => "unused-attempt", verifiedTakeover: () => true,
+        pauseAuthority: { captureState: () => ({}), releaseLeases: () => {}, releaseOwnership: () => {} },
+        resumeAuthority: { acquireOwnership: () => {}, acquireLeases: () => {}, revalidateHashes: () => true, rollbackAuthority: () => {} },
+        cancellationAuthority: { terminateProcessTrees: () => {}, capturePartialState: () => ({}), releaseLeases: () => {} },
+        questionControl: { authenticateControl: (request) => request.claimedIdentity },
+      });
+      await restarted.runWorkers();
+      assert.equal(restarted.delegationState().tasks["task-1"].result?.summary, "worker result survived");
+      assert.equal(restarted.delegationState().tasks["task-1"].attempts.length, 1);
+      assert.equal(readFileSync(markerPath, "utf8").trim().split("\n").length, 1, "successful worker provider result must replay from the durable attempt");
+    } else {
+      const restarted = new RunOrchestrationService({
+        projectRoot, projectId: "project-1", sessionId: "session-1", snapshot: active, runtimeOwnerNonce: "owner-killed", maxParallel: 1,
+        workerFactory: async () => ({ linkedSessionId: "unused", prompt: async () => "unused", dispose() {} }),
+        createTaskId: () => "unused-task", createAttemptId: () => "unused-attempt",
+        pauseAuthority: { captureState: () => ({}), releaseLeases: () => {}, releaseOwnership: () => {} },
+        resumeAuthority: { acquireOwnership: () => {}, acquireLeases: () => {}, revalidateHashes: () => true, rollbackAuthority: () => {} },
+        cancellationAuthority: { terminateProcessTrees: () => {}, capturePartialState: () => ({}), releaseLeases: () => {} },
+        questionControl: { authenticateControl: (request) => request.claimedIdentity },
+      });
+      const replayed = await restarted.rootServices().dispatch.model({ correlationId: "root-kill", operation: "root.prompt", input: { stable: true }, dispatch: async () => { appendFileSync(markerPath, "provider\n"); return "must not redispatch"; } });
+      assert.equal(replayed, "root result survived");
+      assert.equal(readFileSync(markerPath, "utf8").trim().split("\n").length, 1);
+    }
+    assert.deepEqual(scope === "root" ? questions.prepareRootAnswerDeliveries("root") : questions.prepareTaskAnswerDeliveries("task-1"), []);
+  }
+});
+
+test("a successful live root tool answer is atomically bound to its containing model attempt", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const { service } = fixture(undefined, active, async () => ({ value: true, claimedIdentity: "root-user", credential: "secret", operationId: "root-live-success-answer" }));
+  const root = service.rootServices();
+  let questionId = "";
+  await root.dispatch.model({ correlationId: "root-live-success", operation: "root.prompt", input: {}, dispatch: async () => {
+    const result = await root.runWithToolRuntime(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+    questionId = result.details.questionId;
+    return "successful containing root turn";
+  } });
+  const attempt = Object.values(service.attemptRuntime().restore().attempts).find((candidate) => candidate.operation === "root.prompt");
+  const question = service.questionControls().restore().questions[questionId];
+  assert.deepEqual(attempt?.intentConsumerReceipt?.deliveryIds, []);
+  assert.deepEqual(attempt?.consumerReceipt?.deliveryIds, [question.rootDeliveryId]);
+  assert.equal(question.rootDeliveryReceipt?.attemptId, attempt?.attemptId);
+  assert.ok(question.rootDeliveryAcceptedSequence);
+});
+
+test("after-publication live-root receipt faults reconcile without duplicate provider or answer delivery", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let writes = 0;
+  const { service, options } = fixture(undefined, active, async () => ({ value: true, claimedIdentity: "root-user", credential: "secret", operationId: "root-after-answer" }), {
+    questionJournalFault: (_type, stage) => { if (stage === "afterRename" && ++writes >= 5) throw new Error("root stop after publication"); },
+  });
+  const root = service.rootServices();
+  let providerCalls = 0;
+  await root.dispatch.model({ correlationId: "root-after-publication", operation: "root.prompt", input: {}, dispatch: async () => {
+    providerCalls++;
+    await root.runWithToolRuntime(() => call("human_question", { prompt: "After publication?", kind: "confirm", required: true }));
+    return "root after result";
+  } });
+  assert.equal(providerCalls, 1);
+  const question = Object.values(service.questionControls().restore().questions)[0];
+  assert.ok(question.rootDeliveryReceipt);
+  assert.ok(question.rootDeliveryAcceptedSequence);
+  const restarted = new RunOrchestrationService({ ...options, questionControl: { authenticateControl: options.questionControl.authenticateControl } });
+  let reinjected: unknown = "not-called";
+  await restarted.rootServices().dispatch.model({ correlationId: "root-after-next", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    reinjected = invocation.rootQuestionDelivery;
+    return "next";
+  } });
+  assert.equal(reinjected, undefined);
+});
+
+test("persistent live-root receipt fault reconstructs from the successful result after restart without redispatch or reinjection", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let transitionWrites = 0;
+  const presenter = async () => ({ value: true, claimedIdentity: "root-user", credential: "secret", operationId: "root-live-persistent-answer" });
+  const built = fixture(undefined, active, presenter, { questionJournalFault: (_type, stage) => {
+    if (stage === "beforeRename" && ++transitionWrites >= 5) throw new Error("persistent root receipt stop");
+  } });
+  const root = built.service.rootServices();
+  let providerCalls = 0;
+  await assert.rejects(() => root.dispatch.model({ correlationId: "root-live-persistent", operation: "root.prompt", input: {}, dispatch: async () => {
+    providerCalls++;
+    await root.runWithToolRuntime(() => call("human_question", { prompt: "Persist?", kind: "confirm", required: true }));
+    return "durable provider result";
+  } }), /persistent root receipt stop/i);
+  const completed = Object.values(built.service.attemptRuntime().restore().attempts).find((attempt) => attempt.operation === "root.prompt");
+  assert.equal(completed?.status, "completed");
+  assert.equal(completed?.consumerReceipt?.deliveryIds.length, 1);
+
+  const restarted = new RunOrchestrationService({
+    ...built.options,
+    questionControl: { authenticateControl: built.options.questionControl.authenticateControl, presentLive: presenter },
+  });
+  restarted.rootServices();
+  assert.equal(providerCalls, 1, "restart receipt reconstruction must not invoke the successful provider again");
+  const restoredQuestion = Object.values(restarted.questionControls().restore().questions)[0];
+  assert.ok(restoredQuestion.rootDeliveryReceipt);
+  assert.ok(restoredQuestion.rootDeliveryAcceptedSequence);
+  let reinjected: unknown = "not-called";
+  await restarted.rootServices().dispatch.model({ correlationId: "root-after-persistent", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    reinjected = invocation.rootQuestionDelivery;
+    return "new turn";
+  } });
+  assert.equal(reinjected, undefined);
+});
+
+test("a live root answer is accepted only after its containing turn and is recovered once after a failed turn", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const { service, options } = fixture(undefined, active, async () => ({ value: true, claimedIdentity: "root-user", credential: "secret", operationId: "root-live-fault-answer" }));
+  const first = service.rootServices();
+  await assert.rejects(() => first.dispatch.model({
+    correlationId: "root-live-failed-turn", operation: "root.prompt", input: {},
+    dispatch: async () => {
+      const result = await first.runWithToolRuntime(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+      assert.equal(result.details.answer.value, true);
+      throw Object.assign(new Error("crash before containing root turn acceptance"), { effectNotApplied: true, assistantOutputObserved: true });
+    },
+  }), /containing root turn acceptance/i);
+
+  const restarted = new RunOrchestrationService(options);
+  let recoveredIds: string[] = [];
+  await restarted.rootServices().dispatch.model({ correlationId: "root-live-recovery", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    recoveredIds = invocation.rootQuestionDelivery?.questionIds as string[] ?? [];
+    assert.match(invocation.promptContext.text, /root-user/);
+    return "accepted recovery turn";
+  } });
+  assert.equal(recoveredIds.length, 1);
+  let duplicate: unknown = "not-called";
+  await restarted.rootServices().dispatch.model({ correlationId: "root-live-no-duplicate", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    duplicate = invocation.rootQuestionDelivery;
+    return "next turn";
+  } });
+  assert.equal(duplicate, undefined);
+});
+
+test("dashboard and command winners settle a losing live worker presenter without failing or hanging the task", async () => {
+  for (const channel of ["dashboard", "command"] as const) {
+    const active = snapshot() as any;
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    let presented!: (questionId: string) => void;
+    const presentationStarted = new Promise<string>((resolve) => { presented = resolve; });
+    const { service, projectRoot } = fixture(async () => ({
+      linkedSessionId: `live-race-${channel}`,
+      async prompt(_text, _signal, current) {
+        const result = await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+        assert.equal(result.details.state, "answered");
+        assert.equal(result.details.answer.channel, channel);
+        return `completed after ${channel}`;
+      },
+      dispose() {},
+    }), active, async (question: any) => {
+      presented(question.questionId);
+      return new Promise(() => {});
+    });
+    service.rootServices().delegate({ targetNodeId: "worker", objective: "race", deliverables: [] });
+    const workers = service.runWorkers();
+    const questionId = await presentationStarted;
+    const externalControl = new QuestionService({
+      projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: active,
+      authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+    });
+    externalControl.answer({
+      projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId, expectedState: "pending", value: true,
+      channel, claimedIdentity: "human", credential: "secret", operationId: `winner-${channel}`,
+    });
+    await Promise.race([workers, new Promise<never>((_, reject) => setTimeout(() => reject(new Error("worker live-answer race hung")), 250))]);
+    const task = Object.values(service.delegationState().tasks)[0];
+    assert.equal(task.result?.status, "completed");
+    assert.equal(task.result?.summary, `completed after ${channel}`);
+    const containingAttempt = Object.values(service.attemptRuntime().restore().attempts).find((attempt) => attempt.operation === "worker.provider.prompt");
+    const durableQuestion = service.questionControls().restore().questions[questionId];
+    assert.equal(containingAttempt?.consumerReceipt?.deliveryIds.includes(durableQuestion.taskDeliveryId!), true, "live worker delivery must bind to the successful containing attempt");
+    assert.equal(durableQuestion.taskAttemptId, task.attempts[0].attemptId);
+    assert.equal((service as any).current.questions.hasLiveHandles(), false);
+  }
+});
+
+test("offline root answers resume the same root transcript with one replay-safe delivery", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const { service } = fixture(undefined, active);
+  const root = service.rootServices();
+  let pending: any;
+  await root.dispatch.model({
+    correlationId: "root-question-create", operation: "root.prompt", input: {},
+    dispatch: async () => {
+      pending = await root.runWithToolRuntime(() => call("human_question", { prompt: "Choose release", kind: "single", choices: [{ value: "stable", label: "Stable" }], required: true }));
+      return "root turn suspended";
+    },
+  });
+  assert.equal(pending.details.state, "pending");
+  assert.equal(service.lifecycle.restore().latestRun?.status, "waiting_for_human");
+
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.details.questionId, expectedState: "pending", value: "stable", channel: "dashboard", claimedIdentity: "root-owner", credential: "secret", operationId: "root-answer-1" });
+  let firstPrompt = "";
+  let firstDeliveryId = "";
+  const resumed = service.rootServices();
+  await resumed.dispatch.model({
+    correlationId: "root-answer-delivery-1", operation: "root.prompt", input: {},
+    dispatch: async (invocation: any) => {
+      firstPrompt = invocation.promptContext.text;
+      firstDeliveryId = invocation.rootQuestionDelivery.deliveryId;
+      return "continued root transcript";
+    },
+  });
+  assert.match(firstPrompt, /human-answer:.*root-owner/);
+  assert.match(firstPrompt, /stable/);
+  assert.match(firstDeliveryId, /^root-question-delivery-/);
+
+  let secondDelivery: unknown = "not-called";
+  await resumed.dispatch.model({
+    correlationId: "root-answer-delivery-2", operation: "root.prompt", input: {},
+    dispatch: async (invocation: any) => { secondDelivery = invocation.rootQuestionDelivery; return "next root turn"; },
+  });
+  assert.equal(secondDelivery, undefined, "an accepted root answer is delivered to the transcript exactly once");
+});
+
+test("a consumed handoff and maximum escaped root input preserve a near-bound answer exactly once across restart through terminal progress", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const handoff = createHandoffPacket({
+    projectId: "project-1", workflowId: "source-workflow", sessionId: "source-session", createdAt: "2026-01-01T00:00:00.000Z",
+    terminal: {
+      runId: "source-run", snapshotId: "a".repeat(64), terminalEventHash: "c".repeat(64),
+      status: "completed", summary: "valid near-limit handoff", fileChanges: [], changeCoverage: "recorded",
+      artifactRefs: [], evidenceRefs: [], data: { body: "\"".repeat(30_000) }, unsatisfiedGates: [], closedQuestionIds: [],
+      partialState: {}, finishedByNodeId: "root", finishedAt: "2026-01-01T00:00:00.000Z",
+    },
+  });
+  let inputLow = 1, inputHigh = 131_072;
+  while (inputLow < inputHigh) {
+    const candidate = Math.ceil((inputLow + inputHigh) / 2);
+    try {
+      fixture(undefined, active, undefined, { stagedHandoff: handoff, initialInputText: "\"".repeat(candidate) });
+      inputLow = candidate;
+    } catch (error) {
+      if (!/PAYLOAD_LIMIT|too large/i.test(String(error instanceof Error ? error.message : error))) throw error;
+      inputHigh = candidate - 1;
+    }
+  }
+  assert.ok(inputLow < 131_072, "the event envelope, not the semantic input limit, is the escaped-input ceiling");
+  assert.throws(() => fixture(undefined, active, undefined, { stagedHandoff: handoff, initialInputText: "\"".repeat(inputLow + 1) }), /PAYLOAD_LIMIT|too large/i);
+  const built = fixture(undefined, active, undefined, { stagedHandoff: handoff, initialInputText: "\"".repeat(inputLow) });
+  const question = built.service.questionControls().create({
+    nodeId: "root", definition: { prompt: "Near bound?", kind: "text", required: true },
+    provenance: { source: "human_question", toolCallId: "root-bound-call" },
+  });
+  const measurement = (answerLength: number) => measureLosslessDynamicPromptDelivery(losslessDynamicPromptInputs({
+    provenance: `human-answer:${question.questionId}:dashboard:root-owner`,
+    content: {
+      questionId: question.questionId, definition: question.definition,
+      answer: { value: "\"".repeat(answerLength), channel: "dashboard", identity: "root-owner", operationId: "root-bound-answer", inputHash: `sha256:${"0".repeat(64)}`, answeredAt: "2026-01-01T00:00:01.000Z" },
+    },
+    ref: `run:run-1/node:root/question:${question.questionId}`,
+  }));
+  let low = 0, high = QUESTION_LIMITS.textAnswerBytes;
+  while (low < high) {
+    const candidate = Math.ceil((low + high) / 2);
+    if (measurement(candidate).encodedBytes <= ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS.encodedBytes) low = candidate;
+    else high = candidate - 1;
+  }
+  built.service.questionControls().answer({
+    projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending",
+    value: "\"".repeat(low), channel: "dashboard", claimedIdentity: "root-owner", credential: "secret", operationId: "root-bound-answer",
+  });
+
+  const restarted = new RunOrchestrationService(built.options);
+  let delivered = 0;
+  await restarted.rootServices().dispatch.model({
+    correlationId: "root-bound-consume", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+      delivered += invocation.rootQuestionDeliveries?.flatMap((delivery) => delivery.questionIds).filter((id) => id === question.questionId).length ?? 0;
+      assert.equal(invocation.rootQuestionDeliveries?.[0]?.answers[0]?.answer.value, "\"".repeat(low));
+      return "consumed near-bound answer";
+    },
+  });
+  const afterConsume = new RunOrchestrationService(built.options);
+  await afterConsume.rootServices().dispatch.model({
+    correlationId: "root-bound-after", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+      delivered += invocation.rootQuestionDeliveries?.flatMap((delivery) => delivery.questionIds).filter((id) => id === question.questionId).length ?? 0;
+      return "continued root transcript";
+    },
+  });
+  assert.equal(delivered, 1, "the accepted answer must reach the same durable root transcript exactly once");
+  const restored = afterConsume.questionControls().restore().questions[question.questionId];
+  assert.match(restored.rootDeliveryReceipt?.transcriptRef ?? "", /run:run-1\/node:root\/transcript/u);
+  assert.ok(restored.rootDeliveryAcceptedSequence);
+  const terminal = await afterConsume.lifecycle.finish({ status: "completed", summary: "bounded answer consumed" }, { callerNodeId: "root", toolBatch: ["workflow_finish"] });
+  assert.equal(terminal.ok, true, terminal.ok ? "" : terminal.issues.join(" "));
+});
+
+test("near-bound JSON-escaped root questions and answers are delivered in exact lossless pages across failure and restart", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const built = fixture(undefined, active);
+  const { service, options } = built;
+  const maximumPrompt = `${"\n".repeat(QUESTION_LIMITS.promptBytes - 1)}x`;
+  const questions = Array.from({ length: 4 }, (_value, index) => service.questionControls().create({
+    nodeId: "root", definition: { prompt: maximumPrompt, kind: "text", required: true },
+    provenance: { source: "human_question", toolCallId: `root-page-call-${index}` },
+  }));
+  const answerMeasurement = (answerLength: number) => measureLosslessDynamicPromptDelivery(losslessDynamicPromptInputs({
+    provenance: `human-answer:${questions[0].questionId}:dashboard:human`,
+    content: {
+      questionId: questions[0].questionId, definition: questions[0].definition,
+      answer: { value: "\n".repeat(answerLength), channel: "dashboard", identity: "human", operationId: "root-page-answer-0", inputHash: `sha256:${"0".repeat(64)}`, answeredAt: "2026-01-01T00:00:00.000Z" },
+    },
+    ref: `run:run-1/node:root/question:${questions[0].questionId}`,
+  }));
+  let answerLow = 0, answerHigh = QUESTION_LIMITS.textAnswerBytes;
+  while (answerLow < answerHigh) {
+    const candidate = Math.ceil((answerLow + answerHigh) / 2);
+    if (answerMeasurement(candidate).encodedBytes <= ROOT_LOSSLESS_DYNAMIC_DELIVERY_LIMITS.encodedBytes) answerLow = candidate;
+    else answerHigh = candidate - 1;
+  }
+  const maximum = "\n".repeat(answerLow);
+  const questionIds = questions.map((question) => question.questionId);
+  for (const [index, question] of questions.entries()) {
+    service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: maximum, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `root-page-answer-${index}` });
+    service.questionControls().prepareRootAnswerDeliveries("root", [question.questionId]);
+  }
+  assert.equal(service.questionControls().preparedRootAnswerDeliveries("root").length, 4);
+
+  const pages: string[][] = [];
+  let failFirstPage = true;
+  const dispatchPage = (owner: RunOrchestrationService, ordinal: number) => owner.rootServices().dispatch.model({
+    correlationId: `root-answer-page-${ordinal}`, operation: "root.prompt", input: { ordinal }, dispatch: async (invocation) => {
+      const deliveries = invocation.rootQuestionDeliveries ?? [];
+      const ids = deliveries.flatMap((delivery) => delivery.questionIds);
+      assert.ok(ids.length > 0);
+      assert.equal(deliveries.flatMap((delivery) => delivery.answers).every((answer) => answer.answer.value === maximum), true);
+      pages.push(ids);
+      if (failFirstPage) {
+        failFirstPage = false;
+        throw Object.assign(new Error("known root page failure"), { effectNotApplied: true, assistantOutputObserved: false, toolCallObserved: false });
+      }
+      return "root page consumed";
+    },
+  });
+
+  await assert.rejects(() => dispatchPage(service, 0), /known root page failure/i);
+  assert.equal(questionIds.every((questionId) => service.questionControls().restore().questions[questionId].rootDeliveryReceipt === undefined), true, "a failed root page acknowledges nothing");
+  const restarted = new RunOrchestrationService(options);
+  await dispatchPage(restarted, 1);
+  const firstAcceptedPage = new Set(pages[1]);
+  for (const questionId of questionIds) {
+    const restored = restarted.questionControls().restore().questions[questionId];
+    assert.equal(restored.rootDeliveryReceipt !== undefined, firstAcceptedPage.has(questionId), "only the exact fitting root page receives a consumer receipt");
+    assert.equal(restored.rootDeliveryAcceptedSequence !== undefined, firstAcceptedPage.has(questionId), "only the exact fitting root page is accepted");
+  }
+  for (let page = 2; page <= 10 && restarted.questionControls().preparedRootAnswerDeliveries("root").length; page++) await dispatchPage(restarted, page);
+
+  assert.deepEqual(pages[1], pages[0], "the failed root page is retried unchanged after restart");
+  assert.ok(pages[0].length < questionIds.length, "the root aggregate must require more than one prompt page");
+  const successfulIds = pages.slice(1).flat();
+  assert.deepEqual(successfulIds, questionIds, "successful root pages are ordered, lossless, and non-overlapping");
+  assert.equal(new Set(successfulIds).size, questionIds.length);
+  assert.equal(restarted.questionControls().preparedRootAnswerDeliveries("root").length, 0);
+  for (const questionId of questionIds) {
+    const restored = restarted.questionControls().restore().questions[questionId];
+    assert.ok(restored.rootDeliveryReceipt);
+    assert.ok(restored.rootDeliveryAcceptedSequence);
+  }
+});
+
+test("approval waits reject queued worker admission across multiple requests and restart without task mutation", async () => {
+  let prompts = 0;
+  const { projectRoot, service, options } = fixture(async () => ({ linkedSessionId: "approval-queued", async prompt() { prompts++; return "ran"; }, dispose() {} }));
+  const appendApproval = (operation: "request" | "decision", requestId: string) => appendWorkflowEvent(projectRoot, createWorkflowEvent({
+    projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded",
+    producer: operation === "request" ? "harness" : "dashboard", timestamp: new Date().toISOString(),
+    payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation, requestId },
+  }));
+  const first = service.rootServices().delegate({ targetNodeId: "worker", objective: "first queued", deliverables: [] });
+  const second = service.rootServices().delegate({ targetNodeId: "worker", objective: "second queued", deliverables: [] });
+  appendApproval("request", "approval-a");
+  appendApproval("request", "approval-b");
+  await assert.rejects(() => service.runWorkers(), /approval|waiting|running/i);
+  assert.equal(prompts, 0);
+  assert.deepEqual([service.delegationState().tasks[first.taskId].queueState, service.delegationState().tasks[second.taskId].queueState], ["queued", "queued"]);
+  appendApproval("decision", "approval-a");
+  const restarted = new RunOrchestrationService(options);
+  await assert.rejects(() => restarted.runWorkers(), /approval|waiting|running/i);
+  assert.equal(prompts, 0);
+  assert.deepEqual([restarted.delegationState().tasks[first.taskId].queueState, restarted.delegationState().tasks[second.taskId].queueState], ["queued", "queued"]);
+  appendApproval("decision", "approval-b");
+  await restarted.runWorkers();
+  assert.equal(prompts, 2);
+});
+
+test("approval waits preserve a question-resume-ready task across runWorkers calls and restart", async () => {
+  const activeSnapshot = snapshot() as any;
+  const workerAuthority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let prompts = 0;
+  const { projectRoot, service, options } = fixture(async () => ({ linkedSessionId: "approval-resume-ready", async prompt(_text, _signal, current) {
+    prompts++;
+    if (prompts === 1) await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Resume?", kind: "confirm", required: true }));
+    return prompts === 1 ? "waiting" : "resumed";
+  }, dispose() {} }), activeSnapshot);
+  const delegated = service.rootServices().delegate({ targetNodeId: "worker", objective: "resume ready", deliverables: [] });
+  await service.runWorkers();
+  const pending = service.questionControls().status({ state: "pending", limit: 1 }).items[0];
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "approval-resume-answer" });
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded", producer: "harness", timestamp: new Date().toISOString(), payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation: "request", requestId: "approval-resume" } }));
+  const before = service.delegationState().tasks[delegated.taskId];
+  assert.equal(before.queueState, "active");
+  assert.ok(before.resumedByQuestionSequence);
+  await assert.rejects(() => service.runWorkers(), /approval|waiting|running/i);
+  const restarted = new RunOrchestrationService(options);
+  await assert.rejects(() => restarted.runWorkers(), /approval|waiting|running/i);
+  const preserved = restarted.delegationState().tasks[delegated.taskId];
+  assert.equal(preserved.queueState, "active");
+  assert.equal(preserved.resumedByQuestionSequence, before.resumedByQuestionSequence);
+  assert.equal(prompts, 1);
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded", producer: "dashboard", timestamp: new Date().toISOString(), payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation: "decision", requestId: "approval-resume" } }));
+  await restarted.runWorkers();
+  const completed = restarted.delegationState().tasks[delegated.taskId];
+  assert.equal(completed.result?.status, "completed", completed.result?.summary);
+  assert.equal(completed.attempts.length, 1);
+  assert.equal(prompts, 2);
+});
+
+test("an approval arising during active work lets that work settle but does not launch the queued successor", async () => {
+  let started!: () => void;
+  let release!: () => void;
+  const startedGate = new Promise<void>((resolve) => { started = resolve; });
+  const releaseGate = new Promise<void>((resolve) => { release = resolve; });
+  let prompts = 0;
+  const { projectRoot, service } = fixture(async () => ({ linkedSessionId: "approval-active", async prompt() {
+    prompts++;
+    if (prompts === 1) { started(); await releaseGate; }
+    return `done-${prompts}`;
+  }, dispose() {} }));
+  const root = service.rootServices();
+  const active = root.delegate({ targetNodeId: "worker", objective: "active", deliverables: [] });
+  const queued = root.delegate({ targetNodeId: "worker", objective: "queued", deliverables: [] });
+  const running = service.runWorkers();
+  await startedGate;
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded", producer: "harness", timestamp: new Date().toISOString(), payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation: "request", requestId: "approval-active" } }));
+  release();
+  await running;
+  assert.equal(service.delegationState().tasks[active.taskId].result?.status, "completed");
+  assert.equal(service.delegationState().tasks[queued.taskId].queueState, "queued");
+  assert.equal(prompts, 1);
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded", producer: "dashboard", timestamp: new Date().toISOString(), payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation: "decision", requestId: "approval-active" } }));
+  await service.runWorkers();
+  assert.equal(service.delegationState().tasks[queued.taskId].result?.status, "completed");
+  assert.equal(prompts, 2);
+});
+
+test("root consumer receipt reconciles a before-acceptance fault across restart and a newly answered second question", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let injectFault = false;
+  let markerWrites = 0;
+  const built = fixture(undefined, active, undefined, { questionJournalFault: (_type, stage) => {
+    if (injectFault && stage === "beforeRename" && ++markerWrites === 3) throw new Error("process stopped before root acceptance publication");
+  } });
+  const { service, options, projectRoot } = built;
+  const q1 = service.questionControls().create({ nodeId: "root", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-receipt-q1" } });
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q1.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "root-receipt-a1" });
+  injectFault = true;
+  const seen: string[][] = [];
+  await assert.rejects(() => service.rootServices().dispatch.model({ correlationId: "root-receipt-first", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    seen.push((invocation.rootQuestionDeliveries ?? []).flatMap((delivery) => delivery.questionIds));
+    return "consumer succeeded";
+  } }), /acceptance publication/i);
+  injectFault = false;
+  const receipt = readWorkflowJournal(projectRoot, "session-1").find((event) => event.type === "question.transition" && (event.payload as any).operation === "root-delivery-consumed");
+  assert.equal(typeof (receipt?.payload as any)?.promptHash, "string");
+  assert.match((receipt?.payload as any)?.attemptId ?? "", /^attempt-/);
+  assert.match((receipt?.payload as any)?.transcriptRef ?? "", /run:run-1\/node:root\/transcript/);
+
+  const q2 = service.questionControls().create({ nodeId: "root", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-receipt-q2" } });
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q2.questionId, expectedState: "pending", value: false, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "root-receipt-a2" });
+  const restarted = new RunOrchestrationService(options);
+  await restarted.rootServices().dispatch.model({ correlationId: "root-receipt-second", operation: "root.prompt", input: {}, dispatch: async (invocation) => {
+    seen.push((invocation.rootQuestionDeliveries ?? []).flatMap((delivery) => delivery.questionIds));
+    return "second consumer succeeded";
+  } });
+  assert.deepEqual(seen, [[q1.questionId], [q2.questionId]]);
+});
+
+test("completed model attempt reconciles a before-publication root receipt fault after restart without provider replay", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let armed = false;
+  let failed = false;
+  const built = fixture(undefined, active, undefined, { questionJournalFault: (_type, stage) => {
+    if (armed && !failed && stage === "beforeRename") { failed = true; throw new Error("receipt before-publication fault"); }
+  } });
+  const { service, options } = built;
+  const question = service.questionControls().create({ nodeId: "root", definition: { prompt: "Receipt?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "root-receipt-before" } });
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "root-receipt-before-answer" });
+  service.questionControls().prepareRootAnswerDeliveries("root");
+  let providerCalls = 0;
+  armed = true;
+  await assert.rejects(() => service.rootServices().dispatch.model({
+    correlationId: "root-receipt-before-attempt", operation: "root.prompt", input: {},
+    dispatch: async () => { providerCalls++; return "consumer completed"; },
+  }), /receipt before-publication/i);
+  assert.equal(providerCalls, 1);
+  assert.equal(service.questionControls().restore().questions[question.questionId].rootDeliveryReceipt, undefined);
+
+  armed = false;
+  const restarted = new RunOrchestrationService(options);
+  await restarted.rootServices().dispatch.model({
+    correlationId: "root-receipt-after-restart", operation: "root.prompt", input: {},
+    dispatch: async (invocation) => {
+      providerCalls++;
+      assert.equal(invocation.rootQuestionDelivery, undefined);
+      return "next turn";
+    },
+  });
+  const restored = restarted.questionControls().restore().questions[question.questionId];
+  assert.ok(restored.rootDeliveryReceipt, "completed containing attempt must reconstruct the missing receipt");
+  assert.ok(restored.rootDeliveryAcceptedSequence);
+  assert.equal(providerCalls, 2, "restart must not present the accepted answer to the provider twice");
+});
+
+test("receipt acceptance reconciliation faults before worker admission and never becomes a worker result", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let armed = false;
+  let failed = false;
+  let prompts = 0;
+  const built = fixture(async () => ({ linkedSessionId: "settlement-worker", async prompt() { prompts++; return "unexpected"; }, dispose() {} }), active, undefined, {
+    questionJournalFault: (_type, stage) => { if (armed && !failed && stage === "beforeRename") { failed = true; throw new Error("acceptance before-publication fault"); } },
+  });
+  const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: "settle receipt", deliverables: [] });
+  const runtime = (built.service as any).current.runtime;
+  runtime.start(delegated.taskId, "attempt-settlement");
+  const questions = built.service.questionControls();
+  const question = questions.create({ nodeId: "worker", taskId: delegated.taskId, definition: { prompt: "Settle?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "settlement-call" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "settlement-answer" });
+  const [delivery] = questions.prepareTaskAnswerDeliveries(delegated.taskId);
+  questions.recordTaskAnswerDeliveryReceipt(delivery, { promptHash: "c".repeat(64), attemptId: "attempt-settlement", transcriptRef: `run:run-1/node:worker/task:${delegated.taskId}/transcript` });
+  armed = true;
+
+  const restarted = new RunOrchestrationService(built.options);
+  await assert.rejects(() => restarted.runWorkers(), /acceptance before-publication/i);
+  const unchanged = restarted.delegationState().tasks[delegated.taskId];
+  assert.equal(unchanged.queueState, "active");
+  assert.equal(unchanged.result, undefined);
+  assert.equal(prompts, 0);
+  armed = false;
+  await restarted.runWorkers();
+  assert.equal(restarted.questionControls().restore().questions[question.questionId].taskDeliveryAcceptedSequence !== undefined, true);
+});
+
+test("root terminal publication rejects an answered answer until it reaches the transcript", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  const { service } = fixture(undefined, active);
+  const question = service.questionControls().create({ nodeId: "root", definition: { prompt: "Late answer?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "terminal-root-call" } });
+  service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "terminal-root-answer" });
+  await assert.rejects(
+    () => service.rootServices().runWithToolRuntime(() => call("workflow_finish", { status: "completed", summary: "must wait" })),
+    /transcript|answered|question/i,
+  );
+  assert.equal(service.lifecycle.restore().latestRun?.status, "running");
+});
+
+test("root question waits reconcile with approval waits in both event orders", async () => {
+  for (const approvalFirst of [true, false]) {
+    const active = snapshot() as any;
+    const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+    rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+    rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+    const { projectRoot, service } = fixture(undefined, active);
+    const appendApproval = (operation: "request" | "decision") => appendWorkflowEvent(projectRoot, createWorkflowEvent({
+      projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded",
+      producer: operation === "request" ? "harness" : "dashboard", timestamp: new Date().toISOString(),
+      payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation, requestId: "approval-root" },
+    }));
+    let questionId = "";
+    if (approvalFirst) {
+      appendApproval("request");
+      questionId = service.questionControls().create({
+        nodeId: "root", definition: { prompt: "Proceed?", kind: "confirm", required: true },
+        provenance: { source: "human_question", toolCallId: "approval-first-root" },
+      }).questionId;
+      service.rootServices();
+    } else {
+      const root = service.rootServices();
+      await root.dispatch.model({
+        correlationId: "root-waits-question-first", operation: "root.prompt", input: {},
+        dispatch: async () => {
+          const pending = await root.runWithToolRuntime(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+          questionId = pending.details.questionId;
+          appendApproval("request");
+          return "waiting";
+        },
+      });
+    }
+    assert.deepEqual(service.lifecycle.restore().latestRun?.waitCauses, ["approval", "question"]);
+    appendApproval("decision");
+    assert.equal(service.lifecycle.restore().latestRun?.status, "waiting_for_human", "approval alone must not resume while the root question remains");
+    await assert.rejects(() => service.rootServices().dispatch.model({ correlationId: "must-not-run", operation: "root.prompt", input: {}, dispatch: async () => "ran" }), /admission|running|wait/i);
+    service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `answer-${approvalFirst}` });
+    assert.equal(service.rootServices().context.nodeId, "root");
+    assert.equal(service.lifecycle.restore().latestRun?.status, "running");
+  }
+});
+
+test("worker question waits reconcile with approval waits in both event orders", async () => {
+  for (const approvalFirst of [true, false]) {
+    const active = snapshot() as any;
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    let started!: () => void;
+    let release!: () => void;
+    const startedGate = new Promise<void>((resolve) => { started = resolve; });
+    const releaseGate = new Promise<void>((resolve) => { release = resolve; });
+    let invocations = 0;
+    const { projectRoot, service } = fixture(async () => ({
+      linkedSessionId: `worker-waits-${approvalFirst}`,
+      async prompt(_text, _signal, current) {
+        invocations++;
+        if (invocations > 1) return "resumed";
+        if (approvalFirst) {
+          started();
+          await releaseGate;
+        } else {
+          await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Proceed?", kind: "confirm", required: true }));
+          appendApproval("request");
+        }
+        return "waiting";
+      },
+      dispose() {},
+    }), active);
+    const appendApproval = (operation: "request" | "decision") => { appendWorkflowEvent(projectRoot, createWorkflowEvent({
+      projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "approval.recorded",
+      producer: operation === "request" ? "harness" : "dashboard", timestamp: new Date().toISOString(),
+      payload: { formatVersion: 1, subsystem: "checkpoint-approval", operation, requestId: "approval-worker" },
+    })); };
+    service.rootServices().delegate({ targetNodeId: "worker", objective: "wait", deliverables: [] });
+    if (approvalFirst) {
+      const running = service.runWorkers();
+      await startedGate;
+      appendApproval("request");
+      service.questionControls().create({
+        nodeId: "worker", taskId: "task-1", definition: { prompt: "Proceed?", kind: "confirm", required: true },
+        provenance: { source: "human_question", toolCallId: "approval-first-worker" },
+      });
+      release();
+      await running;
+    } else await service.runWorkers();
+    assert.deepEqual(service.lifecycle.restore().latestRun?.waitCauses, ["approval", "question"]);
+    appendApproval("decision");
+    assert.equal(service.lifecycle.restore().latestRun?.status, "waiting_for_human");
+    const pending = service.questionControls().status({ state: "pending", limit: 1 }).items[0];
+    service.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId, expectedState: "pending", value: true, channel: "command", claimedIdentity: "human", credential: "secret", operationId: `worker-answer-${approvalFirst}` });
+    await service.runWorkers();
+    assert.equal(service.lifecycle.restore().latestRun?.status, "running");
+    assert.equal(invocations, 2);
+  }
+});
+
+test("cancellation question closure derives bounded stable values from the frozen request", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  for (const reasonBytes of [2_048, 2_049, 8_192]) {
+    const runId = reasonBytes === 2_049 ? "r".repeat(256) : `run-${reasonBytes}`;
+    const reason = "x".repeat(reasonBytes);
+    const { service, projectRoot } = fixture(undefined, active, undefined, { runId });
+    const question = service.questionControls().create({ nodeId: "root", definition: { prompt: "Cancel?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: `cancel-${reasonBytes}` } });
+    const cancelled = await service.cancel(reason);
+    assert.equal(cancelled.envelope.status, "cancelled");
+    const state = new QuestionService({
+      projectRoot, projectId: "project-1", sessionId: "session-1", runId, snapshot: active,
+      authenticateControl: (request) => request.claimedIdentity,
+    }).restore().questions[question.questionId].closure!;
+    assert.ok(Buffer.byteLength(state.reason, "utf8") <= 2_048);
+    assert.ok(Buffer.byteLength(state.operationId, "utf8") <= 256);
+    assert.match(state.operationId, /sha256|[0-9a-f]{64}/i);
+  }
+});
+
+test("explicit cancellation closes a pending worker question before publishing its cancelled task result", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let questionId = "";
+  const { service } = fixture(async () => ({ linkedSessionId: "cancel-question-worker", async prompt(_text, _signal, current) {
+    const result = await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Cancel this task?", kind: "confirm", required: true }));
+    questionId = result.details.questionId;
+    return "suspended";
+  }, dispose() {} }), active);
+  const delegated = service.rootServices().delegate({ targetNodeId: "worker", objective: "cancel pending question", deliverables: [] });
+  await service.runWorkers();
+  assert.equal(service.delegationState().tasks[delegated.taskId].queueState, "suspended");
+  const questionOptions = service.questionControls().options;
+  const cancelled = await service.cancel("explicit cancellation");
+  assert.equal(cancelled.envelope.status, "cancelled");
+  assert.equal(service.delegationState().tasks[delegated.taskId].result?.status, "cancelled");
+  const questionControl = new QuestionService({ ...questionOptions });
+  const question = questionControl.restore().questions[questionId];
+  assert.equal(question.state, "closed");
+  assert.throws(() => questionControl.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId, expectedState: "pending", value: true, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "late-cancel-answer" }), /terminal|closed|pending|late/i);
+});
+
+test("answer-first cancellation terminal-settles resume-ready tasks without consuming their answers", async () => {
+  for (const race of ["idle-restart", "executing"] as const) {
+    const active = snapshot() as any;
+    const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+    workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+    workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+    let started!: () => void;
+    const startedGate = new Promise<void>((resolve) => { started = resolve; });
+    const built = fixture(async () => ({ linkedSessionId: `cancel-answer-${race}`, async prompt(_text, signal, current) {
+      if (race === "idle-restart") {
+        await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Answer before cancel?", kind: "confirm", required: true }));
+        return "suspended";
+      }
+      started();
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) resolve(); else signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return "aborted execution";
+    }, dispose() {} }), active);
+    const delegated = built.service.rootServices().delegate({ targetNodeId: "worker", objective: `answer-first ${race}`, deliverables: [] });
+    let owner = built.service;
+    let running: Promise<void> | undefined;
+    if (race === "idle-restart") {
+      await owner.runWorkers();
+    } else {
+      running = owner.runWorkers();
+      await startedGate;
+      owner.questionControls().create({ nodeId: "worker", taskId: delegated.taskId, definition: { prompt: "Race cancellation?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "executing-cancel-question" } });
+    }
+    const pending = owner.questionControls().status({ state: "pending", limit: 1 }).items[0];
+    owner.questionControls().answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: pending.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: `cancel-answer-${race}` });
+    const questionOptions = owner.questionControls().options;
+    if (race === "idle-restart") owner = new RunOrchestrationService(built.options);
+    const cancelled = await owner.cancel(`cancel after answer ${race}`);
+    await running;
+    assert.equal(cancelled.envelope.status, "cancelled");
+    const task = owner.delegationState().tasks[delegated.taskId];
+    assert.equal(task.queueState, "terminal");
+    assert.equal(task.result?.status, "cancelled");
+    const question = new QuestionService({ ...questionOptions }).restore().questions[pending.questionId];
+    assert.equal(question.state, "answered");
+    assert.equal(question.taskDeliveryReceipt, undefined);
+    assert.equal(question.taskDeliveryAcceptedSequence, undefined);
+    assert.deepEqual(cancelled.envelope.closedQuestionIds, []);
+    assert.equal(Object.values(owner.delegationState().tasks).some((candidate) => candidate.queueState !== "terminal"), false);
+  }
+});
+
+test("cancellation retry with changed text reuses the frozen closure provenance after restart", async () => {
+  const active = snapshot() as any;
+  const rootAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "root");
+  rootAuthority.capabilities.effective = { ...(rootAuthority.capabilities.effective ?? {}), "human-input": true };
+  rootAuthority.tools = [...new Set([...rootAuthority.tools, "human_question"])].sort();
+  let failRelease = true;
+  const originalReason = `${"a".repeat(2_048)}original-tail`;
+  const { service, options, projectRoot } = fixture(undefined, active, undefined, { cancellationReleaseLeases: () => {
+    if (failRelease) { failRelease = false; throw new Error("fault after durable question closure"); }
+  } });
+  const question = service.questionControls().create({ nodeId: "root", definition: { prompt: "Cancel?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "cancel-retry" } });
+  await assert.rejects(() => service.cancel(originalReason), /fault after durable question closure|retryable/i);
+  const restarted = new RunOrchestrationService(options);
+  const cancelled = await restarted.cancel("different retry text");
+  assert.equal(cancelled.envelope.status, "cancelled");
+  const events = readWorkflowJournal(projectRoot, "session-1");
+  assert.equal(events.filter((event) => event.type === "question.transition" && (event.payload as any).operation === "close-pending").length, 1);
+  assert.equal(events.filter((event) => event.type === "terminal.recorded").length, 1);
+  const restored = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: active, authenticateControl: (request) => request.claimedIdentity }).restore();
+  assert.equal(restored.questions[question.questionId].closure?.reason, "a".repeat(2_048));
+  assert.equal(restarted.lifecycle.restore().latestRun?.cancellationReason, originalReason);
+});
+
+test("orchestration shutdown aborts non-cooperative question presentation before worker settlement", async () => {
+  const active = snapshot() as any;
+  const workerAuthority = active.payload.authority.nodes.find((entry: any) => entry.nodeId === "worker");
+  workerAuthority.capabilities.effective = { ...(workerAuthority.capabilities.effective ?? {}), "human-input": true };
+  workerAuthority.tools = [...new Set([...workerAuthority.tools, "human_question"])].sort();
+  let presentationStarted!: () => void;
+  const started = new Promise<void>((resolve) => { presentationStarted = resolve; });
+  const { service } = fixture(async (input) => ({
+    linkedSessionId: `linked-${input.nodeId}`,
+    async prompt(_text, _signal, current) {
+      await current!.runWithToolRuntime!(() => call("human_question", { prompt: "Wait?", kind: "confirm", required: true }));
+      return "settled after abort";
+    },
+    dispose() {},
+  }), active, async () => { presentationStarted(); return new Promise(() => {}); });
+  service.rootServices().delegate({ targetNodeId: "worker", objective: "ask live", deliverables: [] });
+  const running = service.runWorkers();
+  await started;
+  assert.equal(service.hasLiveHandles(), true);
+  const began = Date.now();
+  await service.shutdown("test shutdown");
+  await running;
+  assert.ok(Date.now() - began < 1_000, "question abort must happen before the worker settlement wait");
+  assert.equal(service.hasLiveHandles(), false);
 });
 
 test("workflow_finish is root-only, sole-call, policy-rechecked, and returns harness-derived identity", async () => {

--- a/tests/workflows/workflow-workers.test.ts
+++ b/tests/workflows/workflow-workers.test.ts
@@ -4,11 +4,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot.ts";
-import type { PersistedDelegationTask } from "../../src/workflows/delegation.ts";
+import { DelegationRuntime, type PersistedDelegationTask } from "../../src/workflows/delegation.ts";
+import { QuestionService } from "../../src/workflows/questions.ts";
+import { QUESTION_LIMITS } from "../../src/workflows/question-validation.ts";
+import { AttemptRuntime, attemptDescriptorForModel, executeWithConservativeRetry } from "../../src/workflows/attempts.ts";
+import { readWorkflowJournal } from "../../src/workflows/journal.ts";
 import {
   WorkerSessionPool,
   workerTranscriptPath,
   type WorkerSessionFactory,
+  type WorkerModelDispatcher,
 } from "../../src/workflows/workers.ts";
 
 function snapshot(): ActivationSnapshotFileV1 {
@@ -194,6 +199,501 @@ test("structured authorized refs are the only resolved context and prose carries
   assert.match(prompt, /prose.*not.*DLP|not information-flow control/i);
 });
 
+test("question answers resume the same task and node transcript with durable provenance", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-question-resume-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "same objective", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "question-1", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  let creations = 0;
+  const invocations: any[] = [];
+  const pool = new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async (input) => {
+      creations++;
+      return {
+        linkedSessionId: "linked-alpha",
+        async prompt(text, _signal, invocation) {
+          invocations.push({ text, invocation, transcriptPath: input.transcriptPath });
+          if (invocations.length === 1) questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Proceed?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "call-1" } });
+          return invocations.length === 1 ? "waiting" : "resumed";
+        },
+        dispose() {},
+      };
+    },
+  });
+  const activeTask = task("task-1", "alpha", "same objective");
+  const suspended = await pool.execute(activeTask);
+  assert.equal(suspended.status, "suspended");
+  if (suspended.status !== "suspended") return;
+  assert.deepEqual((suspended as any).questionIds, ["question-1"]);
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "answer-1" });
+  const resumed = await pool.execute(activeTask);
+  assert.equal(resumed.status, "completed");
+  assert.equal(creations, 1, "node/run session and transcript must be reused");
+  assert.equal(invocations[0].transcriptPath, invocations[1].transcriptPath);
+  assert.equal(invocations[1].invocation.promptContext.taskContract.taskId, "task-1");
+  assert.equal(invocations[1].invocation.promptContext.taskContract.acceptedAnswers[0].questionId, "question-1");
+  assert.equal(invocations[1].invocation.promptContext.taskContract.acceptedAnswers[0].answer.channel, "dashboard");
+  assert.match(invocations[1].text, /question-1|Proceed\?/);
+});
+
+test("worker answer delivery is accepted once across sequential question cycles and pool restart", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-question-cycles-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "two cycles", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let questionSequence = 0;
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => `question-${++questionSequence}`, authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  const activeTask = task("task-1", "alpha", "two cycles");
+  const seen: string[][] = [];
+  const makePool = () => new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({
+      linkedSessionId: "linked-alpha",
+      async prompt(_text, _signal, invocation) {
+        seen.push(invocation!.promptContext.taskContract.acceptedAnswers.map((entry) => entry.questionId));
+        return "accepted containing turn";
+      },
+      dispose() {},
+    }),
+  });
+  const q1 = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "cycle-q1" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q1.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "cycle-a1" });
+  await makePool().execute(activeTask);
+
+  const q2 = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "cycle-q2" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q2.questionId, expectedState: "pending", value: false, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "cycle-a2" });
+  await makePool().execute(activeTask);
+  await makePool().execute(activeTask);
+  assert.deepEqual(seen, [[q1.questionId], [q2.questionId], []]);
+});
+
+test("failed worker turns retain prepared answers while successful retry accepts each answer once", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-question-fault-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "fault", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  const questions = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "question-fault", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  const question = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Retry?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "fault-q" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "fault-a" });
+  const seen: string[][] = [];
+  let fail = true;
+  const execute = () => new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions: new QuestionService({ ...questions.options }),
+    factory: async () => ({ linkedSessionId: "linked-alpha", async prompt(_text, _signal, invocation) {
+      seen.push(invocation!.promptContext.taskContract.acceptedAnswers.map((entry) => entry.questionId));
+      if (fail) { fail = false; throw new Error("fault before containing transcript acceptance"); }
+      return "accepted";
+    }, dispose() {} }),
+  }).execute(task("task-1", "alpha", "fault"));
+  assert.equal((await execute()).status, "failed");
+  assert.equal((await execute()).status, "completed");
+  assert.equal((await execute()).status, "completed");
+  assert.deepEqual(seen, [[question.questionId], [question.questionId], []]);
+});
+
+test("worker consumer receipts reconcile a before-acceptance publication fault across restart without re-injecting an older answer", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-question-receipt-fault-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "receipt fault", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let questionSequence = 0;
+  const base = new QuestionService({
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => `receipt-question-${++questionSequence}`, authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
+  });
+  const q1 = base.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "receipt-q1" } });
+  base.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q1.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "receipt-a1" });
+  base.prepareTaskAnswerDeliveries("task-1");
+
+  let markerWrites = 0;
+  const faulted = new QuestionService({ ...base.options, journalFault: (_type, stage) => {
+    if (stage === "beforeRename" && ++markerWrites >= 2) throw new Error("process stopped before acceptance publication");
+  } });
+  const seen: string[][] = [];
+  const makePool = (questions: QuestionService) => new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({ linkedSessionId: "linked-alpha", async prompt(_text, _signal, invocation) {
+      seen.push(invocation!.promptContext.taskContract.acceptedAnswers.map((entry) => entry.questionId));
+      return "consumer succeeded";
+    }, dispose() {} }),
+  });
+  assert.equal((await makePool(faulted).execute(task("task-1", "alpha", "receipt fault"))).status, "continuation", "a durable consumer receipt prevents terminal failure when acceptance publication faults");
+  const receipt = readWorkflowJournal(projectRoot, "session-1").find((event) => event.type === "question.transition" && (event.payload as any).operation === "task-delivery-consumed");
+  assert.equal(typeof (receipt?.payload as any)?.promptHash, "string");
+  assert.equal((receipt?.payload as any)?.attemptId, "attempt-task-1");
+  assert.match((receipt?.payload as any)?.transcriptRef ?? "", /run:run-1\/node:alpha\/task:task-1\/transcript/);
+
+  const restarted = new QuestionService({ ...base.options });
+  const q2 = restarted.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Second?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "receipt-q2" } });
+  restarted.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q2.questionId, expectedState: "pending", value: false, channel: "command", claimedIdentity: "human", credential: "secret", operationId: "receipt-a2" });
+  assert.equal((await makePool(restarted).execute(task("task-1", "alpha", "receipt fault"))).status, "completed");
+  assert.equal((await makePool(new QuestionService({ ...base.options })).execute(task("task-1", "alpha", "receipt fault"))).status, "completed");
+  assert.deepEqual(seen, [[q1.questionId], [q2.questionId], []]);
+});
+
+test("maximum JSON-escaped whitespace question and answer are included losslessly before consumption", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-max-question-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "maximum answer", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  const questions = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "maximum-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const maximum = "\n".repeat(QUESTION_LIMITS.textAnswerBytes);
+  const maximumPrompt = `${"\n".repeat(QUESTION_LIMITS.promptBytes - 1)}x`;
+  const question = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: maximumPrompt, kind: "text", validation: { maxLength: QUESTION_LIMITS.textAnswerBytes }, required: true }, provenance: { source: "human_question", toolCallId: "maximum-call" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: maximum, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "maximum-answer" });
+  let prompt = "";
+  const result = await new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({ linkedSessionId: "maximum", async prompt(text) { prompt = text; return "consumed"; }, dispose() {} }) }).execute(task("task-1", "alpha", "maximum answer"));
+  assert.equal(result.status, "completed");
+  assert.match(prompt, /human-answer:maximum-question/);
+  assert.ok(questions.restore().questions[question.questionId].taskDeliveryAcceptedSequence);
+});
+
+test("maximum-size JSON-escaped worker answers are delivered in exact lossless pages across failure and restart", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-answer-pages-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "paged maximum answers", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let questionSequence = 0;
+  const questionOptions = {
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => `paged-question-${++questionSequence}`, authenticateControl: (request: any) => request.claimedIdentity,
+  };
+  const questions = new QuestionService(questionOptions);
+  const maximum = "\n".repeat(QUESTION_LIMITS.textAnswerBytes);
+  const maximumPrompt = `${"\n".repeat(QUESTION_LIMITS.promptBytes - 1)}x`;
+  const questionIds: string[] = [];
+  for (let index = 0; index < 3; index++) {
+    const question = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: maximumPrompt, kind: "text", required: true }, provenance: { source: "human_question", toolCallId: `paged-call-${index}` } });
+    questionIds.push(question.questionId);
+    questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: maximum, channel: "dashboard", claimedIdentity: "human", operationId: `paged-answer-${index}` });
+    questions.prepareTaskAnswerDeliveries("task-1", [question.questionId]);
+  }
+  assert.equal(questions.preparedTaskAnswerDeliveries("task-1").length, 3);
+
+  const pages: string[][] = [];
+  let failFirstPage = true;
+  const execute = (service: QuestionService) => new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions: service,
+    factory: async () => ({ linkedSessionId: "paged-worker", async prompt(_text, _signal, invocation) {
+      const answers = invocation!.promptContext.taskContract.acceptedAnswers;
+      assert.ok(answers.length > 0);
+      assert.equal(answers.every((answer) => answer.answer.value === maximum), true);
+      pages.push(answers.map((answer) => answer.questionId));
+      if (failFirstPage) {
+        failFirstPage = false;
+        throw Object.assign(new Error("known page provider failure"), { effectNotApplied: true, assistantOutputObserved: false, toolCallObserved: false });
+      }
+      return "page consumed";
+    }, dispose() {} }),
+  }).execute(task("task-1", "alpha", "paged maximum answers"));
+
+  assert.equal((await execute(questions)).status, "continuation");
+  assert.equal(questionIds.every((questionId) => questions.restore().questions[questionId].taskDeliveryReceipt === undefined), true, "a failed page acknowledges nothing");
+  const restarted = new QuestionService(questionOptions);
+  await execute(restarted);
+  const firstAcceptedPage = new Set(pages[1]);
+  for (const questionId of questionIds) {
+    const restored = restarted.restore().questions[questionId];
+    assert.equal(restored.taskDeliveryReceipt !== undefined, firstAcceptedPage.has(questionId), "only the exact fitting page receives a consumer receipt");
+    assert.equal(restored.taskDeliveryAcceptedSequence !== undefined, firstAcceptedPage.has(questionId), "only the exact fitting page is accepted");
+  }
+  for (let page = 1; page < 10 && restarted.preparedTaskAnswerDeliveries("task-1").length; page++) await execute(restarted);
+
+  assert.deepEqual(pages[1], pages[0], "the failed exact page is retried unchanged after restart");
+  assert.ok(pages[0].length < questionIds.length, "the aggregate must require more than one prompt page");
+  const successfulIds = pages.slice(1).flat();
+  assert.deepEqual(successfulIds, questionIds, "successful pages are ordered, lossless, and non-overlapping");
+  assert.equal(new Set(successfulIds).size, questionIds.length);
+  assert.equal(restarted.preparedTaskAnswerDeliveries("task-1").length, 0);
+  for (const questionId of questionIds) {
+    const restored = restarted.restore().questions[questionId];
+    assert.ok(restored.taskDeliveryReceipt);
+    assert.ok(restored.taskDeliveryAcceptedSequence);
+  }
+});
+
+test("worker retries a before-publication consumer receipt without presenting the answer twice", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-receipt-before-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "receipt before", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  const base = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "receipt-before-question", authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const question = base.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Receipt?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "receipt-before-call" } });
+  base.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: question.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "receipt-before-answer" });
+  base.prepareTaskAnswerDeliveries("task-1");
+  let failed = false;
+  const questions = new QuestionService({ ...base.options, journalFault: (_type, stage) => {
+    if (!failed && stage === "beforeRename") { failed = true; throw new Error("receipt before-publication fault"); }
+  } });
+  const seen: string[][] = [];
+  const result = await new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({ linkedSessionId: "receipt-before", async prompt(_text, _signal, invocation) {
+      seen.push(invocation!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.questionId));
+      return "completed";
+    }, dispose() {} }),
+  }).execute(task("task-1", "alpha", "receipt before"));
+  assert.equal(result.status, "completed");
+  assert.deepEqual(seen, [[question.questionId]]);
+  const restored = base.restore().questions[question.questionId];
+  assert.ok(restored.taskDeliveryReceipt);
+  assert.ok(restored.taskDeliveryAcceptedSequence);
+});
+
+test("persistent live-worker receipt fault survives pool restart and replays the successful attempt without provider redispatch", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-live-receipt-restart-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "live receipt restart", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let transitionWrites = 0;
+  const baseOptions = { projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "live-receipt-question", authenticateControl: (request: any) => request.credential === "secret" ? request.claimedIdentity : undefined };
+  const faulted = new QuestionService({ ...baseOptions, journalFault: (_type, stage) => {
+    if (stage === "beforeRename" && ++transitionWrites >= 5) throw new Error("persistent worker receipt stop");
+  } });
+  const attempts = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  const dispatchModel: WorkerModelDispatcher = (input) => executeWithConservativeRetry<string | import("../../src/workflows/workers.ts").WorkerPromptResponse>(attempts, {
+    correlationId: `live-worker-${input.promptHash}`, nodeId: "alpha", operation: "worker.provider.prompt", input: { taskId: "task-1", promptHash: input.promptHash },
+    descriptor: attemptDescriptorForModel(),
+    consumerReceipt: { deliveryIds: input.questionDeliveryIds, promptHash: input.promptHash, transcriptRef: input.transcriptRef },
+    consumerReceiptAfterDispatch: () => ({ deliveryIds: input.resolveQuestionDeliveryIds(), promptHash: input.promptHash, transcriptRef: input.transcriptRef }),
+    onConsumerCompleted: input.onConsumerSuccess,
+    dispatch: input.invoke,
+  });
+  let providerCalls = 0;
+  const makePool = (questions: QuestionService) => new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions, dispatchModel,
+    factory: async () => ({ linkedSessionId: "live-receipt-linked", async prompt(_text, _signal, invocation) {
+      providerCalls++;
+      await questions.createAndPresent({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Live receipt?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "live-receipt-call" } },
+        async () => ({ value: true, claimedIdentity: "human", credential: "secret", operationId: "live-receipt-answer" }));
+      assert.equal(invocation!.promptContext.taskContract.acceptedAnswers.length, 0);
+      return "durable live worker result";
+    }, dispose() {} }),
+  });
+  assert.equal((await makePool(faulted).execute(task("task-1", "alpha", "live receipt restart"))).status, "continuation");
+  const completed = Object.values(attempts.restore().attempts)[0];
+  assert.equal(completed.status, "completed");
+  assert.equal(completed.intentConsumerReceipt?.deliveryIds.length, 0);
+  assert.equal(completed.consumerReceipt?.deliveryIds.length, 1);
+
+  const restartedQuestions = new QuestionService(baseOptions);
+  restartedQuestions.reconcileAnswerDeliveryReceipts();
+  const restoredQuestion = restartedQuestions.restore().questions["live-receipt-question"];
+  assert.ok(restoredQuestion.taskDeliveryReceipt);
+  assert.ok(restoredQuestion.taskDeliveryAcceptedSequence);
+  const restartedAttempts = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  const replayPool = new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions: restartedQuestions,
+    dispatchModel: (input: any) => executeWithConservativeRetry(restartedAttempts, {
+      correlationId: `live-worker-${input.promptHash}`, nodeId: "alpha", operation: "worker.provider.prompt", input: { taskId: "task-1", promptHash: input.promptHash },
+      descriptor: attemptDescriptorForModel(), consumerReceipt: { deliveryIds: input.questionDeliveryIds, promptHash: input.promptHash, transcriptRef: input.transcriptRef },
+      consumerReceiptAfterDispatch: () => ({ deliveryIds: input.resolveQuestionDeliveryIds(), promptHash: input.promptHash, transcriptRef: input.transcriptRef }),
+      onConsumerCompleted: input.onConsumerSuccess, dispatch: input.invoke,
+    }),
+    factory: async () => ({ linkedSessionId: "live-receipt-restarted", async prompt() { providerCalls++; return "must not redispatch"; }, dispose() {} }),
+  });
+  const replayed = await replayPool.execute(task("task-1", "alpha", "live receipt restart"));
+  assert.equal(replayed.status, "completed");
+  assert.equal(providerCalls, 1);
+  assert.deepEqual(restartedQuestions.prepareTaskAnswerDeliveries("task-1"), []);
+});
+
+test("worker restart replay receipts only durable final deliveries and leaves a newer answer for same-attempt continuation", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-replay-new-answer-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "replay then continue", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let questionSequence = 0;
+  const questionOptions = {
+    projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => `replay-question-${++questionSequence}`, authenticateControl: (request: any) => request.claimedIdentity,
+  };
+  const questions = new QuestionService(questionOptions);
+  const q1 = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "First?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "replay-q1" } });
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q1.questionId, expectedState: "pending", value: true, channel: "dashboard", claimedIdentity: "human", operationId: "replay-a1" });
+
+  const attempts = new AttemptRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1" });
+  let q3Id = "";
+  let firstProviderCalls = 0;
+  const firstPool = new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    dispatchModel: (input) => executeWithConservativeRetry(attempts, {
+      correlationId: "worker-reused-correlation", nodeId: "alpha", operation: "worker.provider.prompt",
+      input: { taskId: "task-1", promptHash: input.promptHash }, replayInput: { taskId: "task-1" }, descriptor: attemptDescriptorForModel(),
+      consumerReceipt: { deliveryIds: input.questionDeliveryIds, promptHash: input.promptHash, transcriptRef: input.transcriptRef },
+      consumerReceiptAfterDispatch: () => ({ deliveryIds: input.resolveQuestionDeliveryIds(), promptHash: input.promptHash, transcriptRef: input.transcriptRef }),
+      onConsumerCompleted: () => { throw new Error("process stopped before receipt settlement"); }, dispatch: input.invoke,
+    }),
+    factory: async () => ({ linkedSessionId: "first-worker", async prompt() {
+      firstProviderCalls++;
+      await questions.createAndPresent({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Second live?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "replay-q2" } },
+        async () => ({ value: true, claimedIdentity: "human", operationId: "replay-a2" }));
+      q3Id = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Third later?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "replay-q3" } }).questionId;
+      return "old durable result";
+    }, dispose() {} }),
+  });
+  await firstPool.execute(delegation.restore().tasks["task-1"]);
+  const completedAttempt = Object.values(attempts.restore().attempts).find((attempt) => attempt.status === "completed")!;
+  assert.equal(firstProviderCalls, 1);
+  assert.equal(completedAttempt.consumerReceipt?.deliveryIds.length, 2);
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q3Id, expectedState: "pending", value: false, channel: "dashboard", claimedIdentity: "human", operationId: "replay-a3" });
+
+  const restartedQuestions = new QuestionService(questionOptions);
+  restartedQuestions.reconcileAnswerDeliveryReceipts();
+  delegation.start("task-1", "attempt-task-1");
+  const resumeTask = delegation.restore().tasks["task-1"];
+  const recoveryAttemptId = restartedQuestions.containingAttemptForTaskContinuation("task-1", resumeTask.resumedByQuestionSequence);
+  assert.equal(recoveryAttemptId, completedAttempt.attemptId);
+  let replayProviderCalls = 0;
+  const replayPool = new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions: restartedQuestions,
+    dispatchModel: (input) => executeWithConservativeRetry(new AttemptRuntime(attempts.options), {
+      correlationId: "worker-reused-correlation", nodeId: "alpha", operation: "worker.provider.prompt",
+      input: { taskId: "task-1", promptHash: input.promptHash }, replayInput: { taskId: "task-1" }, recoveryAttemptId,
+      recoveryConsumerReceipt: completedAttempt.consumerReceipt,
+      descriptor: attemptDescriptorForModel(), consumerReceipt: { deliveryIds: input.questionDeliveryIds, promptHash: input.promptHash, transcriptRef: input.transcriptRef },
+      onConsumerCompleted: input.onConsumerSuccess, dispatch: input.invoke,
+    }),
+    factory: async () => ({ linkedSessionId: "replay-worker", async prompt() { replayProviderCalls++; return "must not redispatch old result"; }, dispose() {} }),
+  });
+  const replayed = await replayPool.execute(resumeTask);
+  assert.equal(replayed.status, "continuation");
+  assert.equal(replayProviderCalls, 0);
+  let durableQ3 = restartedQuestions.restore().questions[q3Id];
+  assert.equal(durableQ3.taskDeliveryReceipt, undefined, "old attempt must not receipt the newer answer");
+  assert.equal(durableQ3.taskDeliveryAcceptedSequence, undefined);
+  if (replayed.status !== "continuation") assert.fail("replayed containing turn must continue to the newer answer");
+  delegation.start("task-1", "attempt-task-1");
+  const nextTask = delegation.restore().tasks["task-1"];
+  assert.equal(restartedQuestions.containingAttemptForTaskContinuation("task-1", nextTask.resumedByQuestionSequence), undefined,
+    "the durable containing attempt may be replayed only by the first launch for its resume marker");
+
+  let subsequentQuestionIds: readonly string[] = [];
+  const continuationPool = new WorkerSessionPool({
+    projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions: restartedQuestions,
+    factory: async () => ({ linkedSessionId: "continuation-worker", async prompt(_text, _signal, invocation) {
+      subsequentQuestionIds = invocation!.promptContext.taskContract.acceptedAnswers.map((answer) => answer.questionId);
+      return "new continuation result";
+    }, dispose() {} }),
+  });
+  const continued = await continuationPool.execute(resumeTask);
+  assert.equal(continued.status, "completed");
+  assert.deepEqual(subsequentQuestionIds, [q3Id]);
+  durableQ3 = restartedQuestions.restore().questions[q3Id];
+  assert.ok(durableQ3.taskDeliveryAcceptedSequence);
+});
+
+test("after-publication live-worker receipt faults reconcile without duplicate provider or answer delivery", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-live-receipt-after-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "after receipt", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let writes = 0;
+  const questions = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => "live-after-question", authenticateControl: (request) => request.claimedIdentity,
+    journalFault: (_type, stage) => { if (stage === "afterRename" && ++writes >= 5) throw new Error("stop after receipt publication"); } });
+  let providerCalls = 0;
+  const result = await new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({ linkedSessionId: "live-after", async prompt() {
+      providerCalls++;
+      await questions.createAndPresent({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "After?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "live-after-call" } },
+        async () => ({ value: true, claimedIdentity: "human", operationId: "live-after-answer" }));
+      return "after publication";
+    }, dispose() {} }) }).execute(task("task-1", "alpha", "after receipt"));
+  assert.equal(result.status, "completed");
+  assert.equal(providerCalls, 1);
+  const restored = new QuestionService({ ...questions.options, journalFault: undefined }).restore().questions["live-after-question"];
+  assert.ok(restored.taskDeliveryReceipt);
+  assert.ok(restored.taskDeliveryAcceptedSequence);
+});
+
+test("a live first answer followed by an offline second question does not re-inject the live answer", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-question-live-offline-"));
+  const activeSnapshot = snapshot() as any;
+  const authority = activeSnapshot.payload.authority.nodes.find((entry: any) => entry.nodeId === "alpha");
+  authority.capabilities.effective = { ...(authority.capabilities.effective ?? {}), "human-input": true };
+  authority.tools = [...new Set([...authority.tools, "human_question"])].sort();
+  const delegation = new DelegationRuntime({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, createTaskId: () => "task-1" });
+  delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "alpha", objective: "live then offline", deliverables: [] });
+  delegation.start("task-1", "attempt-task-1");
+  let sequence = 0;
+  const questions = new QuestionService({ projectRoot, projectId: "project-1", sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot,
+    createQuestionId: () => `live-offline-${++sequence}`, authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
+  const seen: string[][] = [];
+  let q2 = "";
+  let turn = 0;
+  const pool = new WorkerSessionPool({ projectRoot, sessionId: "session-1", runId: "run-1", snapshot: activeSnapshot, questions,
+    factory: async () => ({ linkedSessionId: "linked-alpha", async prompt(_text, _signal, invocation) {
+      seen.push(invocation!.promptContext.taskContract.acceptedAnswers.map((entry) => entry.questionId));
+      if (turn++ === 0) {
+        await questions.createAndPresent({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Live?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "live-q1" } },
+          async () => ({ value: true, claimedIdentity: "human", credential: "secret", operationId: "live-a1" }));
+        q2 = questions.create({ nodeId: "alpha", taskId: "task-1", definition: { prompt: "Offline?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "offline-q2" } }).questionId;
+      }
+      return "turn";
+    }, dispose() {} }),
+  });
+  assert.equal((await pool.execute(task("task-1", "alpha", "live then offline"))).status, "suspended");
+  questions.answer({ projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: q2, expectedState: "pending", value: false, channel: "dashboard", claimedIdentity: "human", credential: "secret", operationId: "offline-a2" });
+  assert.equal((await pool.execute(task("task-1", "alpha", "live then offline"))).status, "completed");
+  assert.deepEqual(seen, [[], [q2]]);
+});
+
 test("worker result output is bounded and active execution settlement is observable", async () => {
   const projectRoot = mkdtempSync(join(tmpdir(), "hive-workers-cleanup-"));
   let aborts = 0;
@@ -214,7 +714,7 @@ test("worker result output is bounded and active execution settlement is observa
   assert.equal(pool.hasLiveHandles(), true);
   release();
   const result = await pending;
-  if (result.status === "suspended") assert.fail("non-delegating worker must return a terminal result");
+  if (result.status === "suspended" || result.status === "continuation") assert.fail("non-delegating worker must return a terminal result");
   assert.ok(Buffer.byteLength(result.summary, "utf8") <= 64);
   assert.equal(await pool.waitForSettlement(100), true);
   assert.equal(aborts, 1);


### PR DESCRIPTION
## Summary
- add journal-backed typed human questions with authenticated first-answer CAS and terminal closure
- preserve same-attempt root and worker transcript delivery across restart, races, and recovery
- integrate question-aware scheduling, wait causes, cancellation, budgets, and bounded control DTOs
- enforce lossless bounded prompt delivery and closed validation/command parsing

## Validation
- 226 focused workflow/config tests
- `just verify` (937 Node tests, 73 Bun tests, all gates)
- package dry-run and package budgets
- two independent fresh-context adversarial reviews with no blocker, high, or required findings