### PR TITLE
feat(observability): add workflow telemetry projection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -350,6 +350,8 @@ test-node-compat:
     tests/knowledge/knowledge-search.test.ts \
     tests/knowledge/okf-provider.test.ts \
     tests/orchestration/governance.test.ts \
+    tests/observability/workflow-dashboard-api.test.ts \
+    tests/observability/workflow-telemetry.test.ts \
     tests/core/limits.test.ts \
     tests/core/project-identity.test.ts \
     tests/core/safe-path.test.ts \

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -5,12 +5,12 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
-// Durable knowledge enrichment adds the shipped curator, queue/accounting, and
-// proposal runtime, including descriptor-rooted mutation staging with pinned
-// rollback/validation traversal. The existing 10% ceiling remains unchanged.
+// W24 ships readable Node-safe projection/redaction/prune source plus the
+// Bun-isolated SQLite projection/runtime. These are measured package bytes;
+// the existing 10% regression tolerance remains unchanged.
 export const PACKAGE_BASELINES = Object.freeze({
-  packedBytes: 676_280,
-  unpackedBytes: 2_665_841,
+  packedBytes: 770_764,
+  unpackedBytes: 3_055_514,
   reviewRawBytes: 12_625,
   reviewCompressedBytes: 4_304,
 });

--- a/src/observability/events.ts
+++ b/src/observability/events.ts
@@ -1,0 +1,384 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "../config/snapshot-canonical";
+import type { JsonValue } from "../config/types";
+import { verifyWorkflowEvent, type WorkflowEventEnvelope } from "../workflows/events";
+import { redactProjectionValue, type WorkflowRedactionOptions } from "./redaction";
+
+export const WORKFLOW_TELEMETRY_SCHEMA_VERSION = 1 as const;
+export const WORKFLOW_TELEMETRY_LIMITS = Object.freeze({ summaryBytes: 2_048, refs: 64, refBytes: 1_024, dimensionBytes: 1_024, numericMagnitude: 1_000_000_000_000 });
+
+export interface WorkflowTelemetryContext {
+  readonly projectRoot?: string;
+  readonly projectLabel?: string;
+  readonly piSessionId?: string;
+  readonly workflowId?: string;
+  readonly snapshotId?: string;
+  readonly workflowConfigHash?: string;
+  readonly workflowConfigVersion?: string;
+  readonly redaction?: WorkflowRedactionOptions;
+}
+
+export interface WorkflowTelemetryDimensions {
+  readonly projectId: string;
+  readonly projectRoot?: string;
+  readonly projectLabel?: string;
+  readonly sessionId: string;
+  readonly piSessionId?: string;
+  readonly workflowId?: string;
+  readonly snapshotId?: string;
+  readonly workflowConfigHash?: string;
+  readonly workflowConfigVersion?: string;
+  readonly runId?: string;
+  readonly agentId?: string;
+  readonly agentName?: string;
+  readonly nodeId?: string;
+  readonly parentNodeId?: string;
+  readonly taskId?: string;
+  readonly adapterId?: string;
+  readonly adapterVersion?: string;
+  readonly profileId?: string;
+  readonly profileVersion?: string;
+  readonly workspaceId?: string;
+  readonly workspaceHash?: string;
+  readonly leaseState?: string;
+  readonly questionId?: string;
+  readonly checkpointId?: string;
+  readonly approvalId?: string;
+  readonly knowledgeJobId?: string;
+  readonly knowledgeUpdateId?: string;
+  readonly modelId?: string;
+  readonly thinking?: string;
+  readonly toolName?: string;
+  readonly capabilityId?: string;
+  readonly attemptId?: string;
+  readonly operationId?: string;
+}
+
+export interface WorkflowTelemetryUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly costMicroUsd: number;
+  readonly precision: "estimated" | "provider-confirmed";
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly reasoningTokens?: number;
+}
+
+export interface WorkflowTelemetryMetrics {
+  readonly elapsedMs?: number;
+  readonly activeWallTimeMs?: number;
+  readonly budgetScope?: string;
+  readonly budgetUsed?: number;
+  readonly budgetLimit?: number;
+  readonly budgetRemaining?: number;
+}
+
+export interface WorkflowTelemetryTerminal {
+  readonly status?: string;
+  readonly changeCoverage?: string;
+  readonly terminalEventHash?: string;
+  readonly refs: readonly string[];
+}
+
+export interface WorkflowTelemetryEvent {
+  readonly schemaVersion: 1;
+  readonly streamId: string;
+  readonly eventId: string;
+  readonly eventType: string;
+  readonly timestamp: string;
+  readonly producer: string;
+  readonly sequence: number;
+  readonly previousHash: string | null;
+  readonly payloadHash: string;
+  /** Hash of the verified authoritative journal envelope. */
+  readonly sourceEventHash: string;
+  /** Hash of every projected field, including the source journal linkage. */
+  readonly eventHash: string;
+  readonly correlationId?: string;
+  readonly dimensions: WorkflowTelemetryDimensions;
+  readonly status?: string;
+  readonly operation?: string;
+  readonly summary?: string;
+  readonly refs: readonly string[];
+  readonly usage?: WorkflowTelemetryUsage;
+  readonly metrics?: WorkflowTelemetryMetrics;
+  readonly terminal?: WorkflowTelemetryTerminal;
+  readonly metadata: JsonValue;
+}
+
+const TRUSTED_WORKFLOW_TELEMETRY_EVENT = Symbol("trusted-workflow-telemetry-event");
+const SHA256 = /^[0-9a-f]{64}$/u;
+type TrustedWorkflowTelemetryEvent = WorkflowTelemetryEvent & { readonly [TRUSTED_WORKFLOW_TELEMETRY_EVENT]: true };
+
+type RecordValue = Record<string, unknown>;
+
+function projectionHash(value: Omit<WorkflowTelemetryEvent, "eventHash">): string {
+  return createHash("sha256").update("pi-hive-workflow-telemetry-event-v1\0").update(canonicalJson(value)).digest("hex");
+}
+
+function frame(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  const length = Buffer.alloc(8);
+  length.writeBigUInt64BE(BigInt(bytes.length));
+  return Buffer.concat([length, bytes]);
+}
+
+function verifyProjectedIdentity(value: WorkflowTelemetryEvent): void {
+  const dimensionValues = value?.dimensions && typeof value.dimensions === "object" ? Object.values(value.dimensions) : [];
+  const numericValues = [value?.usage?.inputTokens, value?.usage?.outputTokens, value?.usage?.costMicroUsd, value?.usage?.cacheReadTokens,
+    value?.usage?.cacheWriteTokens, value?.usage?.reasoningTokens, value?.metrics?.elapsedMs, value?.metrics?.activeWallTimeMs,
+    value?.metrics?.budgetUsed, value?.metrics?.budgetLimit, value?.metrics?.budgetRemaining].filter((entry): entry is number => entry !== undefined);
+  if (!value || typeof value !== "object" || !value.dimensions || typeof value.dimensions !== "object"
+    || typeof value.dimensions.projectId !== "string" || typeof value.dimensions.sessionId !== "string"
+    || dimensionValues.some((entry) => typeof entry !== "string" || !entry || Buffer.byteLength(entry, "utf8") > WORKFLOW_TELEMETRY_LIMITS.dimensionBytes)
+    || typeof value.streamId !== "string" || typeof value.eventId !== "string" || typeof value.eventType !== "string"
+    || typeof value.timestamp !== "string" || !Number.isFinite(Date.parse(value.timestamp)) || typeof value.producer !== "string" || !Number.isSafeInteger(value.sequence) || value.sequence < 1
+    || !Array.isArray(value.refs) || value.refs.length > WORKFLOW_TELEMETRY_LIMITS.refs || value.refs.some((entry) => typeof entry !== "string" || Buffer.byteLength(entry, "utf8") > WORKFLOW_TELEMETRY_LIMITS.refBytes)
+    || numericValues.some((entry) => !Number.isFinite(entry) || entry < 0 || entry > WORKFLOW_TELEMETRY_LIMITS.numericMagnitude)
+    || (value.usage && [value.usage.inputTokens, value.usage.outputTokens, value.usage.costMicroUsd, value.usage.cacheReadTokens, value.usage.cacheWriteTokens, value.usage.reasoningTokens]
+      .filter((entry): entry is number => entry !== undefined).some((entry) => !Number.isSafeInteger(entry)))) throw new Error("Workflow telemetry persisted event shape is invalid");
+  const dimensionHashes = [value.dimensions.workflowConfigHash, value.dimensions.workspaceHash, value.terminal?.terminalEventHash].filter((hash): hash is string => hash !== undefined);
+  if (value.schemaVersion !== 1 || !SHA256.test(value.eventHash) || !SHA256.test(value.payloadHash) || !SHA256.test(value.sourceEventHash)
+    || (value.previousHash !== null && !SHA256.test(value.previousHash))
+    || dimensionHashes.some((hash) => !SHA256.test(hash) && !/^sha256:[0-9a-f]{64}$/u.test(hash))) throw new Error("Workflow telemetry hash format is invalid");
+  if (value.streamId !== workflowTelemetryStreamId(value.dimensions.projectId, value.dimensions.sessionId)) throw new Error("Workflow telemetry stream identity mismatch");
+  const { eventHash, ...identity } = value;
+  if (projectionHash(identity) !== eventHash) throw new Error("Workflow telemetry projected event hash mismatch");
+}
+
+export function verifyWorkflowTelemetryEvent(value: WorkflowTelemetryEvent): asserts value is TrustedWorkflowTelemetryEvent {
+  if ((value as Partial<TrustedWorkflowTelemetryEvent>)[TRUSTED_WORKFLOW_TELEMETRY_EVENT] !== true) throw new Error("Workflow telemetry event lacks trusted journal authentication");
+  verifyProjectedIdentity(value);
+}
+
+/** Re-authenticates a persisted projection row from its complete committed event hash. */
+export function restoreWorkflowTelemetryEvent(value: unknown): WorkflowTelemetryEvent {
+  const event = value as WorkflowTelemetryEvent;
+  verifyProjectedIdentity(event);
+  Object.defineProperty(event, TRUSTED_WORKFLOW_TELEMETRY_EVENT, { value: true, enumerable: false, writable: false });
+  return Object.freeze(event);
+}
+
+function record(value: unknown): RecordValue | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as RecordValue : undefined;
+}
+
+function findValue(root: RecordValue, keys: readonly string[], depth = 0): unknown {
+  for (const key of keys) if (root[key] !== undefined) return root[key];
+  if (depth >= 4) return undefined;
+  for (const child of Object.values(root)) {
+    const nested = record(child);
+    if (!nested) continue;
+    const found = findValue(nested, keys, depth + 1);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function stringValue(root: RecordValue, keys: readonly string[], maxBytes = 1_024): string | undefined {
+  const value = findValue(root, keys);
+  if (typeof value !== "string" || !value) return undefined;
+  let output = "";
+  let bytes = 0;
+  for (const character of value) {
+    const size = Buffer.byteLength(character, "utf8");
+    if (bytes + size > maxBytes) break;
+    output += character;
+    bytes += size;
+  }
+  return output || undefined;
+}
+
+function boundedNonnegative(value: unknown, label: string, fallback?: number): number | undefined {
+  if (value === undefined) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > WORKFLOW_TELEMETRY_LIMITS.numericMagnitude) throw new Error(`Workflow telemetry ${label} magnitude is invalid`);
+  return value;
+}
+
+function optionalNonnegative(root: RecordValue, keys: readonly string[], label: string): number | undefined {
+  return boundedNonnegative(findValue(root, keys), label);
+}
+
+function boundedUsage(value: unknown, label: string, fallback?: number): number {
+  const result = boundedNonnegative(value, label, fallback);
+  if (result === undefined || !Number.isSafeInteger(result)) throw new Error(`Workflow telemetry ${label} must be a safe integer`);
+  return result;
+}
+
+function metrics(root: RecordValue): WorkflowTelemetryMetrics | undefined {
+  const result: WorkflowTelemetryMetrics = {
+    ...(optionalNonnegative(root, ["elapsedMs", "durationMs"], "elapsed metric") !== undefined ? { elapsedMs: optionalNonnegative(root, ["elapsedMs", "durationMs"], "elapsed metric") } : {}),
+    ...(optionalNonnegative(root, ["activeWallTimeMs"], "active wall-time metric") !== undefined ? { activeWallTimeMs: optionalNonnegative(root, ["activeWallTimeMs"], "active wall-time metric") } : {}),
+    ...(stringValue(root, ["budgetScope"]) ? { budgetScope: stringValue(root, ["budgetScope"]) } : {}),
+    ...(optionalNonnegative(root, ["budgetUsed"], "budget-used metric") !== undefined ? { budgetUsed: optionalNonnegative(root, ["budgetUsed"], "budget-used metric") } : {}),
+    ...(optionalNonnegative(root, ["budgetLimit"], "budget-limit metric") !== undefined ? { budgetLimit: optionalNonnegative(root, ["budgetLimit"], "budget-limit metric") } : {}),
+    ...(optionalNonnegative(root, ["budgetRemaining"], "budget-remaining metric") !== undefined ? { budgetRemaining: optionalNonnegative(root, ["budgetRemaining"], "budget-remaining metric") } : {}),
+  };
+  return Object.keys(result).length ? Object.freeze(result) : undefined;
+}
+
+function usage(root: RecordValue): WorkflowTelemetryUsage | undefined {
+  const candidate = record(findValue(root, ["usage", "providerUsage"]));
+  if (!candidate) return undefined;
+  const precision: WorkflowTelemetryUsage["precision"] | undefined = candidate.precision === "provider-confirmed" ? "provider-confirmed" : candidate.precision === "estimated" ? "estimated" : undefined;
+  if (!precision) return undefined;
+  const base = {
+    inputTokens: boundedUsage(candidate.inputTokens ?? candidate.input, "input-token usage", 0),
+    outputTokens: boundedUsage(candidate.outputTokens ?? candidate.output, "output-token usage", 0),
+    costMicroUsd: boundedUsage(candidate.costMicroUsd, "cost usage", 0),
+    precision,
+  };
+  return Object.freeze({
+    ...base,
+    ...(candidate.cacheReadTokens !== undefined ? { cacheReadTokens: boundedUsage(candidate.cacheReadTokens, "cache-read usage") } : {}),
+    ...(candidate.cacheWriteTokens !== undefined ? { cacheWriteTokens: boundedUsage(candidate.cacheWriteTokens, "cache-write usage") } : {}),
+    ...(candidate.reasoningTokens !== undefined ? { reasoningTokens: boundedUsage(candidate.reasoningTokens, "reasoning-token usage") } : {}),
+  });
+}
+
+const REFERENCE_ARRAY_KEYS = new Set(["refs", "references", "artifactRefs", "evidenceRefs", "checkpointRefs", "knowledgeRefs", "knowledgeJobRefs", "knowledgeUpdateRefs"]);
+const REFERENCE_ID_KEYS = new Set(["id", "workspaceId", "checkpoint", "checkpointId", "toolCallId", "eventId", "candidateId", "knowledgeJobId", "knowledgeUpdateId", "jobId", "updateId"]);
+const REFERENCE_HASH_KEYS = new Set(["digest", "hash", "contentHash", "eventHash", "payloadHash", "sourceHash", "terminalEventHash"]);
+
+function referenceArrays(root: RecordValue, depth = 0): ReadonlyArray<readonly [string, readonly unknown[]]> {
+  const output: Array<readonly [string, readonly unknown[]]> = [];
+  for (const [key, value] of Object.entries(root)) {
+    if (REFERENCE_ARRAY_KEYS.has(key) && Array.isArray(value)) output.push([key, value]);
+    if (depth >= 4) continue;
+    const nested = record(value);
+    if (nested) output.push(...referenceArrays(nested, depth + 1));
+  }
+  return output;
+}
+
+function refs(root: RecordValue, options: WorkflowRedactionOptions): readonly string[] {
+  const output: string[] = [];
+  const seen = new Set<string>();
+  const push = (raw: string): void => {
+    if (!raw || output.length >= WORKFLOW_TELEMETRY_LIMITS.refs) return;
+    const value = String(redactProjectionValue(raw, { ...options, maxStringBytes: WORKFLOW_TELEMETRY_LIMITS.refBytes }));
+    if (!value || seen.has(value)) return;
+    seen.add(value); output.push(value);
+  };
+  for (const [field, values] of referenceArrays(root)) {
+    for (const value of values) {
+      if (typeof value === "string") { push(value); continue; }
+      const structured = record(value);
+      if (!structured) continue;
+      for (const [key, candidate] of Object.entries(structured)) {
+        if (typeof candidate !== "string" || !candidate) continue;
+        if (REFERENCE_ID_KEYS.has(key)) push(candidate);
+        else if (REFERENCE_HASH_KEYS.has(key) && (/^sha256:[0-9a-f]{64}$/u.test(candidate) || SHA256.test(candidate))) push(candidate);
+      }
+      // Evidence claims are useful only through their authenticated identity;
+      // never copy the raw claim into telemetry when no external ID exists.
+      if (field === "evidenceRefs") push(`sha256:${createHash("sha256").update("pi-hive-workflow-evidence-ref-v1\0").update(canonicalJson(structured)).digest("hex")}`);
+    }
+  }
+  return Object.freeze(output);
+}
+
+function dimensions(source: WorkflowEventEnvelope, payload: RecordValue, context: WorkflowTelemetryContext): WorkflowTelemetryDimensions {
+  const optional = (key: keyof WorkflowTelemetryDimensions, value: string | undefined): Record<string, string> => {
+    if (!value) return {};
+    if (Buffer.byteLength(value, "utf8") > WORKFLOW_TELEMETRY_LIMITS.dimensionBytes) throw new Error(`Workflow telemetry ${key} dimension exceeds its byte limit`);
+    return { [key]: value };
+  };
+  return Object.freeze({
+    projectId: source.projectId,
+    ...optional("projectRoot", context.projectRoot), ...optional("projectLabel", context.projectLabel),
+    sessionId: source.sessionId, ...optional("piSessionId", context.piSessionId),
+    ...optional("workflowId", context.workflowId ?? stringValue(payload, ["workflowId"])),
+    ...optional("snapshotId", context.snapshotId ?? stringValue(payload, ["snapshotId"])),
+    ...optional("workflowConfigHash", context.workflowConfigHash ?? stringValue(payload, ["workflowConfigHash", "configHash"])),
+    ...optional("workflowConfigVersion", context.workflowConfigVersion ?? stringValue(payload, ["workflowConfigVersion", "configVersion"])),
+    ...optional("runId", source.runId),
+    ...optional("agentId", stringValue(payload, ["agentId"])),
+    ...optional("agentName", stringValue(payload, ["agentName", "displayName"])),
+    ...optional("nodeId", stringValue(payload, ["nodeId", "targetNodeId"])),
+    ...optional("parentNodeId", stringValue(payload, ["parentNodeId"])),
+    ...optional("taskId", stringValue(payload, ["taskId"])),
+    ...optional("adapterId", stringValue(payload, ["adapterId"])),
+    ...optional("adapterVersion", stringValue(payload, ["adapterVersion"])),
+    ...optional("profileId", stringValue(payload, ["profileId"])),
+    ...optional("profileVersion", stringValue(payload, ["profileVersion"])),
+    ...optional("workspaceId", stringValue(payload, ["workspaceId"]) ?? stringValue(record(payload.workspace) ?? {}, ["id"])),
+    ...optional("workspaceHash", stringValue(payload, ["workspaceHash", "finalWorkspaceHash"])),
+    ...optional("leaseState", stringValue(payload, ["leaseState"])),
+    ...optional("questionId", stringValue(payload, ["questionId"])),
+    ...optional("checkpointId", stringValue(payload, ["checkpointId"])),
+    ...optional("approvalId", stringValue(payload, ["approvalId", "requestId", "decisionId"])),
+    ...optional("knowledgeJobId", stringValue(payload, ["knowledgeJobId", "jobId"])),
+    ...optional("knowledgeUpdateId", stringValue(payload, ["knowledgeUpdateId", "updateId"])),
+    ...optional("modelId", stringValue(payload, ["modelId", "model"])),
+    ...optional("thinking", stringValue(payload, ["thinking"])),
+    ...optional("toolName", stringValue(payload, ["toolName"])),
+    ...optional("capabilityId", stringValue(payload, ["capabilityId", "capability"])),
+    ...optional("attemptId", source.attemptId ?? stringValue(payload, ["attemptId"])),
+    ...optional("operationId", source.correlationId ?? stringValue(payload, ["operationId"])),
+  }) as unknown as WorkflowTelemetryDimensions;
+}
+
+export function workflowTelemetryStreamId(projectId: string, sessionId: string): string {
+  const digest = createHash("sha256").update("pi-hive-workflow-telemetry-stream-v1\0").update(frame(projectId)).update(frame(sessionId)).digest("hex");
+  return `wfs1-${digest}`;
+}
+
+function eventStatus(eventType: string, payload: RecordValue, operation: string | undefined): string | undefined {
+  const explicit = stringValue(payload, ["status", "to", "state"]);
+  if (explicit) return explicit;
+  if (eventType === "question.transition") {
+    if (operation === "create") return "pending";
+    if (operation === "answer") return "answered";
+    if (operation === "close-pending") return "closed";
+  }
+  if (eventType === "approval.recorded") {
+    if (operation === "request") return "pending";
+    if (operation === "decision") return stringValue(payload, ["verdict", "decisionStatus"]) ?? "decided";
+  }
+  if (eventType === "run.started" || eventType === "task.started") return "running";
+  if (eventType === "session.created" || eventType === "session.linked" || eventType === "session.recovered") return "active";
+  if (eventType === "session.orphaned") return "orphaned";
+  return undefined;
+}
+
+export function toWorkflowTelemetryEvent(source: WorkflowEventEnvelope, context: WorkflowTelemetryContext = {}): WorkflowTelemetryEvent {
+  verifyWorkflowEvent(source);
+  const payload = record(source.payload) ?? {};
+  const redaction = context.redaction ?? {};
+  const operation = stringValue(payload, ["operation"]);
+  const status = eventStatus(source.type, payload, operation);
+  const rawSummary = stringValue(payload, ["summary", "reason", "diagnostic"], WORKFLOW_TELEMETRY_LIMITS.summaryBytes);
+  const summary = rawSummary === undefined ? undefined : String(redactProjectionValue(rawSummary, { ...redaction, maxStringBytes: WORKFLOW_TELEMETRY_LIMITS.summaryBytes }));
+  const eventRefs = refs(payload, redaction);
+  const terminal = source.type === "terminal.recorded" ? Object.freeze({
+    ...(status ? { status } : {}),
+    ...(stringValue(payload, ["changeCoverage"]) ? { changeCoverage: stringValue(payload, ["changeCoverage"]) } : {}),
+    ...(stringValue(payload, ["terminalEventHash"]) ? { terminalEventHash: stringValue(payload, ["terminalEventHash"]) } : {}),
+    refs: eventRefs,
+  }) : undefined;
+  const metadata = redactProjectionValue({ formatVersion: payload.formatVersion, operation, status }, redaction);
+  const identity: Omit<WorkflowTelemetryEvent, "eventHash"> = {
+    schemaVersion: WORKFLOW_TELEMETRY_SCHEMA_VERSION,
+    streamId: workflowTelemetryStreamId(source.projectId, source.sessionId),
+    eventId: source.eventId,
+    eventType: source.type,
+    timestamp: source.timestamp,
+    producer: source.producer,
+    sequence: source.sequence,
+    previousHash: source.previousHash,
+    payloadHash: source.payloadHash,
+    sourceEventHash: source.eventHash,
+    ...(source.correlationId ? { correlationId: source.correlationId } : {}),
+    dimensions: dimensions(source, payload, context),
+    ...(status ? { status } : {}), ...(operation ? { operation } : {}), ...(summary ? { summary } : {}),
+    refs: eventRefs,
+    ...(usage(payload) ? { usage: usage(payload) } : {}),
+    ...(metrics(payload) ? { metrics: metrics(payload) } : {}),
+    ...(terminal ? { terminal } : {}),
+    metadata,
+  };
+  const result = { ...identity, eventHash: projectionHash(identity) } as TrustedWorkflowTelemetryEvent;
+  Object.defineProperty(result, TRUSTED_WORKFLOW_TELEMETRY_EVENT, { value: true, enumerable: false, writable: false });
+  return Object.freeze(result);
+}

--- a/src/observability/journal-prune.ts
+++ b/src/observability/journal-prune.ts
@@ -1,0 +1,236 @@
+import { closeSync, constants, existsSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { canonicalJson } from "../config/snapshot-canonical";
+import { withCrossProcessFileLock } from "../core/file-lock";
+import { readWorkflowJournal, withWorkflowJournalTransaction, workflowJournalDirectory, workflowSessionDirectory } from "../workflows/journal";
+import type { WorkflowEventEnvelope } from "../workflows/events";
+
+export interface WorkflowJournalPrunePreview {
+  readonly sessionId: string;
+  readonly eventCount: number;
+  readonly runIds: readonly string[];
+  readonly firstTimestamp?: string;
+  readonly lastTimestamp?: string;
+  readonly warning: string;
+}
+
+export interface WorkflowJournalPruneRequest {
+  readonly projectRoot: string;
+  readonly sessionId: string;
+  readonly credential: string;
+  readonly operationId: string;
+  readonly confirmIrrecoverable: boolean;
+}
+
+export interface WorkflowJournalPruneAuthority {
+  readonly authenticate: (credential: string) => string | undefined;
+}
+
+export type WorkflowJournalPruneFaultStage = "afterReceipt" | "afterDetach" | "duringCleanup";
+export interface WorkflowJournalPruneServiceOptions extends WorkflowJournalPruneAuthority {
+  readonly fault?: (stage: WorkflowJournalPruneFaultStage) => void;
+}
+
+type PruneResult = Readonly<WorkflowJournalPrunePreview & { deletedEvents: number; authenticatedIdentity: string }>;
+type ReceiptStatus = "prepared" | "detached" | "completed";
+interface JournalIdentity {
+  readonly eventCount: number;
+  readonly firstEventHash: string | null;
+  readonly lastEventHash: string | null;
+  readonly eventHashesHash: string;
+  readonly contentHash: string;
+}
+interface PruneReceipt {
+  readonly protocolVersion: 1;
+  readonly status: ReceiptStatus;
+  readonly journal: JournalIdentity;
+  readonly result: PruneResult;
+}
+
+function latestRunTransition(events: readonly WorkflowEventEnvelope[], runId: string): WorkflowEventEnvelope | undefined {
+  return events.filter((event) => event.runId === runId && (event.type === "terminal.recorded" || event.type === "run.started" || event.type === "run.transition"
+    || event.type === "run.cancel.requested" || event.type === "run.cancel.settlement.failed" || event.type === "run.terminal.prepared")).at(-1);
+}
+
+function preview(events: readonly WorkflowEventEnvelope[], sessionId: string): WorkflowJournalPrunePreview {
+  const missingRunIdentity = events.find((event) => (event.type.startsWith("run.") || event.type === "terminal.recorded") && !event.runId);
+  if (missingRunIdentity) throw new Error(`Journal prune refuses lifecycle event ${missingRunIdentity.eventId} without run identity`);
+  const runIds = [...new Set(events.flatMap((event) => event.runId ? [event.runId] : []))].sort();
+  const open = runIds.filter((runId) => latestRunTransition(events, runId)?.type !== "terminal.recorded");
+  if (open.length) throw new Error(`Journal prune refuses open/nonterminal runs: ${open.join(", ")}`);
+  return Object.freeze({
+    sessionId,
+    eventCount: events.length,
+    runIds: Object.freeze(runIds),
+    ...(events[0] ? { firstTimestamp: events[0].timestamp, lastTimestamp: events.at(-1)!.timestamp } : {}),
+    warning: "Deleting this authoritative journal is irrecoverable: run audit, recovery, approvals, questions, and projection rebuild history will be lost.",
+  });
+}
+
+function fsyncDirectory(path: string): void {
+  const fd = openSync(path, constants.O_RDONLY);
+  try { fsyncSync(fd); } finally { closeSync(fd); }
+}
+
+function safeOperation(value: string): string {
+  let unsafe = false;
+  for (const character of value) if (character === "/" || character === "\\" || character.codePointAt(0)! <= 0x1f) unsafe = true;
+  if (!value || Buffer.byteLength(value, "utf8") > 256 || unsafe) throw new Error("Journal prune operation ID is invalid");
+  return createHash("sha256").update("pi-hive-journal-prune-operation-v1\0").update(value).digest("hex");
+}
+
+function exactRequest(value: WorkflowJournalPruneRequest): void {
+  const allowed = new Set(["projectRoot", "sessionId", "credential", "operationId", "confirmIrrecoverable"]);
+  if (!value || typeof value !== "object" || Object.keys(value).some((key) => !allowed.has(key))) throw new Error("Journal prune request has an unknown field");
+}
+
+function journalIdentity(events: readonly WorkflowEventEnvelope[]): JournalIdentity {
+  const eventHashes = createHash("sha256").update("pi-hive-journal-prune-event-hashes-v1\0");
+  const content = createHash("sha256").update("pi-hive-journal-prune-content-v1\0");
+  for (const event of events) {
+    eventHashes.update(String(event.sequence)).update("\0").update(event.eventHash).update("\0");
+    content.update(canonicalJson(event)).update("\n");
+  }
+  return Object.freeze({
+    eventCount: events.length,
+    firstEventHash: events[0]?.eventHash ?? null,
+    lastEventHash: events.at(-1)?.eventHash ?? null,
+    eventHashesHash: eventHashes.digest("hex"),
+    contentHash: content.digest("hex"),
+  });
+}
+
+function sameJournal(left: JournalIdentity, right: JournalIdentity): boolean {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function writeReceipt(path: string, receipt: PruneReceipt, sessionDirectory: string): void {
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(temporary, `${canonicalJson(receipt)}\n`, { mode: 0o600, flag: "wx" });
+  const fd = openSync(temporary, constants.O_RDONLY);
+  try { fsyncSync(fd); } finally { closeSync(fd); }
+  renameSync(temporary, path);
+  fsyncDirectory(sessionDirectory);
+}
+
+function validHash(value: unknown): value is string { return typeof value === "string" && /^[0-9a-f]{64}$/u.test(value); }
+
+function readReceipt(path: string, sessionId: string): PruneReceipt | undefined {
+  let parsed: unknown;
+  try { parsed = JSON.parse(readFileSync(path, "utf8")); } catch { throw new Error("Journal prune receipt is invalid"); }
+  const value = parsed as Partial<PruneReceipt>;
+  const result = value?.result as PruneResult | undefined;
+  const identity = value?.journal as JournalIdentity | undefined;
+  if (value?.protocolVersion === 1 && (value.status === "prepared" || value.status === "detached" || value.status === "completed")
+    && identity && Number.isSafeInteger(identity.eventCount) && identity.eventCount >= 0
+    && (identity.firstEventHash === null || validHash(identity.firstEventHash)) && (identity.lastEventHash === null || validHash(identity.lastEventHash))
+    && validHash(identity.eventHashesHash) && validHash(identity.contentHash)
+    && result && result.sessionId === sessionId && result.eventCount === identity.eventCount && result.deletedEvents === identity.eventCount
+    && typeof result.authenticatedIdentity === "string" && Array.isArray(result.runIds)) return value as PruneReceipt;
+  // Receipts written before the state protocol are completed-only evidence. They
+  // can satisfy an idempotent empty-journal retry, but can never select authority.
+  const legacy = parsed as PruneResult;
+  if (legacy && legacy.sessionId === sessionId && Number.isSafeInteger(legacy.deletedEvents) && legacy.deletedEvents >= 0 && typeof legacy.authenticatedIdentity === "string") return undefined;
+  throw new Error("Journal prune receipt is invalid");
+}
+
+function regularJournalFiles(events: readonly WorkflowEventEnvelope[], journalDirectory: string): void {
+  for (const event of events) {
+    const name = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`;
+    const stat = lstatSync(join(journalDirectory, name));
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("Journal prune refuses a non-regular event file");
+  }
+}
+
+export function previewWorkflowJournalPrune(projectRoot: string, sessionId: string): WorkflowJournalPrunePreview {
+  return preview(readWorkflowJournal(projectRoot, sessionId), sessionId);
+}
+
+export function createWorkflowJournalPruneService(options: WorkflowJournalPruneServiceOptions): Readonly<{ prune(request: WorkflowJournalPruneRequest): PruneResult }> {
+  if (!options || typeof options.authenticate !== "function") throw new Error("Journal prune requires a trusted authentication authority");
+  return Object.freeze({
+    prune(request: WorkflowJournalPruneRequest): PruneResult {
+      exactRequest(request);
+      const authenticatedIdentity = options.authenticate(request.credential);
+      if (!authenticatedIdentity || Buffer.byteLength(authenticatedIdentity, "utf8") > 512) throw new Error("Journal prune authentication failed");
+      if (!request.confirmIrrecoverable) throw new Error("Journal prune requires explicit irrecoverability confirmation");
+      const operationHash = safeOperation(request.operationId);
+      const sessionDirectory = workflowSessionDirectory(request.projectRoot, request.sessionId);
+      const journalDirectory = workflowJournalDirectory(request.projectRoot, request.sessionId);
+      const detached = join(sessionDirectory, `.journal-pruned-${operationHash}`);
+      const receiptPath = join(sessionDirectory, `.journal-prune-receipt-${operationHash}.json`);
+
+      return withCrossProcessFileLock(join(sessionDirectory, ".journal-prune-session"), () => withWorkflowJournalTransaction(request.projectRoot, request.sessionId, (events) => {
+        let authorityEvents = events;
+        const recoveryNames = readdirSync(sessionDirectory).filter((name) => /^\.journal-prune-receipt-[0-9a-f]{64}\.json$/u.test(name) || /^\.journal-pruned-[0-9a-f]{64}$/u.test(name));
+        if (recoveryNames.length > 128) throw new Error("Journal prune recovery artifact limit exceeded");
+        const receiptNames = recoveryNames.filter((name) => name.startsWith(".journal-prune-receipt-")).sort();
+        const detachedNames = new Set(recoveryNames.filter((name) => name.startsWith(".journal-pruned-")));
+        for (const name of detachedNames) {
+          const hash = name.slice(".journal-pruned-".length);
+          if (!receiptNames.includes(`.journal-prune-receipt-${hash}.json`)) throw new Error("Journal prune detached authority lacks a durable receipt");
+        }
+
+        for (const name of receiptNames) {
+          const hash = name.slice(".journal-prune-receipt-".length, -".json".length);
+          const path = join(sessionDirectory, name);
+          let receipt = readReceipt(path, request.sessionId);
+          const recoveryDetached = join(sessionDirectory, `.journal-pruned-${hash}`);
+          if (!receipt) {
+            if (existsSync(recoveryDetached)) {
+              options.fault?.("duringCleanup"); rmSync(recoveryDetached, { recursive: true, force: true }); fsyncDirectory(sessionDirectory);
+            }
+            continue;
+          }
+          if (receipt.status === "completed") {
+            if (existsSync(recoveryDetached)) throw new Error("Journal prune completed receipt has a detached authority artifact");
+            continue;
+          }
+          if (receipt.status === "prepared") {
+            if (!existsSync(recoveryDetached)) {
+              if (!sameJournal(receipt.journal, journalIdentity(authorityEvents))) throw new Error("Journal prune prepared receipt conflicts with authoritative journal identity");
+              regularJournalFiles(authorityEvents, journalDirectory);
+              renameSync(journalDirectory, recoveryDetached); fsyncDirectory(sessionDirectory);
+              authorityEvents = [];
+            }
+            receipt = Object.freeze({ ...receipt, status: "detached" });
+            writeReceipt(path, receipt, sessionDirectory);
+          }
+          if (receipt.status === "detached") {
+            if (existsSync(recoveryDetached)) { options.fault?.("duringCleanup"); rmSync(recoveryDetached, { recursive: true, force: true }); fsyncDirectory(sessionDirectory); }
+            writeReceipt(path, Object.freeze({ ...receipt, status: "completed" }), sessionDirectory);
+          }
+        }
+
+        let prior: PruneReceipt | undefined;
+        if (existsSync(receiptPath)) prior = readReceipt(receiptPath, request.sessionId);
+        if (!prior && existsSync(receiptPath)) {
+          const legacy = JSON.parse(readFileSync(receiptPath, "utf8")) as PruneResult;
+          if (legacy.authenticatedIdentity !== authenticatedIdentity) throw new Error("Journal prune operation belongs to a different authenticated identity");
+          if (!authorityEvents.length) return Object.freeze(legacy);
+          throw new Error("Journal prune legacy completed receipt conflicts with current authoritative journal");
+        }
+        if (prior && prior.result.authenticatedIdentity !== authenticatedIdentity) throw new Error("Journal prune operation belongs to a different authenticated identity");
+        if (prior) {
+          if (!authorityEvents.length && prior.status === "completed") return Object.freeze(prior.result);
+          throw new Error("Journal prune completed operation receipt conflicts with current authoritative journal");
+        }
+
+        const checked = preview(authorityEvents, request.sessionId);
+        const result = Object.freeze({ ...checked, deletedEvents: authorityEvents.length, authenticatedIdentity });
+        const identity = journalIdentity(authorityEvents);
+        regularJournalFiles(authorityEvents, journalDirectory);
+        let receipt: PruneReceipt = Object.freeze({ protocolVersion: 1, status: "prepared", journal: identity, result });
+        writeReceipt(receiptPath, receipt, sessionDirectory); options.fault?.("afterReceipt");
+        if (existsSync(detached)) throw new Error("Journal prune detached target unexpectedly exists");
+        renameSync(journalDirectory, detached); fsyncDirectory(sessionDirectory);
+        receipt = Object.freeze({ ...receipt, status: "detached" });
+        writeReceipt(receiptPath, receipt, sessionDirectory); options.fault?.("afterDetach");
+        options.fault?.("duringCleanup"); rmSync(detached, { recursive: true, force: true }); fsyncDirectory(sessionDirectory);
+        writeReceipt(receiptPath, Object.freeze({ ...receipt, status: "completed" }), sessionDirectory);
+        return result;
+      }), { timeoutMs: 5_000, staleMs: 30_000 });
+    },
+  });
+}

--- a/src/observability/projection.ts
+++ b/src/observability/projection.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+import { readWorkflowJournal } from "../workflows/journal";
+import { toWorkflowTelemetryEvent, verifyWorkflowTelemetryEvent, type WorkflowTelemetryContext, type WorkflowTelemetryDimensions, type WorkflowTelemetryEvent, type WorkflowTelemetryUsage } from "./events";
+
+export const WORKFLOW_PROJECTION_SCHEMA_VERSION = 1 as const;
+export const WORKFLOW_PROJECTION_PAGE_LIMIT = 500;
+/** Safe internal replay ceiling; public history/current output remains capped at 500 rows. */
+export const WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT = 100_000;
+export const WORKFLOW_PROJECTION_QUERY_BYTES = 8_192;
+export const WORKFLOW_PROJECTION_VALUE_BYTES = 1_024;
+
+export interface ProjectionStreamStatus {
+  readonly streamId: string;
+  readonly state: "ready" | "blocked";
+  readonly lastSequence: number;
+  readonly lastHash: string | null;
+  readonly diagnostic?: string;
+}
+
+export interface WorkflowProjectionCurrentRow extends WorkflowTelemetryDimensions {
+  readonly eventId: string;
+  readonly eventType: string;
+  readonly timestamp: string;
+  readonly sequence: number;
+  readonly status?: string;
+  readonly operation?: string;
+}
+
+export interface WorkflowProjectionCurrent {
+  readonly sessions: readonly WorkflowProjectionCurrentRow[];
+  readonly runs: readonly WorkflowProjectionCurrentRow[];
+  readonly nodes: readonly WorkflowProjectionCurrentRow[];
+  readonly tasks: readonly WorkflowProjectionCurrentRow[];
+  readonly workspaces: readonly WorkflowProjectionCurrentRow[];
+  readonly questions: readonly WorkflowProjectionCurrentRow[];
+  readonly approvals: readonly WorkflowProjectionCurrentRow[];
+  readonly knowledge: readonly WorkflowProjectionCurrentRow[];
+}
+
+export interface WorkflowProjectionUsageTotals {
+  readonly estimated: Readonly<{ inputTokens: number; outputTokens: number; costMicroUsd: number }>;
+  readonly providerConfirmed: Readonly<{ inputTokens: number; outputTokens: number; costMicroUsd: number }>;
+}
+
+export interface WorkflowHistoryQuery {
+  readonly limit: number;
+  readonly cursor?: string;
+  readonly projectId?: string;
+  readonly sessionId?: string;
+  readonly workflowId?: string;
+  readonly runId?: string;
+  readonly nodeId?: string;
+  readonly taskId?: string;
+  readonly eventType?: string;
+}
+
+export interface WorkflowHistoryPage {
+  readonly items: readonly WorkflowTelemetryEvent[];
+  readonly nextCursor?: string;
+  readonly hasMore: boolean;
+}
+
+export interface WorkflowCurrentPageQuery { readonly kind: keyof WorkflowProjectionCurrent; readonly limit: number; readonly cursor?: string }
+export interface WorkflowCurrentPage { readonly items: readonly WorkflowProjectionCurrentRow[]; readonly nextCursor?: string; readonly hasMore: boolean }
+
+export class ProjectionStreamError extends Error {
+  readonly streamId: string;
+  constructor(streamId: string, message: string) {
+    super(`Workflow projection stream ${streamId} ${message}`);
+    this.name = "ProjectionStreamError";
+    this.streamId = streamId;
+  }
+}
+
+interface MutableStream {
+  state: "ready" | "blocked";
+  lastSequence: number;
+  lastHash: string | null;
+  diagnostic?: string;
+}
+
+type CurrentKind = keyof WorkflowProjectionCurrent;
+
+function compareEvents(a: WorkflowTelemetryEvent, b: WorkflowTelemetryEvent): number {
+  return a.timestamp.localeCompare(b.timestamp) || a.streamId.localeCompare(b.streamId) || a.sequence - b.sequence || a.eventId.localeCompare(b.eventId);
+}
+
+type CurrentCursorKey = readonly [string, string, string, string, string];
+
+function currentEntityId(row: WorkflowProjectionCurrentRow): string {
+  return String(row.nodeId ?? row.taskId ?? row.questionId ?? row.approvalId ?? row.knowledgeJobId ?? row.knowledgeUpdateId ?? row.workspaceId ?? "");
+}
+
+function currentCursorKey(row: WorkflowProjectionCurrentRow, entityKey: string): CurrentCursorKey {
+  return [row.projectId, row.sessionId, String(row.runId ?? ""), currentEntityId(row), entityKey];
+}
+
+function framedUtf8OrderKey(parts: CurrentCursorKey): string {
+  return parts.map((part) => `${Buffer.from(part, "utf8").toString("hex")}!`).join("");
+}
+
+/** ASCII key whose lexical order is the framed UTF-8 byte order of every current identity component. */
+export function workflowProjectionCurrentOrderKey(row: WorkflowProjectionCurrentRow, entityKey: string): string {
+  return framedUtf8OrderKey(currentCursorKey(row, entityKey));
+}
+
+function cursorKey(event: WorkflowTelemetryEvent): readonly [string, string, number, string] {
+  return [event.timestamp, event.streamId, event.sequence, event.eventId];
+}
+
+function strictBase64Url(value: string, label: string): Buffer {
+  if (!value || !/^[A-Za-z0-9_-]+$/u.test(value)) throw new Error(`${label} cursor is invalid`);
+  const bytes = Buffer.from(value, "base64url");
+  if (!bytes.length || bytes.toString("base64url") !== value) throw new Error(`${label} cursor is invalid`);
+  return bytes;
+}
+
+export function encodeWorkflowHistoryCursor(event: WorkflowTelemetryEvent): string {
+  return Buffer.from(JSON.stringify(cursorKey(event)), "utf8").toString("base64url");
+}
+
+export function decodeWorkflowHistoryCursor(value: string): readonly [string, string, number, string] {
+  try {
+    const parsed: unknown = JSON.parse(strictBase64Url(value, "Workflow history").toString("utf8"));
+    if (!Array.isArray(parsed) || parsed.length !== 4 || typeof parsed[0] !== "string" || !Number.isFinite(Date.parse(parsed[0]))
+      || typeof parsed[1] !== "string" || !/^wfs1-[0-9a-f]{64}$/u.test(parsed[1])
+      || !Number.isSafeInteger(parsed[2]) || parsed[2] < 1 || typeof parsed[3] !== "string" || !parsed[3]) throw new Error();
+    return parsed as [string, string, number, string];
+  } catch {
+    throw new Error("Workflow history cursor is invalid");
+  }
+}
+
+export function encodeWorkflowCurrentCursor(row: WorkflowProjectionCurrentRow, entityKey: string): string {
+  return Buffer.from(JSON.stringify(currentCursorKey(row, entityKey)), "utf8").toString("base64url");
+}
+
+export function decodeWorkflowCurrentCursor(value: string): CurrentCursorKey {
+  try {
+    const parsed: unknown = JSON.parse(strictBase64Url(value, "Workflow current").toString("utf8"));
+    if (!Array.isArray(parsed) || parsed.length !== 5 || parsed.some((entry) => typeof entry !== "string")
+      || !/^(?:wfs1|wfe1)-[0-9a-f]{64}$/u.test(parsed[4])
+      || parsed.reduce((sum, entry) => sum + Buffer.byteLength(entry, "utf8"), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error();
+    return parsed as [string, string, string, string, string];
+  } catch { throw new Error("Workflow current cursor is invalid"); }
+}
+
+export function workflowProjectionCurrentCursorOrderKey(value: string): string {
+  return framedUtf8OrderKey(decodeWorkflowCurrentCursor(value));
+}
+
+function compareKey(event: WorkflowTelemetryEvent, key: readonly [string, string, number, string]): number {
+  return event.timestamp.localeCompare(key[0]) || event.streamId.localeCompare(key[1]) || event.sequence - key[2] || event.eventId.localeCompare(key[3]);
+}
+
+function derivedStatus(event: WorkflowTelemetryEvent): string | undefined {
+  if (event.terminal?.status) return event.terminal.status;
+  if (event.status) return event.status;
+  if (event.eventType === "run.started" || event.eventType === "task.started") return "running";
+  if (event.eventType === "question.transition" && event.operation === "create") return "pending";
+  return undefined;
+}
+
+function row(event: WorkflowTelemetryEvent, existing?: WorkflowProjectionCurrentRow, includeStatus = true): WorkflowProjectionCurrentRow {
+  const status = includeStatus ? derivedStatus(event) : undefined;
+  return Object.freeze({
+    ...(existing ?? {}), ...event.dimensions,
+    eventId: event.eventId,
+    eventType: event.eventType,
+    timestamp: event.timestamp,
+    sequence: event.sequence,
+    ...(status ? { status } : {}),
+    ...(event.operation ? { operation: event.operation } : {}),
+  });
+}
+
+function authoritativeFor(kind: CurrentKind, event: WorkflowTelemetryEvent): boolean {
+  if (kind === "sessions") return event.eventType.startsWith("session.") || event.eventType === "run.started";
+  if (kind === "runs") return event.eventType.startsWith("run.") || event.eventType === "terminal.recorded";
+  if (kind === "nodes") return event.eventType === "run.started" || event.eventType.startsWith("task.");
+  if (kind === "tasks") return event.eventType.startsWith("task.");
+  if (kind === "workspaces") return event.eventType === "artifact.recorded";
+  if (kind === "questions") return event.eventType === "question.transition";
+  if (kind === "approvals") return event.eventType === "approval.recorded";
+  return event.eventType === "knowledge.transition";
+}
+
+function validateQueryValues(query: WorkflowHistoryQuery): void {
+  const values = [query.cursor, query.projectId, query.sessionId, query.workflowId, query.runId, query.nodeId, query.taskId, query.eventType].filter((value): value is string => value !== undefined);
+  if (values.some((value) => Buffer.byteLength(value, "utf8") > WORKFLOW_PROJECTION_VALUE_BYTES)
+    || values.reduce((sum, value) => sum + Buffer.byteLength(value, "utf8"), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow projection query exceeds its byte limit");
+}
+
+function framedEntityKey(parts: readonly string[]): string {
+  const hash = createHash("sha256").update("pi-hive-workflow-entity-key-v1\0");
+  for (const part of parts) {
+    const bytes = Buffer.from(part, "utf8");
+    const length = Buffer.alloc(8); length.writeBigUInt64BE(BigInt(bytes.length));
+    hash.update(length).update(bytes);
+  }
+  return `wfe1-${hash.digest("hex")}`;
+}
+
+export function workflowProjectionCurrentKey(kind: CurrentKind, event: WorkflowTelemetryEvent): string | undefined {
+  const d = event.dimensions;
+  switch (kind) {
+    case "sessions": return event.streamId;
+    case "runs": return d.runId ? framedEntityKey([event.streamId, d.runId]) : undefined;
+    case "nodes": return d.nodeId ? framedEntityKey([event.streamId, d.runId ?? "", d.nodeId]) : undefined;
+    case "tasks": return d.taskId ? framedEntityKey([event.streamId, d.runId ?? "", d.taskId]) : undefined;
+    case "workspaces": return d.workspaceId ? framedEntityKey([event.streamId, d.runId ?? "", d.workspaceId]) : undefined;
+    case "questions": return d.questionId ? framedEntityKey([event.streamId, d.runId ?? "", d.questionId]) : undefined;
+    case "approvals": return d.approvalId ? framedEntityKey([event.streamId, d.runId ?? "", d.approvalId]) : undefined;
+    case "knowledge": {
+      const id = d.knowledgeJobId ?? d.knowledgeUpdateId;
+      return id ? framedEntityKey([event.streamId, d.runId ?? "", id]) : undefined;
+    }
+  }
+}
+
+function safeTotal(left: number, right: number): number {
+  const total = left + right;
+  if (!Number.isSafeInteger(total) || total < 0) throw new Error("Workflow projection usage total exceeds its safe magnitude");
+  return total;
+}
+
+function usageBucket(input: WorkflowTelemetryUsage, totals: WorkflowProjectionUsageTotals): void {
+  const key = input.precision === "provider-confirmed" ? "providerConfirmed" : "estimated";
+  const bucket = totals[key] as { inputTokens: number; outputTokens: number; costMicroUsd: number };
+  bucket.inputTokens = safeTotal(bucket.inputTokens, input.inputTokens);
+  bucket.outputTokens = safeTotal(bucket.outputTokens, input.outputTokens);
+  bucket.costMicroUsd = safeTotal(bucket.costMicroUsd, input.costMicroUsd);
+}
+
+export class WorkflowTelemetryProjection {
+  private events: WorkflowTelemetryEvent[] = [];
+  private readonly eventLimit: number;
+  private readonly eventHashes = new Map<string, string>();
+  private readonly streams = new Map<string, MutableStream>();
+  private readonly materialized: Record<CurrentKind, Map<string, WorkflowProjectionCurrentRow>> = {
+    sessions: new Map(), runs: new Map(), nodes: new Map(), tasks: new Map(), workspaces: new Map(),
+    questions: new Map(), approvals: new Map(), knowledge: new Map(),
+  };
+  private readonly totals: WorkflowProjectionUsageTotals = {
+    estimated: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 },
+    providerConfirmed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 },
+  };
+
+  constructor(options: Readonly<{ eventLimit?: number }> = {}) {
+    const limit = options.eventLimit ?? WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT;
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT) throw new Error("Workflow in-memory projection event limit is invalid");
+    this.eventLimit = limit;
+  }
+
+  ingest(event: WorkflowTelemetryEvent): "inserted" | "duplicate" {
+    verifyWorkflowTelemetryEvent(event);
+    const stream = this.streams.get(event.streamId) ?? { state: "ready" as const, lastSequence: 0, lastHash: null };
+    const duplicateHash = this.eventHashes.get(event.eventId);
+    if (duplicateHash !== undefined) {
+      if (duplicateHash === event.eventHash) return "duplicate";
+      return this.block(event.streamId, stream, "reused an event ID with a different hash");
+    }
+    if (stream.state === "blocked") throw new ProjectionStreamError(event.streamId, `is blocked: ${stream.diagnostic ?? "integrity failure"}`);
+    if (this.events.length >= this.eventLimit) throw new Error("Workflow in-memory projection event limit exceeded");
+    const expectedSequence = stream.lastSequence + 1;
+    if (event.sequence !== expectedSequence) return this.block(event.streamId, stream, `sequence gap: expected ${expectedSequence}, received ${event.sequence}`);
+    if (event.previousHash !== stream.lastHash) return this.block(event.streamId, stream, "previous hash mismatch");
+
+    this.eventHashes.set(event.eventId, event.eventHash);
+    this.events.push(event);
+    stream.lastSequence = event.sequence;
+    stream.lastHash = event.sourceEventHash;
+    this.streams.set(event.streamId, stream);
+    for (const kind of Object.keys(this.materialized) as CurrentKind[]) {
+      const key = workflowProjectionCurrentKey(kind, event);
+      if (key && authoritativeFor(kind, event)) this.materialized[kind].set(key, row(event, this.materialized[kind].get(key), kind !== "sessions" || event.eventType.startsWith("session.")));
+    }
+    if (event.usage) usageBucket(event.usage, this.totals);
+    return "inserted";
+  }
+
+  private block(streamId: string, stream: MutableStream, diagnostic: string): never {
+    stream.state = "blocked";
+    stream.diagnostic = diagnostic.slice(0, 2_048);
+    this.streams.set(streamId, stream);
+    throw new ProjectionStreamError(streamId, diagnostic);
+  }
+
+  streamStatus(streamId: string): ProjectionStreamStatus {
+    const stream = this.streams.get(streamId) ?? { state: "ready" as const, lastSequence: 0, lastHash: null };
+    return Object.freeze({ streamId, state: stream.state, lastSequence: stream.lastSequence, lastHash: stream.lastHash, ...(stream.diagnostic ? { diagnostic: stream.diagnostic } : {}) });
+  }
+
+  current(): WorkflowProjectionCurrent {
+    const output = {} as Record<CurrentKind, readonly WorkflowProjectionCurrentRow[]>;
+    for (const kind of Object.keys(this.materialized) as CurrentKind[]) output[kind] = this.currentPage({ kind, limit: WORKFLOW_PROJECTION_PAGE_LIMIT }).items;
+    return Object.freeze(output) as unknown as WorkflowProjectionCurrent;
+  }
+
+  currentPage(query: WorkflowCurrentPageQuery): WorkflowCurrentPage {
+    if (!Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error(`Workflow current limit must be 1..${WORKFLOW_PROJECTION_PAGE_LIMIT}`);
+    if (!(query.kind in this.materialized)) throw new Error("Workflow current kind is invalid");
+    if (query.cursor && Buffer.byteLength(query.cursor, "utf8") > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current cursor exceeds its byte limit");
+    const cursorOrder = query.cursor ? workflowProjectionCurrentCursorOrderKey(query.cursor) : undefined;
+    const entries = [...this.materialized[query.kind]].map(([key, value]) => ({ key, value, order: workflowProjectionCurrentOrderKey(value, key) }))
+      .sort((a, b) => a.order < b.order ? -1 : a.order > b.order ? 1 : 0)
+      .filter((entry) => !cursorOrder || entry.order > cursorOrder);
+    const selected = entries.slice(0, query.limit + 1);
+    const hasMore = selected.length > query.limit;
+    const page = selected.slice(0, query.limit);
+    return Object.freeze({ items: Object.freeze(page.map((entry) => entry.value)), ...(hasMore && page.length ? { nextCursor: encodeWorkflowCurrentCursor(page.at(-1)!.value, page.at(-1)!.key) } : {}), hasMore });
+  }
+
+  usage(): WorkflowProjectionUsageTotals {
+    return structuredClone(this.totals);
+  }
+
+  history(query: WorkflowHistoryQuery): WorkflowHistoryPage {
+    if (!Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error(`Workflow history limit must be 1..${WORKFLOW_PROJECTION_PAGE_LIMIT}`);
+    validateQueryValues(query);
+    const cursor = query.cursor ? decodeWorkflowHistoryCursor(query.cursor) : undefined;
+    const filtered = this.events.filter((event) => {
+      const d = event.dimensions;
+      return (!cursor || compareKey(event, cursor) > 0)
+        && (!query.projectId || d.projectId === query.projectId)
+        && (!query.sessionId || d.sessionId === query.sessionId)
+        && (!query.workflowId || d.workflowId === query.workflowId)
+        && (!query.runId || d.runId === query.runId)
+        && (!query.nodeId || d.nodeId === query.nodeId)
+        && (!query.taskId || d.taskId === query.taskId)
+        && (!query.eventType || event.eventType === query.eventType);
+    }).sort(compareEvents);
+    const items = filtered.slice(0, query.limit);
+    const hasMore = filtered.length > items.length;
+    return Object.freeze({ items: Object.freeze(items), ...(hasMore && items.length ? { nextCursor: encodeWorkflowHistoryCursor(items.at(-1)!) } : {}), hasMore });
+  }
+
+  pruneProjection(cutoffIso: string): Readonly<{ removed: number; retained: number }> {
+    const cutoffMs = Date.parse(cutoffIso);
+    if (!Number.isFinite(cutoffMs)) throw new Error("Projection prune cutoff is invalid");
+    const before = this.events.length;
+    const removableIds = new Set<string>();
+    const stoppedStreams = new Set<string>();
+    for (const event of [...this.events].sort((a, b) => a.streamId < b.streamId ? -1 : a.streamId > b.streamId ? 1 : a.sequence - b.sequence)) {
+      if (stoppedStreams.has(event.streamId)) continue;
+      if (Date.parse(event.timestamp) < cutoffMs) removableIds.add(event.eventId);
+      else stoppedStreams.add(event.streamId);
+    }
+    this.events = this.events.filter((event) => !removableIds.has(event.eventId));
+    // Event identities are an integrity boundary, not retained history. Keep them
+    // permanently so a pruned ID can never acquire a different meaning later.
+    for (const bucket of [this.totals.estimated, this.totals.providerConfirmed]) { (bucket as any).inputTokens = 0; (bucket as any).outputTokens = 0; (bucket as any).costMicroUsd = 0; }
+    for (const event of this.events) if (event.usage) usageBucket(event.usage, this.totals);
+    return Object.freeze({ removed: before - this.events.length, retained: this.events.length });
+  }
+
+  snapshot(): Readonly<Record<string, unknown>> {
+    return Object.freeze({
+      schemaVersion: WORKFLOW_PROJECTION_SCHEMA_VERSION,
+      streams: [...this.streams.keys()].sort().map((streamId) => this.streamStatus(streamId)),
+      current: this.current(),
+      history: this.history({ limit: Math.max(1, Math.min(WORKFLOW_PROJECTION_PAGE_LIMIT, this.events.length || 1)) }).items,
+      usage: this.usage(),
+    });
+  }
+}
+
+export function rebuildWorkflowProjection(streams: readonly (readonly WorkflowTelemetryEvent[])[]): WorkflowTelemetryProjection {
+  const projection = new WorkflowTelemetryProjection();
+  const ordered = [...streams].map((events) => [...events].sort((a, b) => a.sequence - b.sequence))
+    .sort((a, b) => String(a[0]?.streamId ?? "").localeCompare(String(b[0]?.streamId ?? "")));
+  for (const events of ordered) for (const event of events) projection.ingest(event);
+  return projection;
+}
+
+export interface WorkflowJournalProjectionRegistration {
+  readonly projectRoot: string;
+  readonly sessionId: string;
+  readonly context?: WorkflowTelemetryContext;
+}
+
+export function rebuildWorkflowProjectionFromJournals(registrations: readonly WorkflowJournalProjectionRegistration[]): WorkflowTelemetryProjection {
+  const streams = [...registrations]
+    .sort((a, b) => a.projectRoot.localeCompare(b.projectRoot) || a.sessionId.localeCompare(b.sessionId))
+    .map((registration) => readWorkflowJournal(registration.projectRoot, registration.sessionId)
+      .map((event) => toWorkflowTelemetryEvent(event, { projectRoot: registration.projectRoot, ...(registration.context ?? {}) })));
+  return rebuildWorkflowProjection(streams);
+}

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -1,0 +1,188 @@
+import { existsSync, lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, posix, relative, resolve } from "node:path";
+import type { JsonValue } from "../config/types";
+
+export const TELEMETRY_REDACTED = "[REDACTED]" as const;
+
+export type WorkflowRedactionMode = "journal-pre-persistence" | "authoritative-projection";
+
+export interface WorkflowRedactionOptions {
+  /** Projection mode is deterministic and never reads or applies process/configured secrets. */
+  readonly mode?: WorkflowRedactionMode;
+  readonly environment?: Readonly<Record<string, string | undefined>>;
+  readonly protectedPaths?: readonly string[];
+  /** Canonical project root used to match absolute and project-relative path spellings. */
+  readonly projectRoot?: string;
+  readonly maxStringBytes?: number;
+  readonly maxArrayItems?: number;
+  readonly maxObjectKeys?: number;
+  readonly maxDepth?: number;
+}
+
+const SENSITIVE_KEY = /^(?:cookie|set-cookie|api[-_]?key|x[-_]?(?:api[-_]?key|auth[-_]?token)|access[-_]?token|refresh[-_]?token|auth[-_]?token|password|passwd|secret|private[-_]?key|client[-_]?secret|credential|credentials)$/iu;
+const AUTH_HEADER_KEY = /^(?:authorization|proxy-authorization)$/iu;
+const SENSITIVE_ENV_KEY = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|PRIVATE_KEY|CREDENTIAL|AUTH)(?:$|_)/iu;
+const OMITTED_PROJECTION_FIELD = /^(?:transcript|transcriptText|prompt|promptText|messages|conversation|toolArgs|toolArguments|toolResult|toolResults|arguments|args|resultPayload|raw|rawContent)$/iu;
+const PROTECTED_CONTENT_FIELD = /^(?:content|body|text|bytes|source|data|fileContent|raw|value)$/iu;
+const PATH_KEY_TERMINALS = new Set(["path", "file", "filename", "directory", "dir", "root"]);
+
+function pathField(key: string): boolean {
+  const words = key.replace(/([a-z0-9])([A-Z])/gu, "$1 $2").toLowerCase().split(/[^a-z0-9]+/u).filter(Boolean);
+  if (!words.length) return false;
+  const compact = words.join("");
+  return PATH_KEY_TERMINALS.has(words.at(-1)!) || /^(?:canonical|config|source|target|workspace|working|artifact)?(?:path|file|filename|directory|dir|root)$/u.test(compact);
+}
+
+function utf8Prefix(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length <= maxBytes) return value;
+  let end = maxBytes;
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) end--;
+  return bytes.subarray(0, end).toString("utf8");
+}
+
+const REDACTION_POLICY_LIMITS = Object.freeze({ environmentEntries: 1_024, secrets: 128, secretCharacters: 8_192, secretBytes: 8_192, totalSecretBytes: 262_144, protectedPaths: 256, protectedPathBytes: 4_096 });
+
+function secretValues(environment: Readonly<Record<string, string | undefined>>): readonly string[] {
+  const output: string[] = [];
+  let entries = 0;
+  let totalBytes = 0;
+  for (const [key, value] of Object.entries(environment)) {
+    entries++;
+    if (entries > REDACTION_POLICY_LIMITS.environmentEntries) throw new Error("Workflow redaction environment entry limit exceeded");
+    if (key.length > 512 || !SENSITIVE_ENV_KEY.test(key) || value === undefined || value === "") continue;
+    if (value.length < 4 || value.length > REDACTION_POLICY_LIMITS.secretCharacters) throw new Error("Workflow redaction secret length limit exceeded");
+    const bytes = Buffer.byteLength(value, "utf8");
+    if (bytes > REDACTION_POLICY_LIMITS.secretBytes) throw new Error("Workflow redaction secret byte limit exceeded");
+    totalBytes += bytes;
+    if (output.length >= REDACTION_POLICY_LIMITS.secrets || totalBytes > REDACTION_POLICY_LIMITS.totalSecretBytes) throw new Error("Workflow redaction secret limit exceeded");
+    output.push(value);
+  }
+  return output.sort((a, b) => b.length - a.length || a.localeCompare(b));
+}
+
+function redactText(value: string, secrets: readonly string[], maxBytes: number): string {
+  let output = value
+    .replace(/-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----[\s\S]*?-----END(?: [A-Z0-9]+)? PRIVATE KEY-----/giu, TELEMETRY_REDACTED)
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/-]+=*/giu, `$1 ${TELEMETRY_REDACTED}`)
+    .replace(/\b((?:api[-_]?key|x[-_]?(?:api[-_]?key|auth[-_]?token)|access[-_]?token|refresh[-_]?token|auth[-_]?token|password|passwd|secret|client[-_]?secret|credential)\s*[=:]\s*)(["']?)[^\s,"';&]+\2/giu, `$1${TELEMETRY_REDACTED}`)
+    .replace(/\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+:)[^\s/@]+(@)/giu, `$1${TELEMETRY_REDACTED}$2`);
+  for (const secret of secrets) output = output.split(secret).join(TELEMETRY_REDACTED);
+  return utf8Prefix(output, maxBytes);
+}
+
+function normalizedPath(value: string): string {
+  const slash = value.replaceAll("\\", "/");
+  const normalized = posix.normalize(slash);
+  return normalized === "." ? "" : normalized.replace(/^\.\//u, "").replace(/\/+$/u, "");
+}
+
+function canonicalExistingPath(value: string, projectRoot?: string): string | undefined {
+  if (!projectRoot) return undefined;
+  const absolute = isAbsolute(value) ? resolve(value) : resolve(projectRoot, value);
+  let ancestor = absolute;
+  const suffix: string[] = [];
+  try {
+    while (!existsSync(ancestor)) {
+      try { if (lstatSync(ancestor).isSymbolicLink()) return undefined; } catch { /* absent component */ }
+      const parent = dirname(ancestor);
+      if (parent === ancestor) return undefined;
+      suffix.unshift(ancestor.slice(parent.length + (parent.endsWith("/") ? 0 : 1)));
+      ancestor = parent;
+    }
+    return normalizedPath(resolve(realpathSync.native(ancestor), ...suffix));
+  } catch { return undefined; }
+}
+
+function pathSpellings(value: string, projectRoot?: string): readonly string[] | undefined {
+  const normalized = normalizedPath(value);
+  const output = new Set<string>([normalized]);
+  if (projectRoot) {
+    const canonicalRoot = canonicalExistingPath(projectRoot, projectRoot);
+    const canonical = canonicalExistingPath(value, projectRoot);
+    if (!canonicalRoot || !canonical) return undefined;
+    const absolute = normalized.startsWith("/") ? normalized : normalizedPath(resolve(projectRoot, normalized));
+    output.add(absolute); output.add(canonical);
+    for (const candidate of [absolute, canonical]) {
+      const projectRelative = normalizedPath(relative(canonicalRoot, candidate).replaceAll("\\", "/"));
+      if (projectRelative && projectRelative !== ".." && !projectRelative.startsWith("../")) output.add(projectRelative);
+    }
+  }
+  return [...output];
+}
+
+function pathProtected(value: string, protectedPaths: readonly string[], projectRoot?: string): boolean {
+  const candidates = pathSpellings(value, projectRoot);
+  if (!candidates) return true;
+  return protectedPaths.some((root) => {
+    const roots = pathSpellings(root, projectRoot);
+    if (!roots) return true;
+    return candidates.some((candidate) => roots.some((protectedRoot) => candidate === protectedRoot || candidate.startsWith(`${protectedRoot}/`)
+      || (!isAbsolute(protectedRoot) && candidate.endsWith(`/${protectedRoot}`))));
+  });
+}
+
+interface InternalOptions {
+  readonly secrets: readonly string[];
+  readonly protectedPaths: readonly string[];
+  readonly maxStringBytes: number;
+  readonly maxArrayItems: number;
+  readonly maxObjectKeys: number;
+  readonly maxDepth: number;
+  readonly omitProjectionFields: boolean;
+  readonly projectRoot?: string;
+}
+
+function redactValue(value: unknown, options: InternalOptions, depth: number, seen: WeakSet<object>, protectedTaint = false): JsonValue {
+  if (typeof value === "string") return redactText(value, options.secrets, options.maxStringBytes);
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "boolean" || value === null) return value;
+  if (value === undefined || typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") return null;
+  if (depth >= options.maxDepth) return "[TRUNCATED]";
+  if (seen.has(value as object)) return TELEMETRY_REDACTED;
+  seen.add(value as object);
+  if (Array.isArray(value)) {
+    const output = value.slice(0, options.maxArrayItems).map((entry) => redactValue(entry, options, depth + 1, seen, protectedTaint));
+    seen.delete(value);
+    return output;
+  }
+  const source = value as Record<string, unknown>;
+  const protectedObject = protectedTaint || Object.entries(source).some(([key, entry]) => pathField(key) && typeof entry === "string" && pathProtected(entry, options.protectedPaths, options.projectRoot));
+  const output: Record<string, JsonValue> = {};
+  for (const [key, entry] of Object.entries(source).sort(([a], [b]) => a.localeCompare(b)).slice(0, options.maxObjectKeys)) {
+    if (options.omitProjectionFields && OMITTED_PROJECTION_FIELD.test(key)) continue;
+    const structuredAuthorization = key.toLowerCase() === "authorization" && (entry === "authorized" || entry === "denied");
+    if (SENSITIVE_KEY.test(key) || (AUTH_HEADER_KEY.test(key) && typeof entry === "string" && !structuredAuthorization)
+      || (protectedObject && (PROTECTED_CONTENT_FIELD.test(key) || OMITTED_PROJECTION_FIELD.test(key)))) output[key] = TELEMETRY_REDACTED;
+    else output[key] = redactValue(entry, options, depth + 1, seen, protectedObject);
+  }
+  seen.delete(value as object);
+  return output;
+}
+
+function options(input: WorkflowRedactionOptions, mode: WorkflowRedactionMode): InternalOptions {
+  const projection = mode === "authoritative-projection";
+  const configuredPaths = projection ? [] : input.protectedPaths ?? [];
+  if (configuredPaths.length > REDACTION_POLICY_LIMITS.protectedPaths || configuredPaths.some((value) => typeof value !== "string" || !value || value.includes("\0") || Buffer.byteLength(value, "utf8") > REDACTION_POLICY_LIMITS.protectedPathBytes)) throw new Error("Workflow redaction protected path limit exceeded");
+  return {
+    secrets: projection ? [] : secretValues(input.environment ?? process.env),
+    protectedPaths: [".env", ".git", ".pi/hive/private", ".pi/hive/sessions", ...configuredPaths],
+    ...(!projection && input.projectRoot ? { projectRoot: resolve(input.projectRoot) } : {}),
+    // Journal subsystems already enforce narrower authority-specific limits
+    // (questions, terminal summaries, references). This defensive ceiling must
+    // not truncate valid restart data before those contracts can replay it.
+    maxStringBytes: input.maxStringBytes ?? (projection ? 2_048 : 131_072),
+    maxArrayItems: input.maxArrayItems ?? (projection ? 64 : 8_192),
+    maxObjectKeys: input.maxObjectKeys ?? (projection ? 128 : 8_192),
+    maxDepth: input.maxDepth ?? (projection ? 8 : 64),
+    omitProjectionFields: projection,
+  };
+}
+
+export function redactProjectionValue(value: unknown, input: WorkflowRedactionOptions = {}): JsonValue {
+  return redactValue(value, options(input, "authoritative-projection"), 0, new WeakSet<object>());
+}
+
+export function redactJournalPayload(value: unknown, input: WorkflowRedactionOptions = {}): JsonValue {
+  return redactValue(value, options(input, "journal-pre-persistence"), 0, new WeakSet<object>());
+}

--- a/src/observability/server/config.ts
+++ b/src/observability/server/config.ts
@@ -29,6 +29,9 @@ export const SINGLE_LOG_PATH = process.env.HIVE_TELEMETRY_LOG || "";
 export const HIVE_GLOBAL_DIR = path.join(process.env.PI_CODING_AGENT_DIR || path.join(homedir(), ".pi", "agent"), "hive");
 export const REGISTRY_PATH = path.resolve(process.env.HIVE_TELEMETRY_REGISTRY || path.join(HIVE_GLOBAL_DIR, "telemetry-sessions.jsonl"));
 export const DB_PATH = path.resolve(process.env.HIVE_TELEMETRY_DB || path.join(HIVE_GLOBAL_DIR, "telemetry.db"));
+// Workflow telemetry is a clean schema break. Keep it in a separate rebuildable
+// database so legacy telemetry.db is never migrated, dual-read, or destroyed.
+export const WORKFLOW_DB_PATH = path.resolve(process.env.HIVE_WORKFLOW_TELEMETRY_DB || path.join(HIVE_GLOBAL_DIR, "workflow-telemetry-v1.db"));
 export const CONVERSATION_LOG = process.env.HIVE_CONVERSATION_LOG || "";
 export const BOOT_SESSION_ID = process.env.HIVE_SESSION_ID || "global";
 export const PROJECT_CWD = process.env.HIVE_PROJECT_CWD || process.cwd();

--- a/src/observability/server/index.ts
+++ b/src/observability/server/index.ts
@@ -1,6 +1,6 @@
 import { HOST, IDLE_TIMEOUT_MS, PORT, REGISTRY_PATH } from "./config";
 import { createDashboardHttpHandler } from "./http-handler";
-import { sourcePaths, startTelemetryRuntime } from "./runtime";
+import { sourcePaths, startTelemetryRuntime, stopTelemetryRuntime } from "./runtime";
 import { broadcastPing, subscribers } from "./sse";
 
 void startTelemetryRuntime();
@@ -16,10 +16,14 @@ function scheduleServerStop(): void {
   setTimeout(() => {
     clearInterval(heartbeatTimer);
     clearInterval(idleTimer);
+    stopTelemetryRuntime();
     void server.stop(true);
     process.exit(0);
   }, 50);
 }
+
+process.once("SIGINT", scheduleServerStop);
+process.once("SIGTERM", scheduleServerStop);
 
 const handleRequest = createDashboardHttpHandler({
   onActivity() { lastActivityAt = Date.now(); },

--- a/src/observability/server/runtime.ts
+++ b/src/observability/server/runtime.ts
@@ -9,7 +9,8 @@ import type { AgentConfig, HiveTeam } from "../../core/types";
 import { withCrossProcessFileLock } from "../../core/file-lock";
 import { readJsonlPage } from "../../core/fs";
 import type { HiveStateSnapshot, HiveTelemetryEvent, TelemetryRegistryRow, TelemetrySessionSummary, TopologyNode } from "../../shared/telemetry";
-import { BOOT_SESSION_ID, CAPTURE_THINKING, CONVERSATION_LOG, DB_PATH, PROJECT_CWD, REGISTRY_PATH, RETENTION_DAYS, SINGLE_LOG_PATH } from "./config";
+import { BOOT_SESSION_ID, CAPTURE_THINKING, CONVERSATION_LOG, DB_PATH, PROJECT_CWD, REGISTRY_PATH, RETENTION_DAYS, SINGLE_LOG_PATH, WORKFLOW_DB_PATH } from "./config";
+import { createConfiguredWorkflowProjectionSynchronizer, workflowProjectionRootCandidates, type ConfiguredWorkflowProjectionSynchronizer } from "./workflow-runtime";
 import {
   db,
   dbEventRow,
@@ -1001,11 +1002,32 @@ export function readAgentLog(sessionId: string, agent: string, offset: number, r
   };
 }
 
+let workflowProjectionRuntimeDiagnostics: readonly Readonly<{ projectRoot: string; sessionId: string; diagnostic: string }>[] = Object.freeze([]);
+let workflowProjectionSynchronizer: ConfiguredWorkflowProjectionSynchronizer | undefined;
+let telemetryPruneTimer: ReturnType<typeof setInterval> | undefined;
+let telemetryPollTimer: ReturnType<typeof setInterval> | undefined;
+
+export function readWorkflowProjectionRuntimeDiagnostics(): readonly Readonly<{ projectRoot: string; sessionId: string; diagnostic: string }>[] {
+  return workflowProjectionRuntimeDiagnostics;
+}
+
+function syncWorkflowProjectionRuntime(): void {
+  const projectRoots = workflowProjectionRootCandidates(PROJECT_CWD, [...sources.values()].flatMap((source) => source.meta.project_root ? [source.meta.project_root] : source.meta.cwd ? [source.meta.cwd] : []));
+  try {
+    workflowProjectionSynchronizer ??= createConfiguredWorkflowProjectionSynchronizer({ databasePath: WORKFLOW_DB_PATH, legacyPaths: [DB_PATH, REGISTRY_PATH], retentionDays: RETENTION_DAYS });
+    const result = workflowProjectionSynchronizer.sync(projectRoots);
+    workflowProjectionRuntimeDiagnostics = Object.freeze([...(result.diagnostics ?? [])].slice(0, 256));
+  } catch (error) {
+    workflowProjectionRuntimeDiagnostics = Object.freeze([{ projectRoot: PROJECT_CWD.slice(0, 1_024), sessionId: "", diagnostic: String(error instanceof Error ? error.message : error).slice(0, 2_048) }]);
+  }
+}
+
 export function startTelemetryRuntime() {
   if (started) return;
   started = true;
   resumeIngestSources();
   readRegistry();
+  syncWorkflowProjectionRuntime();
   if (SINGLE_LOG_PATH) addSource(SINGLE_LOG_PATH, { cwd: PROJECT_CWD, conversation_log: CONVERSATION_LOG, session_id: BOOT_SESSION_ID });
   fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true, mode: 0o700 });
   fs.chmodSync(path.dirname(REGISTRY_PATH), 0o700);
@@ -1013,13 +1035,32 @@ export function startTelemetryRuntime() {
   fs.chmodSync(REGISTRY_PATH, 0o600);
   const automaticPrune = () => pruneTelemetry(new Date(Date.now() - RETENTION_DAYS * 86400_000).toISOString());
   automaticPrune();
-  setInterval(automaticPrune, 60 * 60 * 1000).unref?.();
+  telemetryPruneTimer = setInterval(automaticPrune, 60 * 60 * 1000);
+  telemetryPruneTimer.unref?.();
   fs.watchFile(REGISTRY_PATH, { interval: 1000 }, readRegistry);
-  setInterval(() => {
+  telemetryPollTimer = setInterval(() => {
     readRegistry();
+    syncWorkflowProjectionRuntime();
     for (const source of sources.values()) {
       readSource(source.logPath);
       readState(source.logPath);
     }
-  }, 2000).unref?.();
+  }, 2000);
+  telemetryPollTimer.unref?.();
+}
+
+export function stopTelemetryRuntime(): void {
+  if (!started && !workflowProjectionSynchronizer) return;
+  started = false;
+  if (telemetryPruneTimer) clearInterval(telemetryPruneTimer);
+  if (telemetryPollTimer) clearInterval(telemetryPollTimer);
+  telemetryPruneTimer = undefined;
+  telemetryPollTimer = undefined;
+  fs.unwatchFile(REGISTRY_PATH, readRegistry);
+  for (const source of sources.values()) {
+    fs.unwatchFile(source.logPath);
+    fs.unwatchFile(source.statePath);
+  }
+  workflowProjectionSynchronizer?.close();
+  workflowProjectionSynchronizer = undefined;
 }

--- a/src/observability/server/workflow-db.ts
+++ b/src/observability/server/workflow-db.ts
@@ -1,0 +1,652 @@
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, lstatSync, mkdirSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { withCrossProcessFileLock } from "../../core/file-lock";
+import {
+  WORKFLOW_PROJECTION_PAGE_LIMIT,
+  WORKFLOW_PROJECTION_QUERY_BYTES,
+  WORKFLOW_PROJECTION_VALUE_BYTES,
+  decodeWorkflowHistoryCursor,
+  encodeWorkflowCurrentCursor,
+  encodeWorkflowHistoryCursor,
+  workflowProjectionCurrentCursorOrderKey,
+  workflowProjectionCurrentKey,
+  workflowProjectionCurrentOrderKey,
+  type ProjectionStreamStatus,
+  type WorkflowHistoryPage,
+  type WorkflowHistoryQuery,
+  type WorkflowProjectionCurrent,
+  type WorkflowProjectionCurrentRow,
+  type WorkflowProjectionUsageTotals,
+  type WorkflowCurrentPage,
+  type WorkflowCurrentPageQuery,
+} from "../projection";
+import { restoreWorkflowTelemetryEvent, verifyWorkflowTelemetryEvent, workflowTelemetryStreamId, type WorkflowTelemetryEvent } from "../events";
+import { canonicalJson } from "../../config/snapshot-canonical";
+
+export const WORKFLOW_SQLITE_SCHEMA_VERSION = 1 as const;
+
+const SCHEMA = `
+CREATE TABLE workflow_projection_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+CREATE TABLE workflow_streams (
+  stream_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  project_root TEXT,
+  state TEXT NOT NULL,
+  last_sequence INTEGER NOT NULL,
+  last_hash TEXT,
+  diagnostic TEXT,
+  state_hash TEXT NOT NULL
+);
+CREATE TABLE workflow_event_identities (
+  event_id TEXT PRIMARY KEY,
+  event_hash TEXT NOT NULL
+);
+CREATE TABLE workflow_events (
+  event_id TEXT PRIMARY KEY,
+  stream_id TEXT NOT NULL,
+  project_id TEXT NOT NULL,
+  project_root TEXT,
+  project_label TEXT,
+  pi_session_id TEXT,
+  session_id TEXT NOT NULL,
+  workflow_id TEXT,
+  snapshot_id TEXT,
+  workflow_config_hash TEXT,
+  workflow_config_version TEXT,
+  run_id TEXT,
+  agent_id TEXT,
+  agent_name TEXT,
+  node_id TEXT,
+  parent_node_id TEXT,
+  task_id TEXT,
+  adapter_id TEXT,
+  adapter_version TEXT,
+  profile_id TEXT,
+  profile_version TEXT,
+  workspace_id TEXT,
+  workspace_hash TEXT,
+  lease_state TEXT,
+  question_id TEXT,
+  checkpoint_id TEXT,
+  approval_id TEXT,
+  knowledge_job_id TEXT,
+  knowledge_update_id TEXT,
+  model_id TEXT,
+  thinking TEXT,
+  tool_name TEXT,
+  capability_id TEXT,
+  attempt_id TEXT,
+  operation_id TEXT,
+  precision TEXT,
+  elapsed_ms INTEGER,
+  active_wall_time_ms INTEGER,
+  budget_scope TEXT,
+  budget_used REAL,
+  budget_limit REAL,
+  budget_remaining REAL,
+  change_coverage TEXT,
+  terminal_refs_json BLOB,
+  sequence INTEGER NOT NULL,
+  previous_hash TEXT,
+  event_hash TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  source_event_hash TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_json BLOB NOT NULL
+);
+CREATE UNIQUE INDEX workflow_events_stream_sequence ON workflow_events(stream_id, sequence);
+CREATE INDEX workflow_events_history ON workflow_events(timestamp, stream_id, sequence, event_id);
+CREATE INDEX workflow_events_dimensions ON workflow_events(project_id, workflow_id, run_id, node_id, task_id);
+CREATE TABLE workflow_current (
+  kind TEXT NOT NULL,
+  entity_key TEXT NOT NULL,
+  current_order_key TEXT NOT NULL,
+  project_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  workflow_id TEXT,
+  snapshot_id TEXT,
+  project_label TEXT,
+  workflow_config_version TEXT,
+  run_id TEXT,
+  node_id TEXT,
+  task_id TEXT,
+  updated_at TEXT NOT NULL,
+  current_json BLOB NOT NULL,
+  current_hash TEXT NOT NULL,
+  PRIMARY KEY(kind, entity_key)
+);
+CREATE INDEX workflow_current_dimensions ON workflow_current(project_id, workflow_id, run_id, kind);
+CREATE UNIQUE INDEX workflow_current_order ON workflow_current(kind, current_order_key);
+CREATE TABLE workflow_usage (
+  event_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  workflow_id TEXT,
+  run_id TEXT,
+  node_id TEXT,
+  precision TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  cost_micro_usd INTEGER NOT NULL,
+  timestamp TEXT NOT NULL
+);
+CREATE INDEX workflow_usage_dimensions ON workflow_usage(project_id, workflow_id, run_id, node_id, precision);
+CREATE TABLE workflow_prune_watermarks (
+  stream_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  project_root TEXT,
+  through_sequence INTEGER NOT NULL,
+  through_hash TEXT NOT NULL,
+  cutoff TEXT NOT NULL,
+  state_hash TEXT NOT NULL
+);
+`;
+
+const PRUNE_SCHEMA = `CREATE TABLE IF NOT EXISTS workflow_prune_watermarks (
+  stream_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  project_root TEXT,
+  through_sequence INTEGER NOT NULL,
+  through_hash TEXT NOT NULL,
+  cutoff TEXT NOT NULL,
+  state_hash TEXT NOT NULL
+);`;
+
+type CurrentKind = keyof WorkflowProjectionCurrent;
+const CURRENT_KINDS: readonly CurrentKind[] = ["sessions", "runs", "nodes", "tasks", "workspaces", "questions", "approvals", "knowledge"];
+
+function parseEvent(value: string): WorkflowTelemetryEvent {
+  try { return restoreWorkflowTelemetryEvent(JSON.parse(value)); }
+  catch { throw new Error("Workflow projection persisted event integrity failure"); }
+}
+function currentHash(kind: CurrentKind, entityKey: string, value: WorkflowProjectionCurrentRow): string {
+  return createHash("sha256").update("pi-hive-workflow-current-v1\0").update(canonicalJson({ kind, entityKey, value })).digest("hex");
+}
+function parseCurrent(kind: CurrentKind, entityKey: string, value: string, expectedHash: string): WorkflowProjectionCurrentRow {
+  try {
+    const parsed = JSON.parse(value) as WorkflowProjectionCurrentRow;
+    if (!parsed || typeof parsed !== "object" || currentHash(kind, entityKey, parsed) !== expectedHash) throw new Error();
+    return parsed;
+  } catch { throw new Error("Workflow projection persisted current integrity failure"); }
+}
+function derivedStatus(event: WorkflowTelemetryEvent): string | undefined {
+  return event.terminal?.status ?? event.status ?? (event.eventType === "run.started" || event.eventType === "task.started" ? "running" : undefined);
+}
+function currentRow(event: WorkflowTelemetryEvent, existing?: WorkflowProjectionCurrentRow, includeStatus = true): WorkflowProjectionCurrentRow {
+  const status = includeStatus ? derivedStatus(event) : undefined;
+  return { ...(existing ?? {}), ...event.dimensions, eventId: event.eventId, eventType: event.eventType, timestamp: event.timestamp, sequence: event.sequence, ...(status ? { status } : {}), ...(event.operation ? { operation: event.operation } : {}) };
+}
+function authoritativeFor(kind: CurrentKind, event: WorkflowTelemetryEvent): boolean {
+  if (kind === "sessions") return event.eventType.startsWith("session.") || event.eventType === "run.started";
+  if (kind === "runs") return event.eventType.startsWith("run.") || event.eventType === "terminal.recorded";
+  if (kind === "nodes") return event.eventType === "run.started" || event.eventType.startsWith("task.");
+  if (kind === "tasks") return event.eventType.startsWith("task.");
+  if (kind === "workspaces") return event.eventType === "artifact.recorded";
+  if (kind === "questions") return event.eventType === "question.transition";
+  if (kind === "approvals") return event.eventType === "approval.recorded";
+  return event.eventType === "knowledge.transition";
+}
+function validateQuery(query: WorkflowHistoryQuery): void {
+  const values = [query.cursor, query.projectId, query.sessionId, query.workflowId, query.runId, query.nodeId, query.taskId, query.eventType].filter((value): value is string => value !== undefined);
+  if (values.some((value) => Buffer.byteLength(value) > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow projection query exceeds its byte limit");
+}
+function canonicalDatabasePath(input: string): string {
+  const lexical = resolve(input);
+  mkdirSync(dirname(lexical), { recursive: true, mode: 0o700 });
+  const canonicalParent = realpathSync.native(dirname(lexical));
+  if (canonicalParent !== resolve(dirname(lexical))) throw new Error("Workflow projection database path contains a symlink alias");
+  if (existsSync(lexical) && lstatSync(lexical).isSymbolicLink()) throw new Error("Workflow projection database symlink is refused");
+  chmodSync(canonicalParent, 0o700);
+  return join(canonicalParent, basename(lexical));
+}
+function comparablePath(input: string): string {
+  const lexical = resolve(input);
+  if (existsSync(lexical)) return realpathSync.native(lexical);
+  const parent = dirname(lexical);
+  return existsSync(parent) ? join(realpathSync.native(parent), basename(lexical)) : lexical;
+}
+function privateSqliteFiles(path: string): void {
+  for (const file of [path, `${path}-wal`, `${path}-shm`]) if (existsSync(file)) chmodSync(file, 0o600);
+}
+function streamHash(value: Omit<ProjectionStreamStatus, "streamId"> & { streamId: string; projectId: string; sessionId: string; projectRoot?: string }): string {
+  return createHash("sha256").update("pi-hive-workflow-stream-state-v1\0").update(canonicalJson(value)).digest("hex");
+}
+interface PruneWatermark {
+  readonly streamId: string;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly projectRoot?: string;
+  readonly throughSequence: number;
+  readonly throughHash: string;
+  readonly cutoff: string;
+}
+function watermarkHash(value: PruneWatermark): string {
+  return createHash("sha256").update("pi-hive-workflow-prune-watermark-v1\0").update(canonicalJson(value)).digest("hex");
+}
+
+export class WorkflowProjectionIntegrityError extends Error {
+  constructor(message: string, options?: ErrorOptions) { super(message, options); this.name = "WorkflowProjectionIntegrityError"; }
+}
+
+/** A database format this version does not own and must never repair or replace. */
+export class WorkflowProjectionSchemaError extends Error {
+  constructor(message: string, options?: ErrorOptions) { super(message, options); this.name = "WorkflowProjectionSchemaError"; }
+}
+
+export interface OpenWorkflowProjectionDatabaseOptions {
+  readonly path: string;
+  readonly legacyPaths?: readonly string[];
+}
+
+export class WorkflowProjectionDatabase {
+  readonly database: Database;
+  readonly path: string;
+
+  constructor(options: OpenWorkflowProjectionDatabaseOptions) {
+    this.path = canonicalDatabasePath(options.path);
+    if ((options.legacyPaths ?? []).some((path) => comparablePath(path) === this.path
+      || (existsSync(path) && existsSync(this.path) && statSync(path).dev === statSync(this.path).dev && statSync(path).ino === statSync(this.path).ino))) throw new Error("Workflow projection must use a separate database and cannot open a legacy telemetry file or alias");
+    let opened: Database | undefined;
+    withCrossProcessFileLock(`${this.path}.initialize`, () => {
+      const existed = existsSync(this.path) && statSync(this.path).size > 0;
+      const database = new Database(this.path);
+      try {
+        database.run("PRAGMA busy_timeout = 5000");
+        const metadata = database.query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workflow_projection_metadata'`).get() as { name: string } | null;
+        if (existed && !metadata) throw new WorkflowProjectionSchemaError("Existing database is not a workflow projection; legacy/unknown schemas are preserved and refused");
+        if (!metadata) database.transaction(() => {
+          database.exec(SCHEMA);
+          database.query(`INSERT INTO workflow_projection_metadata (key, value) VALUES ('schema_version', ?)`).run(String(WORKFLOW_SQLITE_SCHEMA_VERSION));
+        })();
+        else {
+          const version = database.query(`SELECT value FROM workflow_projection_metadata WHERE key = 'schema_version'`).get() as { value: string } | null;
+          if (Number(version?.value ?? 0) !== WORKFLOW_SQLITE_SCHEMA_VERSION) throw new WorkflowProjectionSchemaError(`Unsupported workflow projection schema version ${version?.value ?? "missing"}`);
+        }
+        database.exec(PRUNE_SCHEMA);
+        database.run("PRAGMA journal_mode = WAL");
+        privateSqliteFiles(this.path);
+        opened = database;
+      } catch (error) { database.close(); throw error; }
+    }, { timeoutMs: 10_000, staleMs: 30_000 });
+    if (!opened) throw new Error("Workflow projection database initialization failed");
+    this.database = opened;
+    try {
+      if (this.schemaVersion() !== WORKFLOW_SQLITE_SCHEMA_VERSION) throw new WorkflowProjectionSchemaError("Unsupported workflow projection schema version");
+      this.assertPersistedIntegrity();
+    } catch (error) {
+      this.database.close();
+      if (error instanceof WorkflowProjectionIntegrityError || error instanceof WorkflowProjectionSchemaError) throw error;
+      throw new WorkflowProjectionIntegrityError(`Workflow projection persisted integrity failure: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
+  }
+
+  private assertPersistedIntegrity(): void {
+    const watermarkRows = this.database.query(`SELECT * FROM workflow_prune_watermarks ORDER BY stream_id`).all() as any[];
+    const watermarks = new Map<string, PruneWatermark>();
+    for (const row of watermarkRows) {
+      const value: PruneWatermark = { streamId: row.stream_id, projectId: row.project_id, sessionId: row.session_id,
+        ...(row.project_root ? { projectRoot: row.project_root } : {}), throughSequence: Number(row.through_sequence), throughHash: row.through_hash, cutoff: row.cutoff };
+      if (!/^wfs1-[0-9a-f]{64}$/u.test(value.streamId) || !Number.isSafeInteger(value.throughSequence) || value.throughSequence < 1
+        || !/^[0-9a-f]{64}$/u.test(value.throughHash) || !Number.isFinite(Date.parse(value.cutoff)) || row.state_hash !== watermarkHash(value)) throw new Error("Workflow projection persisted prune-watermark integrity failure");
+      watermarks.set(value.streamId, value);
+    }
+    const rows = this.database.query(`SELECT *, json(event_json) AS authenticated_event_json, json(terminal_refs_json) AS authenticated_terminal_refs_json FROM workflow_events ORDER BY stream_id, sequence`).all() as any[];
+    const events: WorkflowTelemetryEvent[] = [];
+    const eventById = new Map<string, WorkflowTelemetryEvent>();
+    const expectedCurrent = new Map<string, { kind: CurrentKind; key: string; event: WorkflowTelemetryEvent }>();
+    const dimensionColumns: ReadonlyArray<readonly [string, keyof WorkflowTelemetryEvent["dimensions"]]> = [
+      ["project_id", "projectId"], ["project_root", "projectRoot"], ["project_label", "projectLabel"], ["pi_session_id", "piSessionId"], ["session_id", "sessionId"],
+      ["workflow_id", "workflowId"], ["snapshot_id", "snapshotId"], ["workflow_config_hash", "workflowConfigHash"], ["workflow_config_version", "workflowConfigVersion"],
+      ["run_id", "runId"], ["agent_id", "agentId"], ["agent_name", "agentName"], ["node_id", "nodeId"], ["parent_node_id", "parentNodeId"], ["task_id", "taskId"],
+      ["adapter_id", "adapterId"], ["adapter_version", "adapterVersion"], ["profile_id", "profileId"], ["profile_version", "profileVersion"], ["workspace_id", "workspaceId"],
+      ["workspace_hash", "workspaceHash"], ["lease_state", "leaseState"], ["question_id", "questionId"], ["checkpoint_id", "checkpointId"], ["approval_id", "approvalId"],
+      ["knowledge_job_id", "knowledgeJobId"], ["knowledge_update_id", "knowledgeUpdateId"], ["model_id", "modelId"], ["thinking", "thinking"], ["tool_name", "toolName"],
+      ["capability_id", "capabilityId"], ["attempt_id", "attemptId"], ["operation_id", "operationId"],
+    ];
+    const priorByStream = new Map<string, { sequence: number; hash: string | null }>();
+    for (const persisted of rows) {
+      const event = parseEvent(persisted.authenticated_event_json);
+      const boundary = priorByStream.get(event.streamId) ?? { sequence: watermarks.get(event.streamId)?.throughSequence ?? 0, hash: watermarks.get(event.streamId)?.throughHash ?? null };
+      if (event.sequence !== boundary.sequence + 1 || event.previousHash !== boundary.hash) throw new Error(`Workflow projection persisted retained-event chain integrity failure in stream ${event.streamId}`);
+      priorByStream.set(event.streamId, { sequence: event.sequence, hash: event.sourceEventHash });
+      const expected: ReadonlyArray<readonly [string, unknown]> = [
+        ["event_id", event.eventId], ["stream_id", event.streamId], ["sequence", event.sequence], ["previous_hash", event.previousHash], ["event_hash", event.eventHash],
+        ["payload_hash", event.payloadHash], ["source_event_hash", event.sourceEventHash], ["timestamp", event.timestamp], ["event_type", event.eventType],
+        ["precision", event.usage?.precision ?? null], ["elapsed_ms", event.metrics?.elapsedMs ?? null], ["active_wall_time_ms", event.metrics?.activeWallTimeMs ?? null],
+        ["budget_scope", event.metrics?.budgetScope ?? null], ["budget_used", event.metrics?.budgetUsed ?? null], ["budget_limit", event.metrics?.budgetLimit ?? null],
+        ["budget_remaining", event.metrics?.budgetRemaining ?? null], ["change_coverage", event.terminal?.changeCoverage ?? null],
+      ];
+      if (expected.some(([column, value]) => persisted[column] !== value)
+        || dimensionColumns.some(([column, key]) => persisted[column] !== (event.dimensions[key] ?? null))
+        || canonicalJson(JSON.parse(persisted.authenticated_terminal_refs_json)) !== canonicalJson(event.terminal?.refs ?? [])) {
+        throw new Error(`Workflow projection persisted event normalized integrity failure in stream ${event.streamId}`);
+      }
+      events.push(event); eventById.set(event.eventId, event);
+      for (const kind of CURRENT_KINDS) {
+        const key = workflowProjectionCurrentKey(kind, event);
+        if (!key || !authoritativeFor(kind, event)) continue;
+        const mapKey = `${kind}\0${key}`;
+        expectedCurrent.set(mapKey, { kind, key, event });
+      }
+    }
+    const identities = this.database.query(`SELECT event_id, event_hash FROM workflow_event_identities ORDER BY event_id`).all() as Array<{ event_id: string; event_hash: string }>;
+    const identityById = new Map(identities.map((entry) => [entry.event_id, entry.event_hash]));
+    const validIdentity = (entry: { event_id: string; event_hash: string }): boolean => typeof entry.event_id === "string" && !!entry.event_id
+      && Buffer.byteLength(entry.event_id, "utf8") <= 256
+      && ![...entry.event_id].some((character) => character === "/" || character === "\\" || character.codePointAt(0)! <= 0x1f)
+      && /^[0-9a-f]{64}$/u.test(entry.event_hash);
+    if (identities.some((entry) => !validIdentity(entry) || (eventById.has(entry.event_id) && eventById.get(entry.event_id)?.eventHash !== entry.event_hash))
+      || events.some((event) => identityById.get(event.eventId) !== event.eventHash)) {
+      throw new Error("Workflow projection persisted event identity integrity failure");
+    }
+
+    const currentRows = this.database.query(`SELECT *, json(current_json) AS authenticated_current_json FROM workflow_current ORDER BY kind, entity_key`).all() as any[];
+    for (const persisted of currentRows) {
+      if (!CURRENT_KINDS.includes(persisted.kind)) throw new Error("Workflow projection persisted current integrity failure");
+      const mapKey = `${persisted.kind}\0${persisted.entity_key}`;
+      const expected = expectedCurrent.get(mapKey);
+      const parsed = parseCurrent(persisted.kind, persisted.entity_key, persisted.authenticated_current_json, persisted.current_hash);
+      const streamId = workflowTelemetryStreamId(parsed.projectId, parsed.sessionId);
+      if (!expected && !watermarks.has(streamId)) throw new Error("Workflow projection persisted current integrity failure");
+      const projected = expected ? currentRow(expected.event, parsed, expected.kind !== "sessions" || expected.event.eventType.startsWith("session.")) : parsed;
+      const d = expected?.event.dimensions;
+      if (canonicalJson(parsed) !== canonicalJson(projected) || persisted.current_order_key !== workflowProjectionCurrentOrderKey(parsed, persisted.entity_key)
+        || persisted.project_id !== parsed.projectId || persisted.session_id !== parsed.sessionId
+        || (d && (persisted.workflow_id !== (d.workflowId ?? null) || persisted.snapshot_id !== (d.snapshotId ?? null) || persisted.project_label !== (d.projectLabel ?? null)
+          || persisted.workflow_config_version !== (d.workflowConfigVersion ?? null) || persisted.run_id !== (d.runId ?? null) || persisted.node_id !== (d.nodeId ?? null)
+          || persisted.task_id !== (d.taskId ?? null))) || persisted.updated_at !== (expected?.event.timestamp ?? parsed.timestamp)) throw new Error("Workflow projection persisted current normalized integrity failure");
+      expectedCurrent.delete(mapKey);
+    }
+    if (expectedCurrent.size) throw new Error("Workflow projection persisted current coverage integrity failure");
+
+    const usageRows = this.database.query(`SELECT * FROM workflow_usage ORDER BY event_id`).all() as any[];
+    const usageEvents = events.filter((event) => event.usage);
+    if (usageRows.length !== usageEvents.length) throw new Error("Workflow projection persisted usage integrity failure");
+    for (const persisted of usageRows) {
+      const event = eventById.get(persisted.event_id); const usage = event?.usage; const d = event?.dimensions;
+      if (!event || !usage || !d || persisted.project_id !== d.projectId || persisted.session_id !== d.sessionId || persisted.workflow_id !== (d.workflowId ?? null)
+        || persisted.run_id !== (d.runId ?? null) || persisted.node_id !== (d.nodeId ?? null) || persisted.precision !== usage.precision
+        || persisted.input_tokens !== usage.inputTokens || persisted.output_tokens !== usage.outputTokens || persisted.cost_micro_usd !== usage.costMicroUsd
+        || persisted.timestamp !== event.timestamp) throw new Error(`Workflow projection persisted usage integrity failure in stream ${event?.streamId ?? "unknown"}`);
+    }
+
+    const byStream = new Map<string, WorkflowTelemetryEvent[]>();
+    for (const event of events) { const stream = byStream.get(event.streamId) ?? []; stream.push(event); byStream.set(event.streamId, stream); }
+    const remainingWatermarks = new Map(watermarks);
+    const streamRows = this.database.query(`SELECT * FROM workflow_streams ORDER BY stream_id`).all() as any[];
+    for (const persisted of streamRows) {
+      const streamEvents = byStream.get(persisted.stream_id) ?? [];
+      const last = streamEvents.at(-1);
+      const watermark = watermarks.get(persisted.stream_id);
+      const boundary = last ? { projectId: last.dimensions.projectId, sessionId: last.dimensions.sessionId, projectRoot: last.dimensions.projectRoot, sequence: last.sequence, hash: last.sourceEventHash }
+        : watermark ? { projectId: watermark.projectId, sessionId: watermark.sessionId, projectRoot: watermark.projectRoot, sequence: watermark.throughSequence, hash: watermark.throughHash } : undefined;
+      const state = persisted.state === "blocked" ? "blocked" : persisted.state === "ready" ? "ready" : undefined;
+      const value = { streamId: persisted.stream_id, projectId: persisted.project_id, sessionId: persisted.session_id, ...(persisted.project_root ? { projectRoot: persisted.project_root } : {}), state, lastSequence: Number(persisted.last_sequence), lastHash: persisted.last_hash ?? null, ...(persisted.diagnostic ? { diagnostic: persisted.diagnostic } : {}) } as any;
+      const emptyBlocked = !boundary && state === "blocked" && Number(persisted.last_sequence) === 0 && persisted.last_hash === null;
+      if (!state || (!boundary && !emptyBlocked) || Buffer.byteLength(persisted.diagnostic ?? "", "utf8") > 2_048 || persisted.state_hash !== streamHash(value)
+        || persisted.stream_id !== workflowTelemetryStreamId(persisted.project_id, persisted.session_id)
+        || (boundary && (persisted.project_id !== boundary.projectId || persisted.session_id !== boundary.sessionId || persisted.project_root !== (boundary.projectRoot ?? null)
+          || Number(persisted.last_sequence) !== boundary.sequence || persisted.last_hash !== boundary.hash))) throw new Error(`Workflow projection persisted stream-state integrity failure in stream ${persisted.stream_id}`);
+      byStream.delete(persisted.stream_id); remainingWatermarks.delete(persisted.stream_id);
+    }
+    if (byStream.size || remainingWatermarks.size) throw new Error("Workflow projection persisted stream-state coverage integrity failure");
+  }
+
+  close(): void { privateSqliteFiles(this.path); this.database.close(); privateSqliteFiles(this.path); }
+  schemaVersion(): number {
+    const row = this.database.query(`SELECT value FROM workflow_projection_metadata WHERE key = 'schema_version'`).get() as { value: string } | null;
+    return Number(row?.value ?? 0);
+  }
+  schemaSql(): string {
+    return (this.database.query(`SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name`).all() as Array<{ sql: string }>).map((row) => row.sql).join("\n");
+  }
+
+  streamStatus(streamId: string): ProjectionStreamStatus {
+    const row = this.database.query(`SELECT * FROM workflow_streams WHERE stream_id = ?`).get(streamId) as any;
+    return { streamId, state: row?.state === "blocked" ? "blocked" : "ready", lastSequence: Number(row?.last_sequence ?? 0), lastHash: row?.last_hash ?? null, ...(row?.diagnostic ? { diagnostic: row.diagnostic } : {}) };
+  }
+
+  persistedStreamEvents(streamIds: ReadonlySet<string>): readonly (readonly WorkflowTelemetryEvent[])[] {
+    const output = new Map<string, WorkflowTelemetryEvent[]>();
+    if (!streamIds.size) return [];
+    for (const row of this.database.query(`SELECT stream_id, json(event_json) AS event_json FROM workflow_events ORDER BY stream_id, sequence`).all() as Array<{ stream_id: string; event_json: string }>) {
+      if (!streamIds.has(row.stream_id)) continue;
+      const stream = output.get(row.stream_id) ?? []; stream.push(parseEvent(row.event_json)); output.set(row.stream_id, stream);
+    }
+    return [...output.values()];
+  }
+
+  assertAuthoritativeEvents(streams: readonly (readonly WorkflowTelemetryEvent[])[], preservedStreamIds: ReadonlySet<string> = new Set()): void {
+    const authoritative = new Map(streams.flatMap((stream) => stream[0] ? [[stream[0].streamId, stream] as const] : []));
+    const watermarks = this.database.query(`SELECT stream_id, through_sequence, through_hash FROM workflow_prune_watermarks`).all() as Array<{ stream_id: string; through_sequence: number; through_hash: string }>;
+    for (const watermark of watermarks) {
+      if (preservedStreamIds.has(watermark.stream_id)) continue;
+      const expected = authoritative.get(watermark.stream_id)?.[Number(watermark.through_sequence) - 1];
+      if (!expected || expected.sourceEventHash !== watermark.through_hash) throw new Error("Workflow projection prune watermark differs from authoritative journal source");
+    }
+    const rows = this.database.query(`SELECT stream_id, sequence, event_hash, source_event_hash FROM workflow_events ORDER BY stream_id, sequence`).all() as Array<{ stream_id: string; sequence: number; event_hash: string; source_event_hash: string }>;
+    for (const row of rows) {
+      const expected = authoritative.get(row.stream_id)?.[Number(row.sequence) - 1];
+      if (preservedStreamIds.has(row.stream_id)) continue;
+      if (!expected || expected.eventHash !== row.event_hash || expected.sourceEventHash !== row.source_event_hash) throw new Error("Workflow projection event differs from authoritative journal source");
+    }
+  }
+
+  ingest(event: WorkflowTelemetryEvent): "inserted" | "duplicate" {
+    verifyWorkflowTelemetryEvent(event);
+    const duplicate = this.database.query(`SELECT event_hash FROM workflow_event_identities WHERE event_id = ?`).get(event.eventId) as { event_hash: string } | null;
+    if (duplicate) {
+      if (duplicate.event_hash === event.eventHash) return "duplicate";
+      this.block(event, "reused event ID with a different hash");
+    }
+    const stream = this.streamStatus(event.streamId);
+    if (stream.state === "blocked") throw new Error(`Workflow projection stream is blocked: ${stream.diagnostic ?? "integrity failure"}`);
+    if (event.sequence !== stream.lastSequence + 1) this.block(event, `sequence gap: expected ${stream.lastSequence + 1}, received ${event.sequence}`);
+    if (event.previousHash !== stream.lastHash) this.block(event, "previous hash mismatch");
+
+    this.database.transaction(() => {
+      const d = event.dimensions;
+      this.database.query(`INSERT INTO workflow_event_identities (event_id, event_hash) VALUES (?, ?)`).run(event.eventId, event.eventHash);
+      this.database.query(`INSERT INTO workflow_events
+        (event_id, stream_id, project_id, project_root, project_label, pi_session_id, session_id, workflow_id, snapshot_id, workflow_config_hash, workflow_config_version, run_id,
+         agent_id, agent_name, node_id, parent_node_id, task_id, adapter_id, adapter_version, profile_id, profile_version,
+         workspace_id, workspace_hash, lease_state, question_id, checkpoint_id, approval_id, knowledge_job_id, knowledge_update_id,
+         model_id, thinking, tool_name, capability_id, attempt_id, operation_id, precision, elapsed_ms, active_wall_time_ms,
+         budget_scope, budget_used, budget_limit, budget_remaining, change_coverage, terminal_refs_json,
+         sequence, previous_hash, event_hash, payload_hash, source_event_hash, timestamp, event_type, event_json)
+        VALUES ($event_id, $stream_id, $project_id, $project_root, $project_label, $pi_session_id, $session_id, $workflow_id, $snapshot_id, $workflow_config_hash, $workflow_config_version, $run_id,
+         $agent_id, $agent_name, $node_id, $parent_node_id, $task_id, $adapter_id, $adapter_version, $profile_id, $profile_version,
+         $workspace_id, $workspace_hash, $lease_state, $question_id, $checkpoint_id, $approval_id, $knowledge_job_id, $knowledge_update_id,
+         $model_id, $thinking, $tool_name, $capability_id, $attempt_id, $operation_id, $precision, $elapsed_ms, $active_wall_time_ms,
+         $budget_scope, $budget_used, $budget_limit, $budget_remaining, $change_coverage, jsonb($terminal_refs_json),
+         $sequence, $previous_hash, $event_hash, $payload_hash, $source_event_hash, $timestamp, $event_type, jsonb($event_json))`).run({
+        $event_id: event.eventId, $stream_id: event.streamId, $project_id: d.projectId, $project_root: d.projectRoot ?? null, $project_label: d.projectLabel ?? null,
+        $pi_session_id: d.piSessionId ?? null, $session_id: d.sessionId, $workflow_id: d.workflowId ?? null, $snapshot_id: d.snapshotId ?? null,
+        $workflow_config_hash: d.workflowConfigHash ?? null, $workflow_config_version: d.workflowConfigVersion ?? null, $run_id: d.runId ?? null, $agent_id: d.agentId ?? null, $agent_name: d.agentName ?? null,
+        $node_id: d.nodeId ?? null, $parent_node_id: d.parentNodeId ?? null, $task_id: d.taskId ?? null, $adapter_id: d.adapterId ?? null,
+        $adapter_version: d.adapterVersion ?? null, $profile_id: d.profileId ?? null, $profile_version: d.profileVersion ?? null,
+        $workspace_id: d.workspaceId ?? null, $workspace_hash: d.workspaceHash ?? null, $lease_state: d.leaseState ?? null,
+        $question_id: d.questionId ?? null, $checkpoint_id: d.checkpointId ?? null, $approval_id: d.approvalId ?? null,
+        $knowledge_job_id: d.knowledgeJobId ?? null, $knowledge_update_id: d.knowledgeUpdateId ?? null, $model_id: d.modelId ?? null,
+        $thinking: d.thinking ?? null, $tool_name: d.toolName ?? null, $capability_id: d.capabilityId ?? null,
+        $attempt_id: d.attemptId ?? null, $operation_id: d.operationId ?? null, $precision: event.usage?.precision ?? null,
+        $elapsed_ms: event.metrics?.elapsedMs ?? null, $active_wall_time_ms: event.metrics?.activeWallTimeMs ?? null,
+        $budget_scope: event.metrics?.budgetScope ?? null, $budget_used: event.metrics?.budgetUsed ?? null,
+        $budget_limit: event.metrics?.budgetLimit ?? null, $budget_remaining: event.metrics?.budgetRemaining ?? null,
+        $change_coverage: event.terminal?.changeCoverage ?? null, $terminal_refs_json: JSON.stringify(event.terminal?.refs ?? []),
+        $sequence: event.sequence, $previous_hash: event.previousHash, $event_hash: event.eventHash, $payload_hash: event.payloadHash, $source_event_hash: event.sourceEventHash,
+        $timestamp: event.timestamp, $event_type: event.eventType, $event_json: JSON.stringify(event),
+      });
+      const streamValue = { streamId: event.streamId, projectId: d.projectId, sessionId: d.sessionId, ...(d.projectRoot ? { projectRoot: d.projectRoot } : {}), state: "ready" as const, lastSequence: event.sequence, lastHash: event.sourceEventHash };
+      this.database.query(`INSERT INTO workflow_streams (stream_id, project_id, session_id, project_root, state, last_sequence, last_hash, diagnostic, state_hash)
+        VALUES (?, ?, ?, ?, 'ready', ?, ?, NULL, ?) ON CONFLICT(stream_id) DO UPDATE SET project_root = excluded.project_root, state = 'ready', last_sequence = excluded.last_sequence, last_hash = excluded.last_hash, diagnostic = NULL, state_hash = excluded.state_hash`)
+        .run(event.streamId, d.projectId, d.sessionId, d.projectRoot ?? null, event.sequence, event.sourceEventHash, streamHash(streamValue));
+      for (const kind of CURRENT_KINDS) {
+        const key = workflowProjectionCurrentKey(kind, event);
+        if (!key || !authoritativeFor(kind, event)) continue;
+        const prior = this.database.query(`SELECT current_hash, json(current_json) AS current_json FROM workflow_current WHERE kind = ? AND entity_key = ?`).get(kind, key) as { current_hash: string; current_json: string } | null;
+        const existing = prior ? parseCurrent(kind, key, prior.current_json, prior.current_hash) : undefined;
+        const projected = currentRow(event, existing, kind !== "sessions" || event.eventType.startsWith("session."));
+        this.database.query(`INSERT INTO workflow_current (kind, entity_key, current_order_key, project_id, session_id, workflow_id, snapshot_id, project_label, workflow_config_version, run_id, node_id, task_id, updated_at, current_json, current_hash)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), ?)
+          ON CONFLICT(kind, entity_key) DO UPDATE SET current_order_key = excluded.current_order_key, updated_at = excluded.updated_at, current_json = excluded.current_json, current_hash = excluded.current_hash,
+            workflow_id = excluded.workflow_id, snapshot_id = excluded.snapshot_id, project_label = excluded.project_label, workflow_config_version = excluded.workflow_config_version,
+            run_id = excluded.run_id, node_id = excluded.node_id, task_id = excluded.task_id`)
+          .run(kind, key, workflowProjectionCurrentOrderKey(projected, key), d.projectId, d.sessionId, d.workflowId ?? null, d.snapshotId ?? null, d.projectLabel ?? null, d.workflowConfigVersion ?? null,
+            d.runId ?? null, d.nodeId ?? null, d.taskId ?? null, event.timestamp, JSON.stringify(projected), currentHash(kind, key, projected));
+      }
+      if (event.usage) this.database.query(`INSERT INTO workflow_usage (event_id, project_id, session_id, workflow_id, run_id, node_id, precision, input_tokens, output_tokens, cost_micro_usd, timestamp)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(event.eventId, d.projectId, d.sessionId, d.workflowId ?? null, d.runId ?? null, d.nodeId ?? null, event.usage.precision, event.usage.inputTokens, event.usage.outputTokens, event.usage.costMicroUsd, event.timestamp);
+    })();
+    return "inserted";
+  }
+
+  markStreamBlocked(streamId: string, projectId: string, sessionId: string, diagnostic: string, projectRoot?: string): void {
+    const prior = this.streamStatus(streamId);
+    const bounded = diagnostic.slice(0, 2_048);
+    const value = { streamId, projectId, sessionId, ...(projectRoot ? { projectRoot } : {}), state: "blocked" as const, lastSequence: prior.lastSequence, lastHash: prior.lastHash, diagnostic: bounded };
+    this.database.query(`INSERT INTO workflow_streams (stream_id, project_id, session_id, project_root, state, last_sequence, last_hash, diagnostic, state_hash)
+      VALUES (?, ?, ?, ?, 'blocked', ?, ?, ?, ?) ON CONFLICT(stream_id) DO UPDATE SET state = 'blocked', diagnostic = excluded.diagnostic, state_hash = excluded.state_hash`)
+      .run(streamId, projectId, sessionId, projectRoot ?? null, prior.lastSequence, prior.lastHash, bounded, streamHash(value));
+  }
+
+  existingStream(projectRoot: string, sessionId: string): Readonly<{ streamId: string; projectId: string; status: ProjectionStreamStatus }> | undefined {
+    const rows = this.database.query(`SELECT stream_id, project_id FROM workflow_streams WHERE project_root = ? AND session_id = ? LIMIT 2`).all(projectRoot, sessionId) as Array<{ stream_id: string; project_id: string }>;
+    if (rows.length !== 1) return undefined;
+    return Object.freeze({ streamId: rows[0].stream_id, projectId: rows[0].project_id, status: this.streamStatus(rows[0].stream_id) });
+  }
+
+  markExistingStreamBlocked(projectRoot: string, sessionId: string, diagnostic: string): string | undefined {
+    const existing = this.existingStream(projectRoot, sessionId);
+    if (!existing) return undefined;
+    this.markStreamBlocked(existing.streamId, existing.projectId, sessionId, diagnostic, projectRoot);
+    return existing.streamId;
+  }
+
+  private block(event: WorkflowTelemetryEvent, diagnostic: string): never {
+    this.markStreamBlocked(event.streamId, event.dimensions.projectId, event.dimensions.sessionId, diagnostic, event.dimensions.projectRoot);
+    throw new Error(`Workflow projection stream ${event.streamId} ${diagnostic}`);
+  }
+
+  history(query: WorkflowHistoryQuery): WorkflowHistoryPage {
+    if (!Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error(`Workflow history limit must be 1..${WORKFLOW_PROJECTION_PAGE_LIMIT}`);
+    validateQuery(query);
+    const where: string[] = [];
+    const parameters: Record<string, string | number> = { $limit: query.limit + 1 };
+    if (query.cursor) {
+      const [timestamp, streamId, sequence, eventId] = decodeWorkflowHistoryCursor(query.cursor);
+      where.push(`(timestamp > $timestamp OR (timestamp = $timestamp AND stream_id > $stream) OR (timestamp = $timestamp AND stream_id = $stream AND sequence > $sequence) OR (timestamp = $timestamp AND stream_id = $stream AND sequence = $sequence AND event_id > $event))`);
+      Object.assign(parameters, { $timestamp: timestamp, $stream: streamId, $sequence: sequence, $event: eventId });
+    }
+    const filters = [["project_id", "$project", query.projectId], ["session_id", "$session", query.sessionId], ["workflow_id", "$workflow", query.workflowId], ["run_id", "$run", query.runId], ["node_id", "$node", query.nodeId], ["task_id", "$task", query.taskId], ["event_type", "$type", query.eventType]] as const;
+    for (const [column, parameter, value] of filters) if (value) { where.push(`${column} = ${parameter}`); parameters[parameter] = value; }
+    const rows = this.database.query(`SELECT json(event_json) AS event_json FROM workflow_events ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY timestamp, stream_id, sequence, event_id LIMIT $limit`).all(parameters) as Array<{ event_json: string }>;
+    const hasMore = rows.length > query.limit;
+    const items = rows.slice(0, query.limit).map((entry) => parseEvent(entry.event_json));
+    return { items, ...(hasMore && items.length ? { nextCursor: encodeWorkflowHistoryCursor(items.at(-1)!) } : {}), hasMore };
+  }
+
+  current(): WorkflowProjectionCurrent {
+    return Object.fromEntries(CURRENT_KINDS.map((kind) => [kind, this.currentPage({ kind, limit: WORKFLOW_PROJECTION_PAGE_LIMIT }).items])) as unknown as WorkflowProjectionCurrent;
+  }
+
+  currentPage(query: WorkflowCurrentPageQuery): WorkflowCurrentPage {
+    if (!CURRENT_KINDS.includes(query.kind) || !Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error("Workflow current page query is invalid");
+    if (query.cursor && Buffer.byteLength(query.cursor) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current cursor exceeds its byte limit");
+    const where: string[] = ["kind = $kind"];
+    const parameters: Record<string, string | number> = { $kind: query.kind, $limit: query.limit + 1 };
+    if (query.cursor) {
+      where.push(`current_order_key > $current_order_key`);
+      parameters.$current_order_key = workflowProjectionCurrentCursorOrderKey(query.cursor);
+    }
+    const rows = this.database.query(`SELECT entity_key, current_hash, json(current_json) AS current_json FROM workflow_current
+      WHERE ${where.join(" AND ")} ORDER BY current_order_key LIMIT $limit`).all(parameters) as Array<{ entity_key: string; current_hash: string; current_json: string }>;
+    const hasMore = rows.length > query.limit;
+    const selected = rows.slice(0, query.limit).map((entry) => ({ ...entry, value: parseCurrent(query.kind, entry.entity_key, entry.current_json, entry.current_hash) }));
+    const last = selected.at(-1);
+    return { items: selected.map((entry) => entry.value), ...(hasMore && last ? { nextCursor: encodeWorkflowCurrentCursor(last.value, last.entity_key) } : {}), hasMore };
+  }
+
+  usage(): WorkflowProjectionUsageTotals {
+    const output: WorkflowProjectionUsageTotals = { estimated: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 }, providerConfirmed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 } };
+    const rows = this.database.query(`SELECT precision, input_tokens, output_tokens, cost_micro_usd FROM workflow_usage ORDER BY event_id`).all() as Array<{ precision: string; input_tokens: number; output_tokens: number; cost_micro_usd: number }>;
+    for (const row of rows) {
+      const key = row.precision === "provider-confirmed" ? "providerConfirmed" : "estimated";
+      const bucket = output[key] as { inputTokens: number; outputTokens: number; costMicroUsd: number };
+      for (const [target, value] of [["inputTokens", row.input_tokens], ["outputTokens", row.output_tokens], ["costMicroUsd", row.cost_micro_usd]] as const) {
+        const total = bucket[target] + Number(value);
+        if (!Number.isSafeInteger(total) || total < 0) throw new Error("Workflow projection usage total exceeds its safe magnitude");
+        bucket[target] = total;
+      }
+    }
+    return output;
+  }
+
+  reset(): void {
+    this.database.transaction(() => {
+      this.database.run(`DELETE FROM workflow_usage`); this.database.run(`DELETE FROM workflow_current`); this.database.run(`DELETE FROM workflow_events`); this.database.run(`DELETE FROM workflow_event_identities`); this.database.run(`DELETE FROM workflow_streams`); this.database.run(`DELETE FROM workflow_prune_watermarks`);
+    })();
+  }
+  rebuild(streams: readonly (readonly WorkflowTelemetryEvent[])[]): Readonly<{ diagnostics: readonly Readonly<{ streamId: string; diagnostic: string }>[] }> {
+    this.reset();
+    const diagnostics: Array<Readonly<{ streamId: string; diagnostic: string }>> = [];
+    const ordered = [...streams].map((events) => [...events].sort((a, b) => a.sequence - b.sequence)).sort((a, b) => String(a[0]?.streamId ?? "").localeCompare(String(b[0]?.streamId ?? "")));
+    for (const stream of ordered) {
+      if (!stream[0]) continue;
+      try { this.database.transaction(() => { for (const event of stream) this.ingest(event); })(); }
+      catch (error) {
+        const diagnostic = String(error instanceof Error ? error.message : error).slice(0, 2_048);
+        this.markStreamBlocked(stream[0].streamId, stream[0].dimensions.projectId, stream[0].dimensions.sessionId, diagnostic, stream[0].dimensions.projectRoot);
+        diagnostics.push(Object.freeze({ streamId: stream[0].streamId, diagnostic }));
+      }
+    }
+    return Object.freeze({ diagnostics: Object.freeze(diagnostics) });
+  }
+  pruneProjection(cutoffIso: string): { removed: number; retained: number } {
+    if (!Number.isFinite(Date.parse(cutoffIso))) throw new Error("Projection prune cutoff is invalid");
+    let removed = 0;
+    const candidateSql = `SELECT e.* FROM workflow_events e WHERE julianday(e.timestamp) < julianday($cutoff) AND NOT EXISTS (
+      SELECT 1 FROM workflow_events prior WHERE prior.stream_id = e.stream_id AND prior.sequence < e.sequence AND julianday(prior.timestamp) >= julianday($cutoff))`;
+    this.database.transaction(() => {
+      const candidates = this.database.query(`${candidateSql} ORDER BY e.stream_id, e.sequence`).all({ $cutoff: cutoffIso }) as any[];
+      removed = candidates.length;
+      const lastByStream = new Map<string, any>();
+      for (const candidate of candidates) lastByStream.set(candidate.stream_id, candidate);
+      for (const candidate of lastByStream.values()) {
+        const value: PruneWatermark = { streamId: candidate.stream_id, projectId: candidate.project_id, sessionId: candidate.session_id,
+          ...(candidate.project_root ? { projectRoot: candidate.project_root } : {}), throughSequence: Number(candidate.sequence), throughHash: candidate.source_event_hash, cutoff: cutoffIso };
+        this.database.query(`INSERT INTO workflow_prune_watermarks (stream_id, project_id, session_id, project_root, through_sequence, through_hash, cutoff, state_hash)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(stream_id) DO UPDATE SET project_id = excluded.project_id, session_id = excluded.session_id,
+          project_root = excluded.project_root, through_sequence = excluded.through_sequence, through_hash = excluded.through_hash, cutoff = excluded.cutoff, state_hash = excluded.state_hash`)
+          .run(value.streamId, value.projectId, value.sessionId, value.projectRoot ?? null, value.throughSequence, value.throughHash, value.cutoff, watermarkHash(value));
+      }
+      this.database.query(`DELETE FROM workflow_usage WHERE event_id IN (SELECT event_id FROM (${candidateSql}))`).run({ $cutoff: cutoffIso });
+      // Identity rows intentionally outlive retained history and its watermark.
+      this.database.query(`DELETE FROM workflow_events WHERE event_id IN (SELECT event_id FROM (${candidateSql}))`).run({ $cutoff: cutoffIso });
+    })();
+    this.assertPersistedIntegrity();
+    const retainedRow = this.database.query(`SELECT COUNT(*) AS count FROM workflow_events`).get() as { count: number } | null;
+    return { removed, retained: Number(retainedRow?.count ?? 0) };
+  }
+  snapshot(): Record<string, unknown> {
+    const countRow = this.database.query(`SELECT COUNT(*) AS count FROM workflow_events`).get() as { count: number } | null;
+    const count = Number(countRow?.count ?? 0);
+    const streams = (this.database.query(`SELECT stream_id FROM workflow_streams ORDER BY stream_id`).all() as Array<{ stream_id: string }>).map((row) => this.streamStatus(row.stream_id));
+    return { schemaVersion: this.schemaVersion(), streams, current: this.current(), history: this.history({ limit: Math.max(1, Math.min(WORKFLOW_PROJECTION_PAGE_LIMIT, count || 1)) }).items, usage: this.usage() };
+  }
+}
+
+export function openWorkflowProjectionDatabase(options: OpenWorkflowProjectionDatabaseOptions): WorkflowProjectionDatabase {
+  return new WorkflowProjectionDatabase(options);
+}

--- a/src/observability/server/workflow-runtime.ts
+++ b/src/observability/server/workflow-runtime.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readdirSync, rmSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { loadConfigProject } from "../../config/manifest";
+import { readWorkflowJournal, readWorkflowJournalFrom, workflowJournalDirectory } from "../../workflows/journal";
+import { toWorkflowTelemetryEvent, type WorkflowTelemetryEvent } from "../events";
+import { WorkflowProjectionIntegrityError, openWorkflowProjectionDatabase } from "./workflow-db";
+
+export interface SyncConfiguredWorkflowProjectionInput {
+  readonly databasePath: string;
+  readonly projectRoots: readonly string[];
+  readonly legacyPaths?: readonly string[];
+  readonly retentionDays?: number;
+  readonly now?: () => Date;
+}
+export interface ConfiguredWorkflowProjectionSynchronizerOptions {
+  readonly databasePath: string;
+  readonly legacyPaths?: readonly string[];
+  readonly retentionDays?: number;
+  readonly now?: () => Date;
+  readonly pruneIntervalMs?: number;
+}
+export interface WorkflowProjectionSyncDiagnostic { readonly projectRoot: string; readonly sessionId: string; readonly diagnostic: string }
+export interface SyncConfiguredWorkflowProjectionResult { readonly active: boolean; readonly events: number; readonly streams: number; readonly diagnostics?: readonly WorkflowProjectionSyncDiagnostic[] }
+export interface ConfiguredWorkflowProjectionSynchronizer {
+  sync(projectRoots: readonly string[]): SyncConfiguredWorkflowProjectionResult;
+  close(): void;
+}
+
+interface JournalReference { readonly projectRoot: string; readonly sessionId: string; readonly journalPath: string }
+interface JournalFingerprint {
+  readonly directory: string;
+  readonly eventCount: number;
+  /** Fixed-size digest of every committed event filename and metadata identity. */
+  readonly identities: string;
+  /** Digest of the current prefix corresponding to the prior fingerprint, when supplied. */
+  readonly priorIdentities?: string;
+}
+
+export function workflowProjectionRootCandidates(projectCwd: string, discoveredRoots: readonly string[]): readonly string[] {
+  return Object.freeze([...new Set([projectCwd, ...discoveredRoots].filter(Boolean))]);
+}
+
+function configuredRoots(inputs: readonly string[]): readonly string[] {
+  const output = new Set<string>();
+  for (const cwd of inputs) {
+    if (!cwd || !existsSync(cwd)) continue;
+    const project = loadConfigProject(cwd);
+    if (project.status === "configured") output.add(project.projectRoot);
+  }
+  return [...output].sort();
+}
+
+function boundedDiagnostic(error: unknown): string {
+  return String(error instanceof Error ? error.message : error).slice(0, 2_048);
+}
+
+function journalReferences(projectRoot: string): Readonly<{ references: JournalReference[]; diagnostics: WorkflowProjectionSyncDiagnostic[] }> {
+  const sessionsRoot = join(projectRoot, ".pi", "hive", "sessions");
+  if (!existsSync(sessionsRoot) || !lstatSync(sessionsRoot).isDirectory() || lstatSync(sessionsRoot).isSymbolicLink()) return { references: [], diagnostics: [] };
+  const references: JournalReference[] = [];
+  const diagnostics: WorkflowProjectionSyncDiagnostic[] = [];
+  for (const sessionId of readdirSync(sessionsRoot).sort()) {
+    try {
+      const sessionPath = join(sessionsRoot, sessionId);
+      const journalPath = workflowJournalDirectory(projectRoot, sessionId);
+      if (!lstatSync(sessionPath).isDirectory() || lstatSync(sessionPath).isSymbolicLink() || !existsSync(journalPath)) continue;
+      const journalStat = lstatSync(journalPath);
+      if (!journalStat.isDirectory() || journalStat.isSymbolicLink()) throw new Error("Workflow journal path invalid");
+      references.push(Object.freeze({ projectRoot, sessionId, journalPath }));
+    } catch (error) {
+      diagnostics.push(Object.freeze({ projectRoot, sessionId: sessionId.slice(0, 256), diagnostic: boundedDiagnostic(error) }));
+    }
+  }
+  return { references, diagnostics };
+}
+
+function statIdentity(path: string): string {
+  const value = statSync(path, { bigint: true });
+  return `${value.dev}:${value.ino}:${value.size}:${value.mtimeNs}:${value.ctimeNs}`;
+}
+
+function updateIdentity(hash: ReturnType<typeof createHash>, name: string, identity: string): void {
+  hash.update(`${Buffer.byteLength(name, "utf8")}:`).update(name).update(`${Buffer.byteLength(identity, "utf8")}:`).update(identity);
+}
+
+function fingerprint(reference: JournalReference, prior?: JournalFingerprint): JournalFingerprint {
+  const directory = statIdentity(reference.journalPath);
+  const names = readdirSync(reference.journalPath).filter((name) => name.endsWith(".json")).sort();
+  const identities = createHash("sha256").update("pi-hive-workflow-journal-metadata-v1\0");
+  const priorIdentities = prior ? createHash("sha256").update("pi-hive-workflow-journal-metadata-v1\0") : undefined;
+  for (let index = 0; index < names.length; index += 1) {
+    const name = names[index];
+    const identity = statIdentity(join(reference.journalPath, name));
+    updateIdentity(identities, name, identity);
+    if (priorIdentities && index < prior!.eventCount) updateIdentity(priorIdentities, name, identity);
+  }
+  return Object.freeze({
+    directory,
+    eventCount: names.length,
+    identities: identities.digest("hex"),
+    ...(priorIdentities ? { priorIdentities: priorIdentities.digest("hex") } : {}),
+  });
+}
+
+function sameFingerprint(left: JournalFingerprint | undefined, right: JournalFingerprint): boolean {
+  return left?.directory === right.directory && left.eventCount === right.eventCount && left.identities === right.identities;
+}
+
+function priorEventsUnchanged(prior: JournalFingerprint | undefined, current: JournalFingerprint): boolean {
+  return !!prior && current.eventCount >= prior.eventCount && current.priorIdentities === prior.identities;
+}
+
+function telemetry(events: readonly import("../../workflows/events").WorkflowEventEnvelope[], reference: JournalReference): WorkflowTelemetryEvent[] {
+  return events.map((event) => toWorkflowTelemetryEvent(event, {
+    projectRoot: reference.projectRoot,
+    projectLabel: basename(reference.projectRoot),
+    workflowConfigVersion: "1",
+  }));
+}
+
+class PersistentConfiguredWorkflowProjectionSynchronizer implements ConfiguredWorkflowProjectionSynchronizer {
+  private projection?: ReturnType<typeof openWorkflowProjectionDatabase>;
+  private readonly fingerprints = new Map<string, JournalFingerprint>();
+  private initial = true;
+  private closed = false;
+  private lastPruneAt: number | undefined;
+
+  constructor(private readonly options: ConfiguredWorkflowProjectionSynchronizerOptions) {
+    if (options.retentionDays !== undefined && (!Number.isSafeInteger(options.retentionDays) || options.retentionDays < 1 || options.retentionDays > 3_650)) {
+      throw new Error("Workflow projection retention days must be 1..3650");
+    }
+    if (options.pruneIntervalMs !== undefined && (!Number.isSafeInteger(options.pruneIntervalMs) || options.pruneIntervalMs < 1_000)) {
+      throw new Error("Workflow projection prune interval is invalid");
+    }
+  }
+
+  private openProjection(): ReturnType<typeof openWorkflowProjectionDatabase> {
+    if (this.projection) return this.projection;
+    try { this.projection = openWorkflowProjectionDatabase({ path: this.options.databasePath, legacyPaths: this.options.legacyPaths }); }
+    catch (error) {
+      if (!(error instanceof WorkflowProjectionIntegrityError)) throw error;
+      for (const path of [this.options.databasePath, `${this.options.databasePath}-wal`, `${this.options.databasePath}-shm`]) rmSync(path, { force: true });
+      this.projection = openWorkflowProjectionDatabase({ path: this.options.databasePath, legacyPaths: this.options.legacyPaths });
+    }
+    return this.projection;
+  }
+
+  private pruneIfDue(projection: ReturnType<typeof openWorkflowProjectionDatabase>): void {
+    if (this.options.retentionDays === undefined) return;
+    const now = (this.options.now ?? (() => new Date()))();
+    const nowMs = now.getTime();
+    if (!Number.isFinite(nowMs)) throw new Error("Workflow projection retention clock is invalid");
+    const interval = this.options.pruneIntervalMs ?? 60 * 60 * 1_000;
+    if (this.lastPruneAt !== undefined && nowMs - this.lastPruneAt < interval) return;
+    projection.pruneProjection(new Date(nowMs - this.options.retentionDays * 86_400_000).toISOString());
+    this.lastPruneAt = nowMs;
+  }
+
+  sync(projectRoots: readonly string[]): SyncConfiguredWorkflowProjectionResult {
+    if (this.closed) throw new Error("Workflow projection synchronizer is closed");
+    const roots = configuredRoots(projectRoots);
+    if (!roots.length) return Object.freeze({ active: false, events: 0, streams: 0 });
+    const projection = this.openProjection();
+    const discovered = roots.map(journalReferences);
+    const references = discovered.flatMap((entry) => entry.references);
+    const diagnostics = discovered.flatMap((entry) => entry.diagnostics);
+    let processed = 0;
+
+    if (this.initial) {
+      const readable: Array<{ reference: JournalReference; events: WorkflowTelemetryEvent[] }> = [];
+      for (const reference of references) {
+        try {
+          const before = fingerprint(reference);
+          const events = telemetry(readWorkflowJournal(reference.projectRoot, reference.sessionId), reference);
+          if (events.length) readable.push({ reference, events });
+          const after = fingerprint(reference, before);
+          if (sameFingerprint(before, after)) this.fingerprints.set(reference.journalPath, after);
+        } catch (error) {
+          const diagnostic = boundedDiagnostic(error);
+          projection.markExistingStreamBlocked(reference.projectRoot, reference.sessionId, diagnostic);
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
+        }
+      }
+      readable.sort((left, right) => left.events[0].streamId.localeCompare(right.events[0].streamId));
+      for (const { reference, events } of readable) {
+        const existing = projection.existingStream(reference.projectRoot, reference.sessionId);
+        if (existing?.status.state === "blocked") {
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic: existing.status.diagnostic ?? "Workflow projection stream is blocked" }));
+          continue;
+        }
+        const boundary = existing?.status.lastSequence ? events[existing.status.lastSequence - 1] : undefined;
+        if (existing && (existing.status.lastSequence > events.length || boundary?.sourceEventHash !== existing.status.lastHash)) {
+          const diagnostic = "Workflow projection cursor differs from authoritative journal source";
+          projection.markStreamBlocked(existing.streamId, existing.projectId, reference.sessionId, diagnostic, reference.projectRoot);
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
+          continue;
+        }
+        try {
+          for (const event of events.slice(existing?.status.lastSequence ?? 0)) if (projection.ingest(event) === "inserted") processed += 1;
+        } catch (error) {
+          const diagnostic = boundedDiagnostic(error);
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
+        }
+      }
+      this.initial = false;
+    } else {
+      for (const reference of references) {
+        const priorFingerprint = this.fingerprints.get(reference.journalPath);
+        let currentFingerprint: JournalFingerprint;
+        try { currentFingerprint = fingerprint(reference, priorFingerprint); }
+        catch (error) {
+          const diagnostic = boundedDiagnostic(error);
+          projection.markExistingStreamBlocked(reference.projectRoot, reference.sessionId, diagnostic);
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
+          continue;
+        }
+        const existing = projection.existingStream(reference.projectRoot, reference.sessionId);
+        if (sameFingerprint(priorFingerprint, currentFingerprint)) {
+          if (existing?.status.state === "blocked") diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic: existing.status.diagnostic ?? "Workflow projection stream is blocked" }));
+          continue;
+        }
+        try {
+          const verifyAll = !!existing && !priorEventsUnchanged(priorFingerprint, currentFingerprint);
+          const source = verifyAll || !existing
+            ? readWorkflowJournal(reference.projectRoot, reference.sessionId)
+            : readWorkflowJournalFrom(reference.projectRoot, reference.sessionId, { sequence: existing.status.lastSequence, hash: existing.status.lastHash, projectId: existing.projectId }, { verifyBoundary: true });
+          const authoritative = telemetry(source, reference);
+          if (verifyAll) projection.assertAuthoritativeEvents([authoritative]);
+          const events = verifyAll && existing ? authoritative.slice(existing.status.lastSequence) : authoritative;
+          if (existing?.status.state === "blocked") {
+            diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic: existing.status.diagnostic ?? "Workflow projection stream is blocked" }));
+          } else {
+            for (const event of events) if (projection.ingest(event) === "inserted") processed += 1;
+          }
+          const after = fingerprint(reference, currentFingerprint);
+          if (sameFingerprint(currentFingerprint, after)) this.fingerprints.set(reference.journalPath, after);
+        } catch (error) {
+          const diagnostic = boundedDiagnostic(error);
+          projection.markExistingStreamBlocked(reference.projectRoot, reference.sessionId, diagnostic);
+          diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
+          // Preserve the prior fingerprint so a repaired source is retried.
+        }
+      }
+    }
+
+    this.pruneIfDue(projection);
+    return Object.freeze({ active: true, events: processed, streams: references.length, ...(diagnostics.length ? { diagnostics: Object.freeze(diagnostics.slice(0, 256)) } : {}) });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.fingerprints.clear();
+    this.projection?.close();
+    this.projection = undefined;
+  }
+}
+
+export function createConfiguredWorkflowProjectionSynchronizer(options: ConfiguredWorkflowProjectionSynchronizerOptions): ConfiguredWorkflowProjectionSynchronizer {
+  return new PersistentConfiguredWorkflowProjectionSynchronizer(options);
+}
+
+/** One-shot compatibility helper. Production owns a persistent synchronizer. */
+export function syncConfiguredWorkflowProjection(input: SyncConfiguredWorkflowProjectionInput): SyncConfiguredWorkflowProjectionResult {
+  const synchronizer = createConfiguredWorkflowProjectionSynchronizer(input);
+  try { return synchronizer.sync(input.projectRoots); }
+  finally { synchronizer.close(); }
+}

--- a/src/shared/dashboard-api.ts
+++ b/src/shared/dashboard-api.ts
@@ -4,6 +4,51 @@ import type {
   HiveTopology,
   TelemetrySessionSummary,
 } from "./telemetry";
+import type { WorkflowTelemetryEvent } from "../observability/events";
+import type {
+  ProjectionStreamStatus,
+  WorkflowProjectionCurrent,
+  WorkflowProjectionCurrentRow,
+  WorkflowProjectionUsageTotals,
+} from "../observability/projection";
+
+export const WORKFLOW_DASHBOARD_API_VERSION = 1 as const;
+export const WORKFLOW_DASHBOARD_MAX_PAGE_SIZE = 500 as const;
+
+export interface WorkflowDashboardHistoryPage {
+  readonly apiVersion: 1;
+  readonly items: readonly WorkflowTelemetryEvent[];
+  readonly nextCursor?: string;
+  readonly hasMore: boolean;
+}
+
+export interface WorkflowDashboardCurrentResponse {
+  readonly apiVersion: 1;
+  /** Compatibility bootstrap only; every entity collection is capped at WORKFLOW_DASHBOARD_MAX_PAGE_SIZE. */
+  readonly current: WorkflowProjectionCurrent;
+  readonly streams: readonly ProjectionStreamStatus[];
+}
+
+export interface WorkflowDashboardCurrentPage {
+  readonly apiVersion: 1;
+  readonly kind: keyof WorkflowProjectionCurrent;
+  readonly items: readonly WorkflowProjectionCurrentRow[];
+  readonly nextCursor?: string;
+  readonly hasMore: boolean;
+}
+
+export interface WorkflowDashboardUsageResponse {
+  readonly apiVersion: 1;
+  readonly usage: WorkflowProjectionUsageTotals;
+}
+
+export interface WorkflowDashboardProjectionMaintenance {
+  readonly apiVersion: 1;
+  readonly operation: "rebuild" | "prune";
+  readonly events: number;
+  readonly streams: number;
+  readonly completedAt: string;
+}
 
 export interface DashboardBootstrap {
   token: string | null;

--- a/src/workflows/events.ts
+++ b/src/workflows/events.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { canonicalJson } from "../config/snapshot-canonical";
 import type { JsonValue } from "../config/types";
+import { redactJournalPayload } from "../observability/redaction";
 
 export const WORKFLOW_EVENT_FORMAT_VERSION = 1 as const;
 export const WORKFLOW_EVENT_LIMITS = Object.freeze({ payloadBytes: 262_144, eventBytes: 524_288, idBytes: 256, diagnosticsBytes: 4_096 });
@@ -87,7 +88,7 @@ function validateDraft(input: WorkflowEventDraft): void {
 }
 export function createWorkflowEvent(input: CreateWorkflowEventInput): WorkflowEventDraft {
   const timestamp = input.timestamp ?? new Date().toISOString();
-  const result = { eventId: boundedId(input.eventId ?? randomUUID(), "ID"), projectId: boundedId(input.projectId, "PROJECT"), sessionId: boundedId(input.sessionId, "SESSION"), ...(input.runId ? { runId: boundedId(input.runId, "RUN") } : {}), type: input.type, payload: deepFreeze(structuredClone(input.payload)), timestamp, producer: input.producer, ...(input.correlationId ? { correlationId: boundedId(input.correlationId, "CORRELATION") } : {}), ...(input.attemptId ? { attemptId: boundedId(input.attemptId, "ATTEMPT") } : {}) }; validateDraft(result); return Object.freeze(result);
+  const result = { eventId: boundedId(input.eventId ?? randomUUID(), "ID"), projectId: boundedId(input.projectId, "PROJECT"), sessionId: boundedId(input.sessionId, "SESSION"), ...(input.runId ? { runId: boundedId(input.runId, "RUN") } : {}), type: input.type, payload: deepFreeze(redactJournalPayload(input.payload)), timestamp, producer: input.producer, ...(input.correlationId ? { correlationId: boundedId(input.correlationId, "CORRELATION") } : {}), ...(input.attemptId ? { attemptId: boundedId(input.attemptId, "ATTEMPT") } : {}) }; validateDraft(result); return Object.freeze(result);
 }
 export function sealWorkflowEvent(draft: WorkflowEventDraft, sequence: number, previousHash: string | null): WorkflowEventEnvelope {
   validateDraft(draft);

--- a/src/workflows/journal.ts
+++ b/src/workflows/journal.ts
@@ -1,13 +1,50 @@
 import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { withCrossProcessFileLock } from "../core/file-lock";
 import { resolveProjectPath } from "../core/safe-path";
+import { loadConfigProject } from "../config/manifest";
 import { canonicalJson } from "../config/snapshot-canonical";
-import { sealWorkflowEvent, verifyWorkflowEvent, WORKFLOW_EVENT_LIMITS, type WorkflowEventDraft, type WorkflowEventEnvelope } from "./events";
+import { redactJournalPayload, type WorkflowRedactionOptions } from "../observability/redaction";
+import { createWorkflowEvent, sealWorkflowEvent, verifyWorkflowEvent, WORKFLOW_EVENT_LIMITS, type WorkflowEventDraft, type WorkflowEventEnvelope } from "./events";
 
 export type JournalFaultStage = "beforeWrite" | "afterFileFsync" | "beforeRename" | "afterRename" | "beforeDirFsync";
-export interface JournalFaultOptions { readonly fault?: (stage: JournalFaultStage) => void }
+export interface JournalFaultOptions { readonly fault?: (stage: JournalFaultStage) => void; readonly redaction?: WorkflowRedactionOptions }
+
+const configuredRedaction = new Map<string, WorkflowRedactionOptions>();
+
+/** Installs the project policy consumed by every production journal writer. */
+export function configureWorkflowJournalRedaction(projectRoot: string, policy: WorkflowRedactionOptions): void {
+  const root = resolve(projectRoot);
+  const configured: WorkflowRedactionOptions = Object.freeze({
+    ...(policy.environment ? { environment: Object.freeze({ ...policy.environment }) } : {}),
+    ...(policy.protectedPaths ? { protectedPaths: Object.freeze([...policy.protectedPaths]) } : {}),
+    projectRoot: root,
+  });
+  // Validate cardinality/byte bounds at configuration time, before a writer can persist.
+  redactJournalPayload(null, configured);
+  if (!configuredRedaction.has(root) && configuredRedaction.size >= 64) throw new Error("Workflow journal redaction project limit exceeded");
+  configuredRedaction.set(root, configured);
+}
+
+function loadedProjectProtectedPaths(projectRoot: string): readonly string[] {
+  const project = loadConfigProject(projectRoot);
+  if (project.status !== "configured") return [];
+  return Object.values(project.manifest.knowledge ?? {}).map((entry) => entry.path);
+}
+
+function journalRedaction(projectRoot: string, local?: WorkflowRedactionOptions): WorkflowRedactionOptions {
+  const configured = configuredRedaction.get(resolve(projectRoot));
+  return {
+    environment: { ...process.env, ...(configured?.environment ?? {}), ...(local?.environment ?? {}) },
+    protectedPaths: [...loadedProjectProtectedPaths(projectRoot), ...(configured?.protectedPaths ?? []), ...(local?.protectedPaths ?? [])],
+    projectRoot: resolve(projectRoot),
+    maxStringBytes: local?.maxStringBytes,
+    maxArrayItems: local?.maxArrayItems,
+    maxObjectKeys: local?.maxObjectKeys,
+    maxDepth: local?.maxDepth,
+  };
+}
 
 function resolveWorkflowSessionDirectory(projectRoot: string, sessionId: string) {
   let unsafe = false; for (const character of sessionId) if (character === "/" || character === "\\" || character.codePointAt(0) === 0) unsafe = true;
@@ -23,7 +60,8 @@ export function workflowJournalIdentity(projectRoot: string, sessionId: string):
 }
 function ensureDirectory(path: string): void { mkdirSync(path, { recursive: true, mode: 0o700 }); if (!lstatSync(path).isDirectory() || lstatSync(path).isSymbolicLink()) throw new Error("WORKFLOW_JOURNAL_DIRECTORY_INVALID"); }
 function fsyncDirectory(path: string): void { const fd = openSync(path, constants.O_RDONLY); try { fsyncSync(fd); } finally { closeSync(fd); } }
-function journalDirectory(root: string, sessionId: string): string { return join(workflowSessionDirectory(root, sessionId), "journal"); }
+export function workflowJournalDirectory(root: string, sessionId: string): string { return join(workflowSessionDirectory(root, sessionId), "journal"); }
+function journalDirectory(root: string, sessionId: string): string { return workflowJournalDirectory(root, sessionId); }
 function deepFreeze<T>(value: T): T { if (value && typeof value === "object") { for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child); Object.freeze(value); } return value; }
 function parseEvent(path: string): WorkflowEventEnvelope {
   let fd: number | undefined;
@@ -31,12 +69,66 @@ function parseEvent(path: string): WorkflowEventEnvelope {
   catch (error) { if (error instanceof Error && /Workflow journal/u.test(error.message)) throw error; throw new Error("Workflow journal event corruption"); }
   finally { if (fd !== undefined) closeSync(fd); }
 }
+export interface WorkflowJournalCursor {
+  readonly sequence: number;
+  readonly hash: string | null;
+  readonly projectId?: string;
+}
+
+function journalEventNames(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
+}
+
+/**
+ * Reads and verifies only events committed after a trusted sequence/hash cursor.
+ * The cursor boundary is authenticated by its immutable filename; callers that
+ * detect an out-of-band file change can request a boundary content check too.
+ */
+export function readWorkflowJournalFrom(
+  projectRoot: string,
+  sessionId: string,
+  cursor: WorkflowJournalCursor,
+  options: { readonly verifyBoundary?: boolean } = {},
+): readonly WorkflowEventEnvelope[] {
+  if (!Number.isSafeInteger(cursor.sequence) || cursor.sequence < 0 || (cursor.sequence === 0 ? cursor.hash !== null : !/^[0-9a-f]{64}$/u.test(cursor.hash ?? ""))) {
+    throw new Error("Workflow journal cursor invalid");
+  }
+  const dir = journalDirectory(projectRoot, sessionId);
+  try { if (!lstatSync(dir).isDirectory() || lstatSync(dir).isSymbolicLink()) throw new Error("Workflow journal path invalid"); }
+  catch (error: any) { if (error?.code === "ENOENT" && cursor.sequence === 0) return Object.freeze([]); throw error; }
+  const names = journalEventNames(dir);
+  if (cursor.sequence > names.length) throw new Error("Workflow journal sequence gap or truncation");
+  let previous = cursor.hash;
+  let projectId = cursor.projectId;
+  if (cursor.sequence > 0) {
+    const boundaryName = names[cursor.sequence - 1];
+    const expectedBoundarySuffix = `-${cursor.hash}.json`;
+    if (!boundaryName.startsWith(`${String(cursor.sequence).padStart(16, "0")}-`) || !boundaryName.endsWith(expectedBoundarySuffix)) {
+      throw new Error("Workflow journal cursor boundary mismatch");
+    }
+    if (options.verifyBoundary) {
+      const boundary = parseEvent(join(dir, boundaryName));
+      if (boundary.sequence !== cursor.sequence || boundary.eventHash !== cursor.hash || boundary.sessionId !== sessionId || (projectId !== undefined && boundary.projectId !== projectId)) {
+        throw new Error("Workflow journal cursor boundary corruption");
+      }
+      projectId = boundary.projectId;
+    }
+  }
+  const output: WorkflowEventEnvelope[] = [];
+  for (let index = cursor.sequence; index < names.length; index += 1) {
+    const event = parseEvent(join(dir, names[index]));
+    if (event.sequence !== index + 1) throw new Error("Workflow journal sequence gap or duplicate");
+    if (event.previousHash !== previous) throw new Error("Workflow journal previous hash mismatch");
+    if (event.sessionId !== sessionId || (projectId !== undefined && event.projectId !== projectId)) throw new Error("Workflow journal identity mismatch");
+    const expectedName = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`;
+    if (names[index] !== expectedName) throw new Error("Workflow journal filename/hash mismatch");
+    projectId = event.projectId; previous = event.eventHash; output.push(event);
+  }
+  return Object.freeze(output);
+}
+
 export function readWorkflowJournal(projectRoot: string, sessionId: string): readonly WorkflowEventEnvelope[] {
-  const dir = journalDirectory(projectRoot, sessionId); try { if (!lstatSync(dir).isDirectory() || lstatSync(dir).isSymbolicLink()) throw new Error("Workflow journal path invalid"); } catch (error: any) { if (error?.code === "ENOENT") return Object.freeze([]); throw error; }
-  const names = readdirSync(dir).filter((name) => name.endsWith(".json")).sort(); const events = names.map((name) => parseEvent(join(dir, name)));
-  let previous: string | null = null; let projectId: string | undefined;
-  for (let index = 0; index < events.length; index += 1) { const event = events[index]; if (event.sequence !== index + 1) throw new Error("Workflow journal sequence gap or duplicate"); if (event.previousHash !== previous) throw new Error("Workflow journal previous hash mismatch"); if (event.sessionId !== sessionId || (projectId !== undefined && event.projectId !== projectId)) throw new Error("Workflow journal identity mismatch"); const expectedName = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; if (names[index] !== expectedName) throw new Error("Workflow journal filename/hash mismatch"); projectId = event.projectId; previous = event.eventHash; }
-  return Object.freeze(events);
+  return readWorkflowJournalFrom(projectRoot, sessionId, { sequence: 0, hash: null });
 }
 export function withWorkflowJournalTransaction<T>(projectRoot: string, sessionId: string, transact: (events: readonly WorkflowEventEnvelope[]) => T): T {
   const dir = journalDirectory(projectRoot, sessionId);
@@ -50,10 +142,11 @@ export function appendWorkflowEventChecked(
   options: JournalFaultOptions = {},
 ): WorkflowEventEnvelope {
   const dir = journalDirectory(projectRoot, draft.sessionId);
-  return withWorkflowJournalTransaction(projectRoot, draft.sessionId, (existing) => {
-    if (existing.some((event) => event.eventId === draft.eventId)) throw new Error("Workflow journal duplicate event ID"); if (existing.length && existing[0].projectId !== draft.projectId) throw new Error("Workflow journal project identity mismatch");
+  const persistedDraft = createWorkflowEvent({ ...draft, payload: redactJournalPayload(draft.payload, journalRedaction(projectRoot, options.redaction)) });
+  return withWorkflowJournalTransaction(projectRoot, persistedDraft.sessionId, (existing) => {
+    if (existing.some((event) => event.eventId === persistedDraft.eventId)) throw new Error("Workflow journal duplicate event ID"); if (existing.length && existing[0].projectId !== persistedDraft.projectId) throw new Error("Workflow journal project identity mismatch");
     check(existing);
-    const last = existing.at(-1); const event = sealWorkflowEvent(draft, existing.length + 1, last?.eventHash ?? null); const content = `${canonicalJson(event)}\n`;
+    const last = existing.at(-1); const event = sealWorkflowEvent(persistedDraft, existing.length + 1, last?.eventHash ?? null); const content = `${canonicalJson(event)}\n`;
     const name = `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`; const target = join(dir, name); const temp = join(dir, `.${name}.${process.pid}.${randomUUID()}.tmp`); let fd: number | undefined;
     try {
       options.fault?.("beforeWrite"); fd = openSync(temp, "wx", 0o600); writeFileSync(fd, content); fsyncSync(fd); closeSync(fd); fd = undefined; options.fault?.("afterFileFsync"); options.fault?.("beforeRename"); renameSync(temp, target); options.fault?.("afterRename"); options.fault?.("beforeDirFsync"); fsyncDirectory(dir); return event;

--- a/src/workflows/orchestration.ts
+++ b/src/workflows/orchestration.ts
@@ -70,7 +70,8 @@ import {
   losslessDynamicPromptInputs,
   type WorkflowPromptAssembly,
 } from "./prompts";
-import { appendWorkflowEvent, readWorkflowJournal } from "./journal";
+import { appendWorkflowEvent, configureWorkflowJournalRedaction, readWorkflowJournal } from "./journal";
+import type { WorkflowRedactionOptions } from "../observability/redaction";
 import { createWorkflowEvent } from "./events";
 import { handoffForRun, handoffPromptInput } from "./handoff";
 import {
@@ -105,6 +106,8 @@ export interface RunOrchestrationServiceOptions {
   readonly projectRoot: string; readonly projectId: string; readonly sessionId: string;
   readonly snapshot: ActivationSnapshotFileV1; readonly runtimeOwnerNonce: string; readonly maxParallel: number;
   readonly workerFactory: WorkerSessionFactory;
+  /** Runtime-configured secrets and protected roots applied centrally to every project journal writer. */
+  readonly journalRedaction?: WorkflowRedactionOptions;
   readonly budgetLimits?: EffectiveRuntimeBudgetLimits;
   readonly nowMs?: () => number;
   /** Required when taking over a run whose previous owner left an active budget clock. */
@@ -294,6 +297,7 @@ export class RunOrchestrationService {
 
   constructor(options: RunOrchestrationServiceOptions) {
     this.options = options;
+    if (options.journalRedaction) configureWorkflowJournalRedaction(options.projectRoot, options.journalRedaction);
     const selectedArtifact = runtimeArtifact(options.snapshot, options.artifactRuntime);
     this.selectedArtifact = selectedArtifact;
     this.artifactCallerIssuer = selectedArtifact ? createRunOrchestrationArtifactCallerIssuer(options.snapshot) : undefined;

--- a/tests/observability/workflow-dashboard-api.test.ts
+++ b/tests/observability/workflow-dashboard-api.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  WORKFLOW_DASHBOARD_API_VERSION,
+  WORKFLOW_DASHBOARD_MAX_PAGE_SIZE,
+} from "../../src/shared/dashboard-api.ts";
+
+test("workflow dashboard DTO contract is versioned and bounded for W25 consumers", () => {
+  assert.equal(WORKFLOW_DASHBOARD_API_VERSION, 1);
+  assert.equal(WORKFLOW_DASHBOARD_MAX_PAGE_SIZE, 500);
+});

--- a/tests/observability/workflow-projection-db.spec.ts
+++ b/tests/observability/workflow-projection-db.spec.ts
@@ -1,0 +1,670 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createWorkflowEvent, sealWorkflowEvent, type WorkflowEventEnvelope } from "../../src/workflows/events";
+import { appendWorkflowEvent } from "../../src/workflows/journal";
+import { toWorkflowTelemetryEvent, workflowTelemetryStreamId, type WorkflowTelemetryEvent } from "../../src/observability/events";
+import { WorkflowTelemetryProjection } from "../../src/observability/projection";
+
+let module: typeof import("../../src/observability/server/workflow-db");
+let runtimeModule: typeof import("../../src/observability/server/workflow-runtime");
+
+beforeAll(async () => {
+  module = await import("../../src/observability/server/workflow-db");
+  runtimeModule = await import("../../src/observability/server/workflow-runtime");
+});
+afterAll(() => {});
+
+function events(count: number, sessionId = "session-db"): WorkflowTelemetryEvent[] {
+  const output: WorkflowEventEnvelope[] = [];
+  for (let index = 0; index < count; index++) {
+    const draft = createWorkflowEvent({
+      eventId: `${sessionId}-event-${index}`,
+      projectId: "project-db",
+      sessionId,
+      runId: "run-db",
+      type: index === count - 1 ? "terminal.recorded" : index === 0 ? "run.started" : "budget.model.usage.recorded",
+      producer: "harness",
+      timestamp: new Date(Date.UTC(2026, 6, 20, 0, 0, index)).toISOString(),
+      payload: index === count - 1
+        ? { formatVersion: 1, status: "completed", changeCoverage: "recorded" }
+        : index === 0
+          ? { formatVersion: 1, status: "running", workflowId: "delivery", nodeId: "root" }
+          : { formatVersion: 1, nodeId: "root", usage: { inputTokens: 1, outputTokens: 2, costMicroUsd: 3, precision: index % 2 ? "estimated" : "provider-confirmed" } },
+    });
+    output.push(sealWorkflowEvent(draft, index + 1, output.at(-1)?.eventHash ?? null));
+  }
+  return output.map((event) => toWorkflowTelemetryEvent(event, { workflowId: "delivery", projectRoot: "/project", projectLabel: "Project DB", workflowConfigVersion: "1" }));
+}
+
+test("workflow projection default path is separate from the legacy database", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-config-"));
+  const child = Bun.spawnSync(["bun", "-e", `const c = await import('./src/observability/server/config.ts'); console.log(JSON.stringify({ legacy: c.DB_PATH, workflow: c.WORKFLOW_DB_PATH }))`], { cwd: process.cwd(), env: { ...process.env, PI_CODING_AGENT_DIR: root, HIVE_TELEMETRY_DB: join(root, "legacy.db") } });
+  expect(child.exitCode).toBe(0);
+  const paths = JSON.parse(child.stdout.toString());
+  expect(paths.workflow).toBe(join(root, "hive", "workflow-telemetry-v1.db"));
+  expect(paths.workflow).not.toBe(paths.legacy);
+});
+
+test("workflow SQLite projection uses a clean v1 schema and leaves legacy DB/JSONL byte-identical", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-"));
+  const legacyDb = join(root, "telemetry.db");
+  const legacyJsonl = join(root, "telemetry-sessions.jsonl");
+  writeFileSync(legacyDb, "legacy-db-bytes");
+  writeFileSync(legacyJsonl, "legacy-jsonl-bytes");
+  const before = [readFileSync(legacyDb), readFileSync(legacyJsonl)];
+  const workflowPath = join(root, "workflow-telemetry-v1.db");
+  const projection = module.openWorkflowProjectionDatabase({ path: workflowPath, legacyPaths: [legacyDb, legacyJsonl] });
+  try {
+    expect(projection.schemaVersion()).toBe(1);
+    const columns = projection.schemaSql().toLowerCase();
+    expect(columns).toContain("workflow_id");
+    expect(columns).toContain("snapshot_id");
+    expect(columns).toContain("project_label");
+    expect(columns).toContain("workflow_config_version");
+    for (const dimension of ["agent_id", "agent_name", "node_id", "parent_node_id", "task_id", "adapter_id", "profile_id", "workspace_id", "workspace_hash", "lease_state", "question_id", "checkpoint_id", "approval_id", "knowledge_job_id", "knowledge_update_id", "model_id", "thinking", "tool_name", "capability_id", "attempt_id", "operation_id", "precision", "elapsed_ms", "budget_scope", "change_coverage", "terminal_refs_json"]) expect(columns).toContain(dimension);
+    expect(columns).not.toContain("planning");
+    expect(columns).not.toContain("hive_team");
+    expect(columns).not.toContain("plan_id");
+  } finally { projection.close(); }
+  expect(readFileSync(legacyDb)).toEqual(before[0]);
+  expect(readFileSync(legacyJsonl)).toEqual(before[1]);
+  expect(() => module.openWorkflowProjectionDatabase({ path: legacyDb, legacyPaths: [legacyDb] })).toThrow(/legacy|separate/i);
+});
+
+test("workflow SQLite ingestion is idempotent, gap/hash fail-stop, crash-atomic, and rebuild-equivalent", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-ingest-"));
+  const path = join(root, "workflow-telemetry-v1.db");
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  const source = events(5);
+  try {
+    expect(projection.ingest(source[0])).toBe("inserted");
+    expect(projection.ingest(source[0])).toBe("duplicate");
+    expect(projection.history({ limit: 10 }).items).toHaveLength(1);
+    const gapDraft = createWorkflowEvent({ eventId: "trusted-gap", projectId: "project-db", sessionId: "session-db", runId: "run-db", type: "budget.model.usage.recorded", producer: "harness", payload: { formatVersion: 1 } });
+    const trustedGap = toWorkflowTelemetryEvent(sealWorkflowEvent(gapDraft, 3, source[0].sourceEventHash), { workflowId: "delivery", projectRoot: "/project" });
+    expect(() => projection.ingest(trustedGap)).toThrow(/gap/i);
+    expect(projection.streamStatus(source[0].streamId).state).toBe("blocked");
+    projection.reset();
+
+    projection.database.run(`CREATE TRIGGER fail_projection_current BEFORE INSERT ON workflow_current BEGIN SELECT RAISE(ABORT, 'crash'); END`);
+    expect(() => projection.ingest(source[0])).toThrow(/crash/i);
+    expect(projection.history({ limit: 10 }).items).toHaveLength(0);
+    expect(projection.streamStatus(source[0].streamId).lastSequence).toBe(0);
+    projection.database.run(`DROP TRIGGER fail_projection_current`);
+
+    projection.rebuild([source]);
+    const rebuilt = projection.snapshot();
+    projection.reset();
+    for (const event of source) projection.ingest(event);
+    expect(projection.snapshot()).toEqual(rebuilt);
+    expect(projection.current().runs[0].status).toBe("completed");
+    expect(projection.usage().estimated.inputTokens).toBe(2);
+    expect(projection.usage().providerConfirmed.inputTokens).toBe(1);
+  } finally { projection.close(); }
+});
+
+test("workflow SQLite rejects forged projected envelopes and matches blocked duplicate/prune usage semantics", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-auth-"));
+  const path = join(root, "workflow.db");
+  let projection = module.openWorkflowProjectionDatabase({ path });
+  const source = events(3);
+  try {
+    expect(() => projection.ingest({ ...source[0], eventHash: "f".repeat(64) })).toThrow(/authentic|trusted|hash/i);
+    projection.ingest(source[0]);
+    expect(() => projection.ingest({ ...source[1], eventId: "forged-gap", sequence: 3 })).toThrow(/authentic|gap/i);
+    expect(projection.ingest(source[0])).toBe("duplicate");
+    projection.reset();
+    projection.rebuild([source]);
+    projection.pruneProjection("2026-07-20T00:00:02.000Z");
+    expect(projection.usage()).toEqual({ estimated: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 }, providerConfirmed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 } });
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_event_identities`).get()).toEqual({ count: 3 });
+  } finally { projection.close(); }
+
+  projection = module.openWorkflowProjectionDatabase({ path });
+  const reused = toWorkflowTelemetryEvent(sealWorkflowEvent(createWorkflowEvent({
+    eventId: source[0].eventId,
+    projectId: "project-reused",
+    sessionId: "session-reused",
+    type: "run.started",
+    producer: "harness",
+    payload: { formatVersion: 1 },
+  }), 1, null));
+  try {
+    expect(() => projection.ingest(reused)).toThrow(/reused event ID/i);
+    expect(projection.streamStatus(reused.streamId).state).toBe("blocked");
+  } finally { projection.close(); }
+});
+
+test("workflow SQLite path initialization rejects symlinks/legacy aliases and enforces private permissions concurrently", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-secure-"));
+  chmodSync(root, 0o777);
+  const legacy = join(root, "legacy.db");
+  writeFileSync(legacy, "legacy bytes");
+  const alias = join(root, "alias.db");
+  symlinkSync(legacy, alias);
+  expect(() => module.openWorkflowProjectionDatabase({ path: alias, legacyPaths: [legacy] })).toThrow(/symlink|legacy|alias/i);
+  const directory = join(root, "private");
+  mkdirSync(directory, { mode: 0o777 });
+  const path = join(directory, "workflow.db");
+  const script = `const {openWorkflowProjectionDatabase}=await import('./src/observability/server/workflow-db.ts'); const db=openWorkflowProjectionDatabase({path:${JSON.stringify(path)}}); db.close()`;
+  const children = await Promise.all([0, 1, 2, 3].map(async () => Bun.spawn(["bun", "-e", script], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" }).exited));
+  expect(children).toEqual([0, 0, 0, 0]);
+  expect(lstatSync(directory).mode & 0o777).toBe(0o700);
+  expect(lstatSync(path).mode & 0o777).toBe(0o600);
+});
+
+test("configured workflow projection runtime incrementally syncs PROJECT_CWD without legacy sources and rebuilds on restart", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-runtime-"));
+  expect(runtimeModule.workflowProjectionRootCandidates(root, [])).toEqual([root]);
+  const dbPath = join(root, "global", "workflow.db");
+  const unconfiguredDb = join(root, "global", "absent.db");
+  expect(runtimeModule.syncConfiguredWorkflowProjection({ databasePath: unconfiguredDb, projectRoots: [join(root, "unconfigured")] })).toEqual({ active: false, events: 0, streams: 0 });
+  expect(existsSync(unconfiguredDb)).toBe(false);
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "runtime-1", projectId: "project-runtime", sessionId: "session-runtime", runId: "run-runtime", type: "run.started", producer: "runtime", payload: { formatVersion: 1, status: "running" } }));
+  expect(runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] }).events).toBe(1);
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "runtime-2", projectId: "project-runtime", sessionId: "session-runtime", runId: "run-runtime", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" } }));
+  expect(runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] }).events).toBe(1);
+  const projection = module.openWorkflowProjectionDatabase({ path: dbPath });
+  try { expect(projection.current().runs[0].status).toBe("completed"); } finally { projection.close(); }
+});
+
+test("configured sync retains healthy rows and a stable zero-event blocked stream without rebuilding", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-runtime-blocked-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  const candidates = ["candidate-a", "candidate-b"].sort((left, right) => workflowTelemetryStreamId("project-runtime-blocked", left).localeCompare(workflowTelemetryStreamId("project-runtime-blocked", right)));
+  const [healthySession, blockedSession] = candidates;
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "shared-event-id", projectId: "project-runtime-blocked", sessionId: healthySession, runId: "run-healthy", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "shared-event-id", projectId: "project-runtime-blocked", sessionId: blockedSession, runId: "run-blocked", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  const path = join(root, "global", "workflow.db");
+  const first = runtimeModule.syncConfiguredWorkflowProjection({ databasePath: path, projectRoots: [root] });
+  expect(first.diagnostics).toHaveLength(1);
+
+  let projection = module.openWorkflowProjectionDatabase({ path });
+  projection.database.run(`CREATE TABLE rebuild_audit (deleted INTEGER NOT NULL)`);
+  projection.database.run(`CREATE TRIGGER audit_projection_rebuild AFTER DELETE ON workflow_events BEGIN INSERT INTO rebuild_audit VALUES (1); END`);
+  projection.close();
+
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "healthy-finish", projectId: "project-runtime-blocked", sessionId: healthySession, runId: "run-healthy", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" } }));
+  const second = runtimeModule.syncConfiguredWorkflowProjection({ databasePath: path, projectRoots: [root] });
+  expect(second.diagnostics).toHaveLength(1);
+  projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM rebuild_audit`).get()).toEqual({ count: 0 });
+    expect(projection.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual(["shared-event-id", "healthy-finish"]);
+    expect(projection.current().runs.find((row) => row.runId === "run-healthy")?.status).toBe("completed");
+    expect(projection.streamStatus(workflowTelemetryStreamId("project-runtime-blocked", blockedSession))).toMatchObject({ state: "blocked", lastSequence: 0 });
+  } finally { projection.close(); }
+});
+
+test("configured sync preserves an unsupported projection schema byte-for-byte", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-unknown-schema-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  const path = join(root, "global", "unknown.db");
+  mkdirSync(join(root, "global"));
+  const unknown = new Database(path);
+  unknown.run(`CREATE TABLE workflow_projection_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+  unknown.query(`INSERT INTO workflow_projection_metadata (key, value) VALUES ('schema_version', '999')`).run();
+  unknown.run(`CREATE TABLE unknown_payload (bytes BLOB NOT NULL)`);
+  unknown.query(`INSERT INTO unknown_payload (bytes) VALUES (?)`).run(Buffer.from("preserve-these-unknown-schema-bytes"));
+  unknown.close();
+  const before = readFileSync(path);
+
+  expect(() => runtimeModule.syncConfiguredWorkflowProjection({ databasePath: path, projectRoots: [root] })).toThrow(module.WorkflowProjectionSchemaError);
+  expect(readFileSync(path)).toEqual(before);
+  const reopened = new Database(path, { readonly: true });
+  try { expect(reopened.query(`SELECT CAST(bytes AS TEXT) AS value FROM unknown_payload`).get()).toEqual({ value: "preserve-these-unknown-schema-bytes" }); }
+  finally { reopened.close(); }
+});
+
+test("workflow SQLite and in-memory current DTOs select the same stable bounded entity set", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-current-"));
+  const projection = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  const memory = new WorkflowTelemetryProjection();
+  try {
+    for (let index = 0; index < 550; index++) {
+      const event = events(2, `current-${String(index).padStart(4, "0")}`)[0];
+      projection.ingest(event);
+      memory.ingest(event);
+    }
+    expect(projection.current().sessions).toHaveLength(500);
+    expect(projection.current().sessions.map((row) => row.sessionId)).toEqual(memory.current().sessions.map((row) => row.sessionId));
+    expect(projection.current().sessions[0].projectLabel).toBe("Project DB");
+    expect(projection.current().sessions[0].workflowConfigVersion).toBe("1");
+    const first = projection.currentPage({ kind: "sessions", limit: 500 });
+    const second = projection.currentPage({ kind: "sessions", limit: 300, cursor: first.nextCursor });
+    expect(first.items).toEqual(projection.current().sessions);
+    expect(first.items).toHaveLength(500);
+    expect(second.items).toHaveLength(50);
+    expect(new Set([...first.items, ...second.items].map((row) => row.sessionId)).size).toBe(550);
+  } finally { projection.close(); }
+}, 10_000);
+
+test("workflow SQLite verifies persisted event and current integrity on restart and repairs from authoritative journals", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-tamper-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "tamper-1", projectId: "project-tamper", sessionId: "session-tamper", runId: "run-tamper", type: "run.started", producer: "runtime", payload: { formatVersion: 1, status: "running" } }));
+  const dbPath = join(root, "global", "workflow.db");
+  runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] });
+  let projection = module.openWorkflowProjectionDatabase({ path: dbPath });
+  projection.database.query(`UPDATE workflow_events SET event_json = jsonb(?)`).run(JSON.stringify({ forged: true }));
+  projection.close();
+  expect(() => module.openWorkflowProjectionDatabase({ path: dbPath })).toThrow(/integrity|corrupt|event/i);
+  // The production synchronizer treats the DB as disposable and reconstructs it from journals.
+  expect(runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] }).events).toBe(1);
+  projection = module.openWorkflowProjectionDatabase({ path: dbPath });
+  projection.database.query(`UPDATE workflow_current SET current_json = jsonb(?)`).run(JSON.stringify({ forged: true }));
+  projection.close();
+  expect(() => module.openWorkflowProjectionDatabase({ path: dbPath })).toThrow(/integrity|corrupt|current/i);
+});
+
+test("configured projection preserves last-known-good corrupt streams while healthy streams continue", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-mixed-journals-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "healthy", projectId: "project-mixed", sessionId: "healthy", runId: "run-healthy", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "corrupt", projectId: "project-mixed", sessionId: "corrupt", runId: "run-corrupt", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  const dbPath = join(root, "workflow.db");
+  runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] });
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "healthy-finish", projectId: "project-mixed", sessionId: "healthy", runId: "run-healthy", type: "terminal.recorded", producer: "runtime", payload: { formatVersion: 1, status: "completed" } }));
+  const corruptDir = join(root, ".pi", "hive", "sessions", "corrupt", "journal");
+  writeFileSync(join(corruptDir, readdirSync(corruptDir)[0]), "{corrupt\n");
+  const result = runtimeModule.syncConfiguredWorkflowProjection({ databasePath: dbPath, projectRoots: [root] });
+  expect(result).toMatchObject({ active: true, events: 1, streams: 2 });
+  expect(result.diagnostics?.[0]?.diagnostic.length).toBeLessThanOrEqual(2_048);
+  const projection = module.openWorkflowProjectionDatabase({ path: dbPath });
+  try {
+    expect(new Set(projection.current().runs.map((row) => row.runId))).toEqual(new Set(["run-corrupt", "run-healthy"]));
+    expect(projection.current().runs.find((row) => row.runId === "run-healthy")?.status).toBe("completed");
+    const corruptStream = projection.current().runs.find((row) => row.runId === "run-corrupt")!;
+    expect(projection.streamStatus(workflowTelemetryStreamId("project-mixed", corruptStream.sessionId)).state).toBe("blocked");
+  } finally { projection.close(); }
+});
+
+test("workflow SQLite rejects malformed history and current cursors", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-cursor-"));
+  const projection = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  try {
+    for (const cursor of ["!", "a=", "a b", "%%%%", "eyJub3QiOiJhLWN1cnNvciJ9"]) {
+      expect(() => projection.history({ limit: 1, cursor })).toThrow(/cursor.*invalid/i);
+      expect(() => projection.currentPage({ kind: "sessions", limit: 1, cursor })).toThrow(/cursor.*invalid/i);
+    }
+  } finally { projection.close(); }
+});
+
+test("workflow SQLite detects normalized filter, timestamp, usage, current, identity, and stream-state tamper", () => {
+  const mutations = [
+    `UPDATE workflow_events SET workflow_id = 'forged'`,
+    `UPDATE workflow_events SET timestamp = '1900-01-01T00:00:00.000Z'`,
+    `UPDATE workflow_usage SET input_tokens = input_tokens + 1000`,
+    `UPDATE workflow_current SET workflow_id = 'forged'`,
+    `UPDATE workflow_event_identities SET event_hash = '${"f".repeat(64)}'`,
+    `UPDATE workflow_streams SET last_sequence = 999`,
+  ];
+  for (const [index, mutation] of mutations.entries()) {
+    const root = mkdtempSync(join(tmpdir(), `pi-hive-workflow-db-tamper-${index}-`));
+    const path = join(root, "workflow.db");
+    const projection = module.openWorkflowProjectionDatabase({ path });
+    projection.rebuild([events(3)]);
+    projection.database.run(mutation);
+    projection.close();
+    expect(() => module.openWorkflowProjectionDatabase({ path })).toThrow(/integrity|tamper|projection/i);
+  }
+});
+
+test("aggregate SQLite rebuild persists zero-event blocked streams across reopen", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-cross-stream-"));
+  const path = join(root, "workflow.db");
+  let projection = module.openWorkflowProjectionDatabase({ path });
+  const healthy = events(2, "a-healthy");
+  const conflictingDraft = createWorkflowEvent({ eventId: healthy[0].eventId, projectId: "project-db", sessionId: "z-corrupt", runId: "run-corrupt", type: "run.started", producer: "harness", payload: { formatVersion: 1 } });
+  const conflicting = toWorkflowTelemetryEvent(sealWorkflowEvent(conflictingDraft, 1, null), { workflowId: "delivery" });
+  const gapDraft = createWorkflowEvent({ eventId: "first-gap", projectId: "project-db", sessionId: "z-gap", runId: "run-gap", type: "run.started", producer: "harness", payload: { formatVersion: 1 } });
+  const gap = toWorkflowTelemetryEvent(sealWorkflowEvent(gapDraft, 2, null), { workflowId: "delivery" });
+  try {
+    const result = projection.rebuild([healthy, [conflicting], [gap]]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(projection.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual(healthy.map((event) => event.eventId));
+    expect(projection.current().runs[0].runId).toBe("run-db");
+    for (const event of [conflicting, gap]) {
+      expect(projection.streamStatus(event.streamId)).toMatchObject({ state: "blocked", lastSequence: 0, lastHash: null });
+    }
+  } finally { projection.close(); }
+
+  projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    expect(projection.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual(healthy.map((event) => event.eventId));
+    for (const event of [conflicting, gap]) expect(projection.streamStatus(event.streamId).state).toBe("blocked");
+  } finally { projection.close(); }
+});
+
+test("in-memory and SQLite DTOs match for filtered history pages and every current kind beyond 500", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-dto-equivalence-"));
+  const database = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  const memory = new WorkflowTelemetryProjection();
+  const streams: WorkflowTelemetryEvent[][] = [];
+  for (let index = 0; index < 501; index++) {
+    const sessionId = `dto-${String(index).padStart(4, "0")}`;
+    const runId = `run-${index}`;
+    const drafts = [
+      createWorkflowEvent({ eventId: `${sessionId}-session`, projectId: "project-dto", sessionId, type: "session.created", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8)).toISOString(), payload: { formatVersion: 1 } }),
+      createWorkflowEvent({ eventId: `${sessionId}-run`, projectId: "project-dto", sessionId, runId, type: "run.started", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 1)).toISOString(), payload: { formatVersion: 1, nodeId: `node-${index}` } }),
+      createWorkflowEvent({ eventId: `${sessionId}-task`, projectId: "project-dto", sessionId, runId, type: "task.started", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 2)).toISOString(), payload: { formatVersion: 1, nodeId: `node-${index}`, taskId: `task-${index}` } }),
+      createWorkflowEvent({ eventId: `${sessionId}-workspace`, projectId: "project-dto", sessionId, runId, type: "artifact.recorded", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 3)).toISOString(), payload: { formatVersion: 1, workspaceId: `workspace-${index}` } }),
+      createWorkflowEvent({ eventId: `${sessionId}-question`, projectId: "project-dto", sessionId, runId, type: "question.transition", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 4)).toISOString(), payload: { formatVersion: 1, operation: "create", questionId: `question-${index}` } }),
+      createWorkflowEvent({ eventId: `${sessionId}-approval`, projectId: "project-dto", sessionId, runId, type: "approval.recorded", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 5)).toISOString(), payload: { formatVersion: 1, operation: "request", approvalId: `approval-${index}` } }),
+      createWorkflowEvent({ eventId: `${sessionId}-knowledge`, projectId: "project-dto", sessionId, runId, type: "knowledge.transition", producer: "harness", timestamp: new Date(Date.UTC(2026, 6, 21, 0, 0, index * 8 + 6)).toISOString(), payload: { formatVersion: 1, knowledgeJobId: `knowledge-${index}` } }),
+    ];
+    const sealed: WorkflowEventEnvelope[] = [];
+    for (const draft of drafts) sealed.push(sealWorkflowEvent(draft, sealed.length + 1, sealed.at(-1)?.eventHash ?? null));
+    const stream = sealed.map((event) => toWorkflowTelemetryEvent(event, { workflowId: index % 2 ? "odd" : "even", snapshotId: `snapshot-${index}` }));
+    streams.push(stream);
+    for (const event of stream) memory.ingest(event);
+  }
+  try {
+    database.rebuild(streams);
+    for (const kind of ["sessions", "runs", "nodes", "tasks", "workspaces", "questions", "approvals", "knowledge"] as const) {
+      const dbItems: unknown[] = [];
+      const memoryItems: unknown[] = [];
+      let dbCursor: string | undefined;
+      let memoryCursor: string | undefined;
+      do {
+        const dbPage = database.currentPage({ kind, limit: 200, ...(dbCursor ? { cursor: dbCursor } : {}) });
+        const memoryPage = memory.currentPage({ kind, limit: 200, ...(memoryCursor ? { cursor: memoryCursor } : {}) });
+        dbItems.push(...dbPage.items); memoryItems.push(...memoryPage.items);
+        dbCursor = dbPage.nextCursor; memoryCursor = memoryPage.nextCursor;
+      } while (dbCursor || memoryCursor);
+      expect(dbItems).toEqual(memoryItems);
+      expect(dbItems).toHaveLength(501);
+    }
+    let dbCursor: string | undefined;
+    let memoryCursor: string | undefined;
+    do {
+      const dbPage = database.history({ limit: 173, workflowId: "even", eventType: "task.started", ...(dbCursor ? { cursor: dbCursor } : {}) });
+      const memoryPage = memory.history({ limit: 173, workflowId: "even", eventType: "task.started", ...(memoryCursor ? { cursor: memoryCursor } : {}) });
+      expect(dbPage).toEqual(memoryPage);
+      dbCursor = dbPage.nextCursor; memoryCursor = memoryPage.nextCursor;
+    } while (dbCursor || memoryCursor);
+  } finally { database.close(); }
+}, 20_000);
+
+test("in-memory and SQLite current pages and cursors are byte-identical for Unicode IDs", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-unicode-order-"));
+  const database = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  const memory = new WorkflowTelemetryProjection();
+  const ids = [`session-\u{10000}`, `session-\uE000`, "session-ascii"];
+  try {
+    for (const [index, sessionId] of ids.entries()) {
+      const draft = createWorkflowEvent({
+        eventId: `unicode-order-${index}`,
+        projectId: "project-unicode",
+        sessionId,
+        runId: `run-${sessionId}`,
+        type: "run.started",
+        producer: "harness",
+        timestamp: `2026-07-21T00:00:0${index}.000Z`,
+        payload: { formatVersion: 1, nodeId: `node-${sessionId}` },
+      });
+      const event = toWorkflowTelemetryEvent(sealWorkflowEvent(draft, 1, null));
+      database.ingest(event);
+      memory.ingest(event);
+    }
+    const seen: string[] = [];
+    let databaseCursor: string | undefined;
+    let memoryCursor: string | undefined;
+    do {
+      const databasePage = database.currentPage({ kind: "sessions", limit: 1, ...(databaseCursor ? { cursor: databaseCursor } : {}) });
+      const memoryPage = memory.currentPage({ kind: "sessions", limit: 1, ...(memoryCursor ? { cursor: memoryCursor } : {}) });
+      expect(databasePage).toEqual(memoryPage);
+      if (databasePage.nextCursor) expect(Buffer.from(databasePage.nextCursor)).toEqual(Buffer.from(memoryPage.nextCursor!));
+      seen.push(...databasePage.items.map((row) => row.sessionId));
+      databaseCursor = databasePage.nextCursor;
+      memoryCursor = memoryPage.nextCursor;
+    } while (databaseCursor || memoryCursor);
+    expect(seen).toEqual(["session-ascii", `session-\uE000`, `session-\u{10000}`]);
+    expect(database.schemaSql()).toContain("current_order_key");
+  } finally { database.close(); }
+});
+
+test("in-memory prune matches SQLite contiguous per-stream prefix semantics for old-new-old timestamps", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-prune-prefix-"));
+  const database = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  const memory = new WorkflowTelemetryProjection();
+  const drafts = [
+    createWorkflowEvent({ eventId: "prefix-old", projectId: "project-prefix", sessionId: "session-prefix", runId: "run-prefix", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-20T00:00:00.000Z", payload: { formatVersion: 1, usage: { inputTokens: 1, outputTokens: 1, costMicroUsd: 1, precision: "estimated" } } }),
+    createWorkflowEvent({ eventId: "prefix-new", projectId: "project-prefix", sessionId: "session-prefix", runId: "run-prefix", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-20T00:00:02.000Z", payload: { formatVersion: 1, usage: { inputTokens: 2, outputTokens: 2, costMicroUsd: 2, precision: "estimated" } } }),
+    createWorkflowEvent({ eventId: "prefix-old-after-new", projectId: "project-prefix", sessionId: "session-prefix", runId: "run-prefix", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-20T00:00:00.500Z", payload: { formatVersion: 1, usage: { inputTokens: 4, outputTokens: 4, costMicroUsd: 4, precision: "estimated" } } }),
+    createWorkflowEvent({ eventId: "prefix-continuation", projectId: "project-prefix", sessionId: "session-prefix", runId: "run-prefix", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-20T00:00:03.000Z", payload: { formatVersion: 1, usage: { inputTokens: 8, outputTokens: 8, costMicroUsd: 8, precision: "estimated" } } }),
+  ];
+  const sealed: WorkflowEventEnvelope[] = [];
+  for (const draft of drafts) sealed.push(sealWorkflowEvent(draft, sealed.length + 1, sealed.at(-1)?.eventHash ?? null));
+  const stream = sealed.map((event) => toWorkflowTelemetryEvent(event));
+  try {
+    for (const event of stream.slice(0, 3)) { database.ingest(event); memory.ingest(event); }
+    const databasePruned = database.pruneProjection("2026-07-20T00:00:01.000Z");
+    expect(databasePruned).toEqual({ removed: 1, retained: 2 });
+    expect(memory.pruneProjection("2026-07-20T00:00:01.000Z")).toEqual(databasePruned);
+    expect(memory.history({ limit: 10 })).toEqual(database.history({ limit: 10 }));
+    expect(memory.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual(["prefix-old-after-new", "prefix-new"]);
+    expect(memory.usage()).toEqual(database.usage());
+    expect(memory.usage().estimated).toEqual({ inputTokens: 6, outputTokens: 6, costMicroUsd: 6 });
+    expect(memory.streamStatus(stream[0].streamId)).toEqual(database.streamStatus(stream[0].streamId));
+    expect(memory.ingest(stream[3])).toBe("inserted");
+    expect(database.ingest(stream[3])).toBe("inserted");
+    expect(memory.snapshot()).toEqual(database.snapshot());
+  } finally { database.close(); }
+});
+
+test("projection prune compares timezone-offset timestamps chronologically in memory and SQLite", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-prune-offset-"));
+  const database = module.openWorkflowProjectionDatabase({ path: join(root, "workflow.db") });
+  const memory = new WorkflowTelemetryProjection();
+  const drafts = [
+    createWorkflowEvent({ eventId: "offset-chronologically-old", projectId: "project-offset", sessionId: "session-offset", runId: "run-offset", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-20T01:00:00.000+02:00", payload: { formatVersion: 1 } }),
+    createWorkflowEvent({ eventId: "offset-chronologically-new", projectId: "project-offset", sessionId: "session-offset", runId: "run-offset", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-07-19T23:30:00.000-02:00", payload: { formatVersion: 1 } }),
+  ];
+  const sealed: WorkflowEventEnvelope[] = [];
+  for (const draft of drafts) sealed.push(sealWorkflowEvent(draft, sealed.length + 1, sealed.at(-1)?.eventHash ?? null));
+  const stream = sealed.map((event) => toWorkflowTelemetryEvent(event));
+  try {
+    for (const event of stream) { database.ingest(event); memory.ingest(event); }
+    const cutoff = "2026-07-20T00:00:00.000Z";
+    expect(database.pruneProjection(cutoff)).toEqual({ removed: 1, retained: 1 });
+    expect(memory.pruneProjection(cutoff)).toEqual({ removed: 1, retained: 1 });
+    expect(memory.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual(["offset-chronologically-new"]);
+    expect(memory.snapshot()).toEqual(database.snapshot());
+  } finally { database.close(); }
+});
+
+test("workflow SQLite history handles more than ten thousand events with bounded pages", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-db-large-"));
+  const path = join(root, "workflow-telemetry-v1.db");
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    const source = events(10_001, "large-session");
+    projection.rebuild([source]);
+    const first = projection.history({ limit: 200 });
+    expect(first.items).toHaveLength(200);
+    expect(first.hasMore).toBe(true);
+    const second = projection.history({ limit: 200, cursor: first.nextCursor });
+    const firstIds = new Set(first.items.map((event) => event.eventId));
+    expect(second.items.some((event) => firstIds.has(event.eventId))).toBe(false);
+    expect(() => projection.history({ limit: 501 })).toThrow(/limit/i);
+    expect(projection.current().runs[0].status).toBe("completed");
+  } finally { projection.close(); }
+}, 30_000);
+
+test("persistent configured synchronizer processes only committed journal suffixes and closes its database", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-incremental-runtime-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  const sessionId = "large-incremental";
+  const journal = join(root, ".pi", "hive", "sessions", sessionId, "journal");
+  mkdirSync(journal, { recursive: true });
+  const source: WorkflowEventEnvelope[] = [];
+  for (let index = 0; index < 2_000; index++) {
+    const draft = createWorkflowEvent({
+      eventId: `incremental-${index}`,
+      projectId: "project-incremental",
+      sessionId,
+      runId: "run-incremental",
+      type: index === 0 ? "run.started" : "budget.model.usage.recorded",
+      producer: "harness",
+      timestamp: new Date(Date.UTC(2026, 6, 20, 0, 0, index)).toISOString(),
+      payload: { formatVersion: 1 },
+    });
+    const event = sealWorkflowEvent(draft, index + 1, source.at(-1)?.eventHash ?? null);
+    source.push(event);
+    writeFileSync(join(journal, `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`), `${JSON.stringify(event)}\n`);
+  }
+  const path = join(root, "global", "workflow.db");
+  const synchronizer = runtimeModule.createConfiguredWorkflowProjectionSynchronizer({ databasePath: path, retentionDays: 30, now: () => new Date("2026-08-01T00:00:00.000Z") });
+  expect(synchronizer.sync([root])).toMatchObject({ active: true, events: 2_000, streams: 1 });
+  expect(synchronizer.sync([root])).toMatchObject({ active: true, events: 0, streams: 1 });
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "incremental-one-more", projectId: "project-incremental", sessionId, runId: "run-incremental", type: "terminal.recorded", producer: "harness", timestamp: "2026-08-01T00:00:01.000Z", payload: { formatVersion: 1, status: "completed" } }));
+  expect(synchronizer.sync([root])).toMatchObject({ active: true, events: 1, streams: 1 });
+  synchronizer.close();
+  expect(() => synchronizer.sync([root])).toThrow(/closed/i);
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  try { expect(projection.current().runs[0].status).toBe("completed"); } finally { projection.close(); }
+}, 20_000);
+
+test("persistent sync detects older event corruption before and after a later append", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-incremental-corrupt-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  const sessionId = "incremental-corrupt";
+  const source: WorkflowEventEnvelope[] = [];
+  for (let index = 0; index < 3; index++) {
+    source.push(appendWorkflowEvent(root, createWorkflowEvent({
+      eventId: `incremental-corrupt-${index}`,
+      projectId: "project-incremental-corrupt",
+      sessionId,
+      runId: "run-incremental-corrupt",
+      type: index === 0 ? "run.started" : "budget.model.usage.recorded",
+      producer: "harness",
+      timestamp: new Date(Date.UTC(2026, 6, 20, 0, 0, index)).toISOString(),
+      payload: { formatVersion: 1 },
+    })));
+  }
+  const path = join(root, "global", "workflow.db");
+  const synchronizer = runtimeModule.createConfiguredWorkflowProjectionSynchronizer({ databasePath: path });
+  expect(synchronizer.sync([root])).toMatchObject({ events: 3, streams: 1 });
+  expect(synchronizer.sync([root])).toMatchObject({ events: 0, streams: 1 });
+
+  const journal = join(root, ".pi", "hive", "sessions", sessionId, "journal");
+  const names = readdirSync(journal).sort();
+  writeFileSync(join(journal, names[0]), "{corrupt-older-event\n");
+  const corrupted = synchronizer.sync([root]);
+  expect(corrupted).toMatchObject({ events: 0, streams: 1 });
+  expect(corrupted.diagnostics?.some((entry) => entry.sessionId === sessionId)).toBe(true);
+
+  const later = sealWorkflowEvent(createWorkflowEvent({
+    eventId: "incremental-corrupt-later",
+    projectId: "project-incremental-corrupt",
+    sessionId,
+    runId: "run-incremental-corrupt",
+    type: "terminal.recorded",
+    producer: "harness",
+    timestamp: "2026-07-20T00:00:03.000Z",
+    payload: { formatVersion: 1, status: "completed" },
+  }), 4, source.at(-1)!.eventHash);
+  writeFileSync(join(journal, `${String(later.sequence).padStart(16, "0")}-${later.eventHash}.json`), `${JSON.stringify(later)}\n`);
+  for (let poll = 0; poll < 2; poll++) {
+    const repeated = synchronizer.sync([root]);
+    expect(repeated).toMatchObject({ events: 0, streams: 1 });
+    expect(repeated.diagnostics?.some((entry) => entry.sessionId === sessionId)).toBe(true);
+  }
+  synchronizer.close();
+
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    const streamId = workflowTelemetryStreamId("project-incremental-corrupt", sessionId);
+    expect(projection.streamStatus(streamId)).toMatchObject({ state: "blocked", lastSequence: 3 });
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_event_identities`).get()).toEqual({ count: 3 });
+  } finally { projection.close(); }
+});
+
+test("production retention prunes only disposable projection rows and preserves journals and current state", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-production-retention-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "retention-open", projectId: "project-retention", sessionId: "retention-open", runId: "run-open", type: "run.started", producer: "runtime", timestamp: "2026-07-01T00:00:00.000Z", payload: { formatVersion: 1, status: "running" } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "retention-closed-start", projectId: "project-retention", sessionId: "retention-closed", runId: "run-closed", type: "run.started", producer: "runtime", timestamp: "2026-07-01T00:00:00.000Z", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "retention-closed-finish", projectId: "project-retention", sessionId: "retention-closed", runId: "run-closed", type: "terminal.recorded", producer: "runtime", timestamp: "2026-07-01T00:00:01.000Z", payload: { formatVersion: 1, status: "completed" } }));
+  const journalBytes = ["retention-open", "retention-closed"].map((sessionId) => readdirSync(join(root, ".pi", "hive", "sessions", sessionId, "journal")).map((name) => readFileSync(join(root, ".pi", "hive", "sessions", sessionId, "journal", name))));
+  const path = join(root, "global", "workflow.db");
+  const synchronizer = runtimeModule.createConfiguredWorkflowProjectionSynchronizer({ databasePath: path, retentionDays: 7, now: () => new Date("2026-08-01T00:00:00.000Z") });
+  expect(synchronizer.sync([root]).events).toBe(3);
+  synchronizer.close();
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    expect(projection.history({ limit: 10 }).items).toHaveLength(0);
+    expect(new Map(projection.current().runs.map((row) => [row.runId, row.status]))).toEqual(new Map([["run-open", "running"], ["run-closed", "completed"]]));
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_prune_watermarks`).get()).toEqual({ count: 2 });
+  } finally { projection.close(); }
+  for (const [index, sessionId] of ["retention-open", "retention-closed"].entries()) {
+    const after = readdirSync(join(root, ".pi", "hive", "sessions", sessionId, "journal")).map((name) => readFileSync(join(root, ".pi", "hive", "sessions", sessionId, "journal", name)));
+    expect(after).toEqual(journalBytes[index]);
+  }
+});
+
+test("fully pruned corrupt stream preserves last-known-good projection while a healthy stream advances", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-pruned-corrupt-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "pruned-corrupt", projectId: "project-pruned-corrupt", sessionId: "corrupt", runId: "run-corrupt", type: "terminal.recorded", producer: "runtime", timestamp: "2026-07-01T00:00:00.000Z", payload: { formatVersion: 1, status: "completed" } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "pruned-healthy", projectId: "project-pruned-corrupt", sessionId: "healthy", runId: "run-healthy", type: "run.started", producer: "runtime", timestamp: "2026-07-01T00:00:00.000Z", payload: { formatVersion: 1, status: "running" } }));
+  const path = join(root, "global", "workflow.db");
+  const synchronizer = runtimeModule.createConfiguredWorkflowProjectionSynchronizer({ databasePath: path, retentionDays: 7, now: () => new Date("2026-08-01T00:00:00.000Z") });
+  expect(synchronizer.sync([root]).events).toBe(2);
+  const corruptJournal = join(root, ".pi", "hive", "sessions", "corrupt", "journal");
+  writeFileSync(join(corruptJournal, readdirSync(corruptJournal)[0]), "{corrupt\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "pruned-healthy-finish", projectId: "project-pruned-corrupt", sessionId: "healthy", runId: "run-healthy", type: "terminal.recorded", producer: "runtime", timestamp: "2026-08-01T00:00:01.000Z", payload: { formatVersion: 1, status: "completed" } }));
+  const result = synchronizer.sync([root]);
+  expect(result).toMatchObject({ active: true, events: 1, streams: 2 });
+  expect(result.diagnostics?.some((entry) => entry.sessionId === "corrupt")).toBe(true);
+  synchronizer.close();
+  const projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    const corruptId = workflowTelemetryStreamId("project-pruned-corrupt", "corrupt");
+    expect(projection.streamStatus(corruptId)).toMatchObject({ state: "blocked", lastSequence: 1 });
+    expect(new Map(projection.current().runs.map((row) => [row.runId, row.status]))).toEqual(new Map([["run-corrupt", "completed"], ["run-healthy", "completed"]]));
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_event_identities`).get()).toEqual({ count: 3 });
+    expect(projection.database.query(`SELECT through_sequence FROM workflow_prune_watermarks WHERE stream_id = ?`).get(corruptId)).toEqual({ through_sequence: 1 });
+  } finally { projection.close(); }
+});
+
+test("projection prune watermark survives reopen and routine sync without reimporting journal history", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-prune-reopen-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "prune-start", projectId: "project-prune", sessionId: "session-prune", runId: "run-prune", type: "run.started", producer: "runtime", timestamp: "2026-07-20T00:00:00.000Z", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "prune-finish", projectId: "project-prune", sessionId: "session-prune", runId: "run-prune", type: "terminal.recorded", producer: "runtime", timestamp: "2026-07-20T00:00:01.000Z", payload: { formatVersion: 1, status: "completed" } }));
+  const path = join(root, "global", "workflow.db");
+  runtimeModule.syncConfiguredWorkflowProjection({ databasePath: path, projectRoots: [root] });
+  let projection = module.openWorkflowProjectionDatabase({ path });
+  expect(projection.pruneProjection("2026-07-20T00:00:02.000Z")).toEqual({ removed: 2, retained: 0 });
+  expect(projection.current().runs[0].status).toBe("completed");
+  projection.close();
+
+  projection = module.openWorkflowProjectionDatabase({ path });
+  expect(projection.history({ limit: 10 }).items).toHaveLength(0);
+  expect(projection.current().runs[0].status).toBe("completed");
+  projection.close();
+  runtimeModule.syncConfiguredWorkflowProjection({ databasePath: path, projectRoots: [root] });
+  projection = module.openWorkflowProjectionDatabase({ path });
+  try {
+    expect(projection.history({ limit: 10 }).items).toHaveLength(0);
+    expect(projection.current().runs[0].status).toBe("completed");
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_event_identities`).get()).toEqual({ count: 2 });
+    expect(projection.database.query(`SELECT COUNT(*) AS count FROM workflow_prune_watermarks`).get()).toEqual({ count: 1 });
+  } finally { projection.close(); }
+});

--- a/tests/observability/workflow-telemetry.test.ts
+++ b/tests/observability/workflow-telemetry.test.ts
@@ -108,7 +108,7 @@ test("workflow telemetry envelope is generic, versioned, bounded, and omits raw 
   assert.equal(event.previousHash, source.previousHash);
   assert.equal(event.sourceEventHash, source.eventHash);
   assert.match(event.eventHash, /^[0-9a-f]{64}$/);
-  assert.partialDeepStrictEqual(event.dimensions, {
+  const expectedDimensions = {
     projectId: "project-1", projectRoot: "/work/project", piSessionId: "pi-session-1",
     workflowId: "delivery", snapshotId: "snapshot-1", runId: "run-1",
     agentId: "agent-1", agentName: "Builder", nodeId: "node-1", parentNodeId: "root", taskId: "task-1",
@@ -117,7 +117,10 @@ test("workflow telemetry envelope is generic, versioned, bounded, and omits raw 
     knowledgeJobId: "job-1", knowledgeUpdateId: "update-1", modelId: "provider/model",
     thinking: "high", toolName: "bash", capabilityId: "shell.mutate",
     attemptId: "attempt-1", operationId: "operation-1",
-  });
+  };
+  for (const [key, value] of Object.entries(expectedDimensions)) {
+    assert.equal((event.dimensions as unknown as Record<string, unknown>)[key], value, key);
+  }
   assert.ok(Buffer.byteLength(event.summary ?? "") <= 2_048);
   assert.deepEqual(event.metrics, { elapsedMs: 125, activeWallTimeMs: 100, budgetScope: "run", budgetUsed: 12, budgetLimit: 20, budgetRemaining: 8 });
   const persisted = JSON.stringify(event);

--- a/tests/observability/workflow-telemetry.test.ts
+++ b/tests/observability/workflow-telemetry.test.ts
@@ -1,0 +1,806 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createWorkflowEvent, sealWorkflowEvent, type WorkflowEventEnvelope } from "../../src/workflows/events.ts";
+import { appendWorkflowEvent, configureWorkflowJournalRedaction, readWorkflowJournal } from "../../src/workflows/journal.ts";
+import { terminalEnvelopeFromEvent } from "../../src/workflows/runs.ts";
+import {
+  WORKFLOW_TELEMETRY_LIMITS,
+  WORKFLOW_TELEMETRY_SCHEMA_VERSION,
+  restoreWorkflowTelemetryEvent,
+  toWorkflowTelemetryEvent,
+} from "../../src/observability/events.ts";
+import {
+  WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT,
+  ProjectionStreamError,
+  WorkflowTelemetryProjection,
+  rebuildWorkflowProjection,
+  rebuildWorkflowProjectionFromJournals,
+} from "../../src/observability/projection.ts";
+import { redactJournalPayload, redactProjectionValue } from "../../src/observability/redaction.ts";
+import {
+  previewWorkflowJournalPrune,
+  createWorkflowJournalPruneService,
+} from "../../src/observability/journal-prune.ts";
+
+function chain(inputs: Array<{ id: string; type?: WorkflowEventEnvelope["type"]; runId?: string; payload: Record<string, unknown>; timestamp?: string }>): WorkflowEventEnvelope[] {
+  const out: WorkflowEventEnvelope[] = [];
+  for (const [index, input] of inputs.entries()) {
+    const draft = createWorkflowEvent({
+      eventId: input.id,
+      projectId: "project-1",
+      sessionId: "workflow-session-1",
+      ...(input.runId ? { runId: input.runId } : {}),
+      type: input.type ?? "artifact.recorded",
+      producer: "harness",
+      timestamp: input.timestamp ?? `2026-07-20T00:00:${String(index).padStart(2, "0")}.000Z`,
+      payload: input.payload as never,
+    });
+    out.push(sealWorkflowEvent(draft, index + 1, out.at(-1)?.eventHash ?? null));
+  }
+  return out;
+}
+
+const context = {
+  projectRoot: "/work/project",
+  projectLabel: "project",
+  piSessionId: "pi-session-1",
+  workflowId: "delivery",
+  snapshotId: "snapshot-1",
+  workflowConfigHash: "a".repeat(64),
+  workflowConfigVersion: "1",
+};
+
+test("workflow telemetry envelope is generic, versioned, bounded, and omits raw content", () => {
+  const [source] = chain([{
+    id: "event-all-dimensions",
+    runId: "run-1",
+    payload: {
+      formatVersion: 1,
+      operation: "provider-call",
+      operationId: "operation-1",
+      attemptId: "attempt-1",
+      agentId: "agent-1",
+      agentName: "Builder",
+      nodeId: "node-1",
+      parentNodeId: "root",
+      taskId: "task-1",
+      adapterId: "openspec",
+      adapterVersion: "2",
+      profileId: "delivery",
+      profileVersion: "3",
+      workspaceId: "workspace-1",
+      workspaceHash: `sha256:${"b".repeat(64)}`,
+      leaseState: "owned",
+      questionId: "question-1",
+      checkpointId: "checkpoint-1",
+      approvalId: "approval-1",
+      knowledgeJobId: "job-1",
+      knowledgeUpdateId: "update-1",
+      modelId: "provider/model",
+      thinking: "high",
+      toolName: "bash",
+      capabilityId: "shell.mutate",
+      status: "running",
+      elapsedMs: 125,
+      activeWallTimeMs: 100,
+      budgetScope: "run",
+      budgetUsed: 12,
+      budgetLimit: 20,
+      budgetRemaining: 8,
+      summary: "x".repeat(10_000),
+      transcript: "raw transcript must not persist",
+      prompt: "raw prompt must not persist",
+      toolArgs: { command: "curl -H 'Authorization: Bearer secret-token'" },
+      toolResult: "unrestricted result",
+      refs: ["artifact:one"],
+    },
+  }]);
+  const event = toWorkflowTelemetryEvent(source, context);
+  assert.equal(event.schemaVersion, WORKFLOW_TELEMETRY_SCHEMA_VERSION);
+  assert.match(event.streamId, /^wfs1-[0-9a-f]{64}$/);
+  assert.equal(event.sequence, source.sequence);
+  assert.equal(event.previousHash, source.previousHash);
+  assert.equal(event.sourceEventHash, source.eventHash);
+  assert.match(event.eventHash, /^[0-9a-f]{64}$/);
+  assert.partialDeepStrictEqual(event.dimensions, {
+    projectId: "project-1", projectRoot: "/work/project", piSessionId: "pi-session-1",
+    workflowId: "delivery", snapshotId: "snapshot-1", runId: "run-1",
+    agentId: "agent-1", agentName: "Builder", nodeId: "node-1", parentNodeId: "root", taskId: "task-1",
+    adapterId: "openspec", profileId: "delivery", workspaceId: "workspace-1",
+    questionId: "question-1", checkpointId: "checkpoint-1", approvalId: "approval-1",
+    knowledgeJobId: "job-1", knowledgeUpdateId: "update-1", modelId: "provider/model",
+    thinking: "high", toolName: "bash", capabilityId: "shell.mutate",
+    attemptId: "attempt-1", operationId: "operation-1",
+  });
+  assert.ok(Buffer.byteLength(event.summary ?? "") <= 2_048);
+  assert.deepEqual(event.metrics, { elapsedMs: 125, activeWallTimeMs: 100, budgetScope: "run", budgetUsed: 12, budgetLimit: 20, budgetRemaining: 8 });
+  const persisted = JSON.stringify(event);
+  assert.doesNotMatch(persisted, /raw transcript|raw prompt|unrestricted result|secret-token/);
+  assert.doesNotMatch(persisted, /planning|hiveTeam|planId/);
+});
+
+test("redaction removes credentials, secret environment values, and protected-path content before persistence", () => {
+  const environment = { PUBLIC_NAME: "visible", SERVICE_TOKEN: "env-secret-value" };
+  const value = {
+    authorization: "Bearer header-secret",
+    note: "SERVICE_TOKEN=env-secret-value password=hunter2",
+    headers: { Authorization: "Basic dXNlcjpwYXNz" },
+    path: ".pi/hive/private/credential.txt",
+    content: "protected-content",
+    nested: [{ apiKey: "key-secret" }],
+  };
+  const redacted = redactJournalPayload(value, { environment, protectedPaths: [".pi/hive/private"] });
+  const text = JSON.stringify(redacted);
+  assert.doesNotMatch(text, /header-secret|env-secret-value|hunter2|dXNlcjpwYXNz|protected-content|key-secret/);
+  assert.match(text, /\[REDACTED\]/);
+  assert.equal((redacted as any).note.length <= 2_048, true);
+
+  const journal = redactJournalPayload({ audit: "keep", password: "journal-secret", summary: "y".repeat(200_000) });
+  assert.equal((journal as any).audit, "keep");
+  assert.equal((journal as any).password, "[REDACTED]");
+  assert.ok(Buffer.byteLength((journal as any).summary) <= 131_072);
+  const draft = createWorkflowEvent({ projectId: "project-1", sessionId: "session-redaction", type: "artifact.recorded", producer: "runtime", payload: { authorization: "Bearer journal-token", audit: "keep" } });
+  assert.equal(JSON.stringify(draft).includes("journal-token"), false, "workflow journal drafts are redacted before append");
+});
+
+test("protected-path aliases taint nested content without relying on a tiny exact key list", () => {
+  for (const key of ["canonicalPath", "config_path", "sourceFile", "workingDirectory", "artifactRoot"]) {
+    const redacted = redactJournalPayload({ [key]: ".pi/hive/private/item.json", nested: { content: "nested-private-content", deeper: [{ body: "nested-private-body" }] } });
+    assert.doesNotMatch(JSON.stringify(redacted), /nested-private-content|nested-private-body/);
+  }
+  assert.equal((redactJournalPayload({ profile: "public", content: "visible" }) as any).content, "visible", "ordinary keys ending in the letters 'file' are not path aliases");
+});
+
+test("credential header aliases and protected-object content aliases are redacted before journaling", () => {
+  const secrets = ["header-api-secret", "header-auth-secret", "normalized-api-secret", "normalized-auth-secret", "protected-data", "protected-file-content", "protected-raw", "protected-value"];
+  const draft = createWorkflowEvent({
+    eventId: "alias-redaction",
+    projectId: "project-1",
+    sessionId: "alias-redaction-session",
+    type: "artifact.recorded",
+    producer: "harness",
+    payload: {
+      headers: {
+        "X-API-Key": secrets[0],
+        "X-Auth-Token": secrets[1],
+        x_api_key: secrets[2],
+        xAuthToken: secrets[3],
+      },
+      path: ".pi/hive/private/aliases.json",
+      nested: { data: secrets[4], deeper: [{ fileContent: secrets[5], raw: secrets[6], value: secrets[7] }] },
+    },
+  });
+  const persistedDraft = JSON.stringify(draft);
+  for (const secret of secrets) assert.doesNotMatch(persistedDraft, new RegExp(secret));
+  assert.match(persistedDraft, /\[REDACTED\]/);
+
+  const publicMetadata = redactJournalPayload({
+    xApiKeyMetadata: "public-description",
+    apiKeyDescription: "public-api-description",
+    metadata: { data: "public-data", fileContent: "public-file-content", raw: "public-raw", value: "public-value" },
+  }, { environment: {} }) as any;
+  assert.equal(publicMetadata.xApiKeyMetadata, "public-description");
+  assert.equal(publicMetadata.apiKeyDescription, "public-api-description");
+  assert.deepEqual(publicMetadata.metadata, { data: "public-data", fileContent: "public-file-content", raw: "public-raw", value: "public-value" });
+});
+
+test("projection from an authoritative journal is deterministic across environment changes", () => {
+  const variable = "W24_REBUILD_SECRET";
+  const prior = process.env[variable];
+  delete process.env[variable];
+  const [source] = chain([{ id: "deterministic-redaction", payload: { formatVersion: 1, summary: "plain-value-that-later-becomes-secret" } }]);
+  const before = toWorkflowTelemetryEvent(source, context);
+  process.env[variable] = "plain-value-that-later-becomes-secret";
+  try {
+    const after = toWorkflowTelemetryEvent(source, { ...context, redaction: { environment: process.env } });
+    assert.equal(after.eventHash, before.eventHash);
+    assert.deepEqual(after, before);
+  } finally {
+    if (prior === undefined) delete process.env[variable]; else process.env[variable] = prior;
+  }
+});
+
+test("projection ingestion is event-ID idempotent and fail-stops only a corrupt stream", () => {
+  const source = chain([
+    { id: "event-1", payload: { formatVersion: 1, operation: "start", status: "running" } },
+    { id: "event-2", payload: { formatVersion: 1, operation: "finish", status: "completed" } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, context));
+  const projection = new WorkflowTelemetryProjection();
+  assert.equal(projection.ingest(source[0]), "inserted");
+  assert.equal(projection.ingest(source[0]), "duplicate");
+  assert.equal(projection.history({ limit: 10 }).items.length, 1);
+
+  const skippedDraft = createWorkflowEvent({ eventId: "skipped", projectId: "project-1", sessionId: "workflow-session-1", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 } });
+  const skipped = toWorkflowTelemetryEvent(sealWorkflowEvent(skippedDraft, 3, source[0].sourceEventHash), context);
+  assert.throws(() => projection.ingest(skipped), ProjectionStreamError);
+  assert.equal(projection.streamStatus(source[0].streamId).state, "blocked");
+  assert.throws(() => projection.ingest(source[1]), /blocked/i);
+
+  const otherDraft = createWorkflowEvent({ eventId: "other-1", projectId: "project-2", sessionId: "session-2", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1, status: "running" } });
+  const otherEvent = toWorkflowTelemetryEvent(sealWorkflowEvent(otherDraft, 1, null), context);
+  assert.equal(projection.ingest(otherEvent), "inserted", "an unrelated stream remains available");
+});
+
+test("incremental and rebuild projections are deterministic and expose current, history, usage, and stable bounded pages", () => {
+  const source = chain([
+    { id: "run-start", type: "run.started", runId: "run-1", payload: { formatVersion: 1, status: "running", nodeId: "root" } },
+    { id: "task-start", type: "task.started", runId: "run-1", payload: { formatVersion: 1, taskId: "task-1", nodeId: "worker", parentNodeId: "root", status: "running" } },
+    { id: "estimated", type: "budget.model.usage.recorded", runId: "run-1", payload: { formatVersion: 1, nodeId: "worker", usage: { inputTokens: 10, outputTokens: 5, costMicroUsd: 20, precision: "estimated" } } },
+    { id: "confirmed", type: "knowledge.transition", runId: "run-1", payload: { formatVersion: 1, operation: "curator-model-usage", jobId: "job-1", usage: { inputTokens: 7, outputTokens: 3, costMicroUsd: 11, precision: "provider-confirmed" } } },
+    { id: "terminal", type: "terminal.recorded", runId: "run-1", payload: { formatVersion: 1, status: "completed", summary: "done", changeCoverage: "scoped-reconciled", terminalEventHash: `sha256:${"c".repeat(64)}`, refs: ["artifact:result"] } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, context));
+
+  const incremental = new WorkflowTelemetryProjection();
+  for (const event of source) incremental.ingest(event);
+  const rebuilt = rebuildWorkflowProjection([source]);
+  assert.deepEqual(rebuilt.snapshot(), incremental.snapshot());
+
+  const current = incremental.current();
+  assert.equal(current.sessions[0].workflowId, "delivery");
+  assert.equal(current.runs[0].status, "completed");
+  assert.equal(current.tasks[0].taskId, "task-1");
+  assert.equal(current.knowledge[0].knowledgeJobId, "job-1");
+  assert.deepEqual(incremental.usage(), {
+    estimated: { inputTokens: 10, outputTokens: 5, costMicroUsd: 20 },
+    providerConfirmed: { inputTokens: 7, outputTokens: 3, costMicroUsd: 11 },
+  });
+  assert.equal(incremental.history({ limit: 10 }).items.at(-1)?.terminal?.changeCoverage, "scoped-reconciled");
+
+  const first = incremental.history({ limit: 2 });
+  assert.equal(first.items.length, 2);
+  assert.equal(first.hasMore, true);
+  const second = incremental.history({ limit: 2, cursor: first.nextCursor });
+  assert.deepEqual(first.items.map((event) => event.eventId).filter((id) => second.items.some((event) => event.eventId === id)), []);
+  assert.throws(() => incremental.history({ limit: 501 }), /limit/i);
+
+  const pruned = incremental.pruneProjection("2026-07-20T00:00:04.000Z");
+  assert.equal(pruned.removed, 4);
+  assert.equal(incremental.current().runs[0].status, "completed", "projection pruning retains materialized current state");
+  assert.equal(source.length, 5, "authoritative source arrays are untouched");
+});
+
+test("question, approval, workspace, knowledge, and terminal transitions materialize without workflow-name semantics", () => {
+  const source = chain([
+    { id: "transition-run", type: "run.started", runId: "run-1", payload: { formatVersion: 1 } },
+    { id: "transition-workspace", type: "artifact.recorded", runId: "run-1", payload: { formatVersion: 1, operation: "bind", workspace: { id: "workspace-1" }, workspaceHash: `sha256:${"d".repeat(64)}`, leaseState: "owned" } },
+    { id: "transition-question-create", type: "question.transition", runId: "run-1", payload: { formatVersion: 1, operation: "create", questionId: "question-1", nodeId: "root" } },
+    { id: "transition-question-answer", type: "question.transition", runId: "run-1", payload: { formatVersion: 1, operation: "answer", questionId: "question-1", nodeId: "root" } },
+    { id: "transition-approval-request", type: "approval.recorded", runId: "run-1", payload: { formatVersion: 1, operation: "request", requestId: "request-1", checkpointId: "verify" } },
+    { id: "transition-approval-decision", type: "approval.recorded", runId: "run-1", payload: { formatVersion: 1, operation: "decision", requestId: "request-1", decision: { verdict: "approved" } } },
+    { id: "transition-knowledge", type: "knowledge.transition", runId: "run-1", payload: { formatVersion: 1, operation: "job-transition", jobId: "job-1", from: "running", to: "completed" } },
+    { id: "transition-terminal", type: "terminal.recorded", runId: "run-1", payload: { formatVersion: 1, status: "completed", changeCoverage: "recorded" } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, { ...context, workflowId: "arbitrary-user-workflow" }));
+  const projection = rebuildWorkflowProjection([source]);
+  const current = projection.current();
+  assert.equal(current.workspaces[0].workspaceId, "workspace-1");
+  assert.equal(current.questions[0].status, "answered");
+  assert.equal(current.approvals[0].status, "approved");
+  assert.equal(current.knowledge[0].status, "completed");
+  assert.equal(current.runs[0].status, "completed");
+  assert.equal(JSON.stringify(projection.snapshot()).includes("arbitrary-user-workflow"), true);
+});
+
+test("authority-owned journal pruning is fail-closed, crash-recoverable, and idempotent", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-prune-"));
+  const projectId = "project-1";
+  const sessionId = "session-1";
+  const service = createWorkflowJournalPruneService({ authenticate: (credential) => credential === "ok" ? "operator" : undefined });
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "open", projectId, sessionId, runId: "run-open", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  assert.throws(() => previewWorkflowJournalPrune(root, sessionId), /nonterminal|open/i);
+  assert.throws(() => service.prune({ projectRoot: root, sessionId, credential: "bad", confirmIrrecoverable: true, operationId: "prune-1", authenticate: () => "spoof" } as never), /unknown|auth/i);
+
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "closed", projectId, sessionId, runId: "run-open", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "reopened", projectId, sessionId, runId: "run-open", type: "run.transition", producer: "runtime", payload: { formatVersion: 1, from: "completed", to: "running" } }));
+  assert.throws(() => previewWorkflowJournalPrune(root, sessionId), /nonterminal|open/i);
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "reclosed", projectId, sessionId, runId: "run-open", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" } }));
+  assert.throws(() => service.prune({ projectRoot: root, sessionId, credential: "ok", confirmIrrecoverable: false, operationId: "prune-1" }), /confirm/i);
+  const crashing = createWorkflowJournalPruneService({ authenticate: () => "operator", fault: (stage) => { if (stage === "afterDetach") throw new Error("simulated crash"); } });
+  assert.throws(() => crashing.prune({ projectRoot: root, sessionId, credential: "ok", confirmIrrecoverable: true, operationId: "prune-1" }), /simulated crash/);
+  const result = service.prune({ projectRoot: root, sessionId, credential: "ok", confirmIrrecoverable: true, operationId: "prune-1" });
+  assert.equal(result.deletedEvents, 4);
+  assert.equal(result.authenticatedIdentity, "operator");
+  assert.equal(service.prune({ projectRoot: root, sessionId, credential: "ok", confirmIrrecoverable: true, operationId: "prune-1" }).deletedEvents, 4);
+  assert.deepEqual(readWorkflowJournal(root, sessionId), []);
+});
+
+test("concurrent prune identities cannot overwrite the operation receipt", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-prune-race-"));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "started", projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "terminal", projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "terminal.recorded", producer: "runtime", payload: { formatVersion: 1, status: "completed" } }));
+  const script = `import {writeFileSync,existsSync} from 'node:fs'; import {createWorkflowJournalPruneService} from './src/observability/journal-prune.ts'; const [root,identity]=process.argv.slice(1); const service=createWorkflowJournalPruneService({authenticate(){writeFileSync(root+'/ready-'+identity,'1'); while(!existsSync(root+'/go')) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,10); return identity;}}); try { const value=service.prune({projectRoot:root,sessionId:'session-1',credential:'ok',operationId:'same-operation',confirmIrrecoverable:true}); console.log(JSON.stringify({ok:true,identity:value.authenticatedIdentity})); } catch(error) { console.log(JSON.stringify({ok:false,error:String(error)})); }`;
+  const children = ["operator-a", "operator-b"].map((identity) => spawn(process.execPath, ["--import", "tsx", "--import", "./tests/helpers/register-ts-loader.mjs", "--input-type=module", "-e", script, root, identity], { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] }));
+  while (!existsSync(join(root, "ready-operator-a")) || !existsSync(join(root, "ready-operator-b"))) await new Promise((resolve) => setTimeout(resolve, 5));
+  writeFileSync(join(root, "go"), "1");
+  const results = await Promise.all(children.map(async (child) => { const output: Buffer[] = []; child.stdout.on("data", (chunk) => output.push(chunk)); await once(child, "exit"); return JSON.parse(Buffer.concat(output).toString().trim()); }));
+  assert.equal(results.filter((result) => result.ok).length, 1);
+  assert.equal(results.filter((result) => !result.ok && /different authenticated identity/.test(result.error)).length, 1);
+});
+
+test("journal pruning refuses lifecycle events whose run identity is missing", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-prune-missing-run-"));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "missing-run", projectId: "project-1", sessionId: "session-1", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  const before = readWorkflowJournal(root, "session-1");
+  assert.throws(() => previewWorkflowJournalPrune(root, "session-1"), /run.*identity|runId|nonterminal/i);
+  assert.equal(readWorkflowJournal(root, "session-1").length, before.length);
+});
+
+test("projection rebuild consumes explicit workflow journal registrations without treating a registry as authority", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-rebuild-"));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "registered-1", projectId: "project-1", sessionId: "registered", runId: "run-1", type: "run.started", producer: "runtime", payload: { formatVersion: 1, status: "running" } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "registered-2", projectId: "project-1", sessionId: "registered", runId: "run-1", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" } }));
+  const rebuilt = rebuildWorkflowProjectionFromJournals([{ projectRoot: root, sessionId: "registered", context: { workflowId: "delivery", snapshotId: "snapshot" } }]);
+  assert.equal(rebuilt.history({ limit: 10 }).items.length, 2);
+  assert.equal(rebuilt.current().runs[0].status, "completed");
+  assert.equal(rebuilt.current().runs[0].workflowId, "delivery");
+});
+
+test("projection authentication rejects forged hashes, first events, and colliding colon identities", () => {
+  const left = chain([{ id: "left", payload: { formatVersion: 1, status: "running" } }])[0];
+  const rightDraft = createWorkflowEvent({ eventId: "right", projectId: "project-1:workflow", sessionId: "session-1", type: "run.started", producer: "harness", payload: { formatVersion: 1 } });
+  const right = toWorkflowTelemetryEvent(sealWorkflowEvent(rightDraft, 1, null));
+  const projected = toWorkflowTelemetryEvent(left);
+  assert.notEqual(projected.streamId, right.streamId);
+  const projection = new WorkflowTelemetryProjection();
+  assert.throws(() => projection.ingest({ ...projected, eventHash: "f".repeat(64) }), /authentic|hash|trusted/i);
+  assert.throws(() => projection.ingest({ ...projected, payloadHash: "not-a-hash" }), /authentic|hash|trusted/i);
+  for (const replacement of [
+    { dimensions: { ...projected.dimensions, workflowId: "forged" } },
+    { status: "forged" },
+    { usage: { inputTokens: 999, outputTokens: 0, costMicroUsd: 0, precision: "estimated" as const } },
+    { metadata: { forged: true } },
+  ]) {
+    const forged = Object.create(Object.getPrototypeOf(projected));
+    Object.defineProperties(forged, Object.fromEntries(Reflect.ownKeys(projected).map((key) => [key, { ...Object.getOwnPropertyDescriptor(projected, key)!, configurable: true, writable: true }])));
+    Object.assign(forged, replacement);
+    assert.throws(() => projection.ingest(forged), /projected event hash/i);
+  }
+  assert.equal(projection.streamStatus(projected.streamId).lastSequence, 0);
+});
+
+test("current state ignores incidental usage, preserves entity status, and remains bounded", () => {
+  const source = chain([
+    { id: "state-run", type: "run.started", runId: "run-1", payload: { formatVersion: 1, status: "running", nodeId: "root" } },
+    { id: "state-usage", type: "budget.model.usage.recorded", runId: "run-1", payload: { formatVersion: 1, nodeId: "root", usage: { inputTokens: 1, outputTokens: 1, costMicroUsd: 1, precision: "estimated" } } },
+    { id: "state-terminal", type: "terminal.recorded", runId: "run-1", payload: { formatVersion: 1, status: "completed" } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, context));
+  const projection = rebuildWorkflowProjection([source]);
+  assert.equal(projection.current().runs[0].status, "completed");
+  assert.equal(projection.current().sessions[0]?.status, undefined, "a run terminal must not close its session");
+  assert.equal(projection.current().nodes[0].status, "running", "usage must not erase node state");
+});
+
+test("projection prune and blocked-stream duplicate semantics remain authority-equivalent", () => {
+  const source = chain([
+    { id: "prune-start", type: "run.started", runId: "run-1", payload: { formatVersion: 1 } },
+    { id: "prune-usage", type: "budget.model.usage.recorded", runId: "run-1", payload: { formatVersion: 1, usage: { inputTokens: 4, outputTokens: 2, costMicroUsd: 8, precision: "estimated" } } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, context));
+  const projection = rebuildWorkflowProjection([source]);
+  assert.throws(() => projection.ingest({ ...source[1], eventId: "gap", sequence: 4 }), /authentic|gap/i);
+  assert.equal(projection.ingest(source[0]), "duplicate");
+  projection.pruneProjection("2026-07-20T00:00:02.000Z");
+  assert.deepEqual(projection.usage().estimated, { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 });
+
+  const reused = toWorkflowTelemetryEvent(sealWorkflowEvent(createWorkflowEvent({
+    eventId: source[0].eventId,
+    projectId: "different-project",
+    sessionId: "different-session",
+    type: "run.started",
+    producer: "harness",
+    payload: { formatVersion: 1 },
+  }), 1, null));
+  assert.throws(() => projection.ingest(reused), /reused an event ID/i, "pruning must permanently retain event-ID identity");
+  assert.equal(projection.streamStatus(reused.streamId).state, "blocked");
+});
+
+test("redaction canonicalizes protected paths, fails closed on secret policy overflow, and production writers consume configured policy", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-redaction-policy-"));
+  const secret = "configured-super-secret";
+  for (const protectedPath of [join(root, ".env"), "nested/../.env", "nested\\..\\.env", join(root, "configured/private/item.json")]) {
+    const redacted = redactJournalPayload({ path: protectedPath, nested: { content: "must-not-survive" } }, { projectRoot: root, protectedPaths: ["configured/private"] });
+    assert.doesNotMatch(JSON.stringify(redacted), /must-not-survive/);
+  }
+  const tooManySecrets = Object.fromEntries(Array.from({ length: 129 }, (_, index) => [`TOKEN_${index}`, `secret-${index}`]));
+  assert.throws(() => redactJournalPayload("value", { environment: tooManySecrets }), /secret.*limit|redaction.*limit/i);
+  assert.throws(() => redactJournalPayload("value", { environment: { API_TOKEN: "abc" } }), /secret.*length|redaction.*limit/i);
+  assert.throws(() => redactJournalPayload("value", { environment: { API_TOKEN: "x".repeat(8_193) } }), /secret.*length|redaction.*limit/i);
+
+  configureWorkflowJournalRedaction(root, { environment: { CONFIG_TOKEN: secret }, protectedPaths: ["configured/private"] });
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "redacted", projectId: "project-1", sessionId: "redacted-session", type: "artifact.recorded", producer: "runtime", payload: {
+    path: "configured/private/item.json",
+    nested: { content: secret, toolArgs: { command: `echo ${secret}` }, deeper: [{ toolResult: secret }] },
+  } }));
+  const bytes = readFileSync(join(root, ".pi/hive/sessions/redacted-session/journal", `${String(1).padStart(16, "0")}-${readWorkflowJournal(root, "redacted-session")[0].eventHash}.json`), "utf8");
+  assert.doesNotMatch(bytes, new RegExp(secret));
+  assert.match(bytes, /\[REDACTED\]/);
+});
+
+test("redaction policy validation covers aggregate bounds and normalized path boundaries", () => {
+  assert.throws(() => redactJournalPayload("value", { environment: Object.fromEntries(Array.from({ length: 1_025 }, (_, index) => [`PUBLIC_${index}`, "visible"])) }), /environment entry limit/i);
+  assert.throws(() => redactJournalPayload("value", { environment: { API_TOKEN: "😀".repeat(3_000) } }), /secret byte limit/i);
+  assert.throws(() => redactJournalPayload("value", { environment: Object.fromEntries(Array.from({ length: 40 }, (_, index) => [`TOKEN_${index}`, `${index}`.padEnd(8_000, "x")])) }), /secret limit/i);
+  assert.throws(() => redactJournalPayload("value", { protectedPaths: Array.from({ length: 257 }, (_, index) => `private/${index}`) }), /protected path limit/i);
+  for (const protectedPaths of [[""], ["bad\0path"], ["x".repeat(4_097)]]) assert.throws(() => redactJournalPayload("value", { protectedPaths }), /protected path limit/i);
+  assert.equal((redactJournalPayload({ path: "/outside/public.txt", content: "visible" }, { projectRoot: "/project" }) as any).content, "visible");
+  assert.equal((redactJournalPayload({ path: "/anywhere/.env", content: "hidden" }) as any).content, "[REDACTED]");
+  assert.equal(redactJournalPayload("abcdef", { environment: { TOKEN_UNDEFINED: undefined, TOKEN_EMPTY: "", PUBLIC: "visible", ["x".repeat(513)]: "ignored" }, maxStringBytes: 4, maxArrayItems: 1, maxObjectKeys: 1, maxDepth: 1 }), "abcd");
+  assert.equal((redactJournalPayload({ path: ".", content: "visible" }, { projectRoot: "/project" }) as any).content, "visible");
+  assert.equal((redactJournalPayload({ path: ".env/child", content: "hidden" }) as any).content, "[REDACTED]");
+  assert.throws(() => redactJournalPayload("value", { protectedPaths: [1 as never] }), /protected path limit/i);
+
+  const secondRoot = mkdtempSync(join(tmpdir(), "pi-hive-redaction-empty-policy-"));
+  configureWorkflowJournalRedaction(secondRoot, {});
+  configureWorkflowJournalRedaction(secondRoot, { protectedPaths: ["private"] });
+  appendWorkflowEvent(secondRoot, createWorkflowEvent({ eventId: "local-options", projectId: "project-2", sessionId: "session-2", type: "artifact.recorded", producer: "runtime", payload: { value: "abcdef" } }), {
+    redaction: { environment: { LOCAL_TOKEN: "local-secret" }, protectedPaths: ["other-private"], maxStringBytes: 4, maxArrayItems: 2, maxObjectKeys: 2, maxDepth: 2 },
+  });
+  assert.equal((readWorkflowJournal(secondRoot, "session-2")[0].payload as any).value, "abcd");
+  let projectLimitError: unknown;
+  for (let index = 0; index < 100 && !projectLimitError; index++) {
+    try { configureWorkflowJournalRedaction(join(secondRoot, `project-${index}`), {}); } catch (error) { projectLimitError = error; }
+  }
+  assert.match(String(projectLimitError), /redaction project limit/i);
+});
+
+test("persisted telemetry restoration verifies the complete projected hash before trusting a row", () => {
+  const event = toWorkflowTelemetryEvent(chain([{ id: "persisted", payload: { formatVersion: 1, status: "running" } }])[0], context);
+  assert.equal(restoreWorkflowTelemetryEvent(JSON.parse(JSON.stringify(event))).eventHash, event.eventHash);
+  assert.throws(() => restoreWorkflowTelemetryEvent({ ...JSON.parse(JSON.stringify(event)), status: "forged" }), /hash/i);
+  assert.throws(() => restoreWorkflowTelemetryEvent({ forged: true }), /shape/i);
+});
+
+test("history and current cursors strictly reject malformed base64url", () => {
+  const projection = new WorkflowTelemetryProjection();
+  assert.throws(() => projection.history({ limit: 1, cursor: "x".repeat(5_000) }), /byte|cursor|limit/i);
+  assert.throws(() => projection.history({ limit: 1, projectId: "x".repeat(2_000) }), /byte|filter|limit/i);
+  for (const cursor of ["!", "a=", "a b", "%%%%", "eyJub3QiOiJhLWN1cnNvciJ9"]) {
+    assert.throws(() => projection.history({ limit: 1, cursor }), /cursor.*invalid/i);
+    assert.throws(() => projection.currentPage({ kind: "sessions", limit: 1, cursor }), /cursor.*invalid/i);
+  }
+});
+
+test("composite entity identities are collision-free", () => {
+  const source = chain([
+    { id: "collision-left", type: "task.started", runId: "a:b", payload: { formatVersion: 1, taskId: "c", nodeId: "n:o" } },
+    { id: "collision-right", type: "task.started", runId: "a", payload: { formatVersion: 1, taskId: "b:c", nodeId: "n:o" } },
+  ]).map((event) => toWorkflowTelemetryEvent(event, context));
+  const projection = rebuildWorkflowProjection([source]);
+  assert.equal(projection.current().tasks.length, 2);
+  assert.deepEqual(new Set(projection.current().tasks.map((row) => `${row.runId}/${row.taskId}`)), new Set(["a:b/c", "a/b:c"]));
+});
+
+test("telemetry rejects unsafe context and numeric magnitudes before projection", () => {
+  const source = chain([{ id: "magnitude", type: "budget.model.usage.recorded", payload: {
+    formatVersion: 1,
+    elapsedMs: 1_000_000_000_001,
+    usage: { inputTokens: 1_000_000_000_001, outputTokens: 0, costMicroUsd: 0, precision: "estimated" },
+  } }])[0];
+  assert.throws(() => toWorkflowTelemetryEvent(source, { ...context, projectLabel: "x".repeat(2_000) }), /dimension|context|byte|limit/i);
+  assert.throws(() => toWorkflowTelemetryEvent(source, context), /metric|usage|magnitude|limit/i);
+});
+
+test("loaded project policy redacts configured protected roots through real symlinks", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-redaction-loaded-policy-"));
+  mkdirSync(join(root, ".pi", "hive"), { recursive: true });
+  mkdirSync(join(root, "protected-knowledge"));
+  writeFileSync(join(root, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\nknowledge:\n  private:\n    provider: okf\n    path: protected-knowledge\n");
+  writeFileSync(join(root, "protected-knowledge", "secret.txt"), "private");
+  symlinkSync("protected-knowledge", join(root, "public-link"));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "symlink-redaction", projectId: "project-policy", sessionId: "session-policy", type: "artifact.recorded", producer: "runtime", payload: {
+    path: "public-link/secret.txt",
+    content: "must-not-survive",
+    note: process.env.HIVE_TEST_CONFIG_TOKEN ?? "visible",
+  } }));
+  assert.doesNotMatch(JSON.stringify(readWorkflowJournal(root, "session-policy")[0].payload), /must-not-survive/);
+});
+
+test("completed journal prune receipts never attach to a later similar closed journal", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-prune-successive-"));
+  const service = createWorkflowJournalPruneService({ authenticate: () => "operator" });
+  const appendClosed = (prefix: string) => {
+    appendWorkflowEvent(root, createWorkflowEvent({ eventId: `${prefix}-start`, projectId: "project-1", sessionId: "session-1", runId: `${prefix}-run`, type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+    appendWorkflowEvent(root, createWorkflowEvent({ eventId: `${prefix}-finish`, projectId: "project-1", sessionId: "session-1", runId: `${prefix}-run`, type: "terminal.recorded", producer: "runtime", payload: { formatVersion: 1, status: "completed" } }));
+  };
+  appendClosed("first");
+  expectPruned("first-operation", 2);
+  appendClosed("second");
+  expectPruned("second-operation", 2);
+  assert.deepEqual(readWorkflowJournal(root, "session-1"), []);
+
+  function expectPruned(operationId: string, count: number): void {
+    const value = service.prune({ projectRoot: root, sessionId: "session-1", credential: "ok", operationId, confirmIrrecoverable: true });
+    assert.equal(value.deletedEvents, count);
+    const operationHash = createHash("sha256").update("pi-hive-journal-prune-operation-v1\0").update(operationId).digest("hex");
+    const receipt = JSON.parse(readFileSync(join(root, ".pi", "hive", "sessions", "session-1", `.journal-prune-receipt-${operationHash}.json`), "utf8"));
+    assert.equal(receipt.status, "completed");
+    assert.match(receipt.journal.contentHash, /^[0-9a-f]{64}$/);
+  }
+});
+
+test("journal prune reconciles a detached prior operation before a new operation ID", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-journal-prune-new-operation-"));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "start", projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "run.started", producer: "runtime", payload: { formatVersion: 1 } }));
+  appendWorkflowEvent(root, createWorkflowEvent({ eventId: "finish", projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "terminal.recorded", producer: "runtime", payload: { formatVersion: 1, status: "completed" } }));
+  const crashing = createWorkflowJournalPruneService({ authenticate: () => "operator", fault(stage) { if (stage === "afterDetach") throw new Error("crash"); } });
+  assert.throws(() => crashing.prune({ projectRoot: root, sessionId: "session-1", credential: "ok", operationId: "old-operation", confirmIrrecoverable: true }), /crash/);
+  const service = createWorkflowJournalPruneService({ authenticate: () => "operator" });
+  const result = service.prune({ projectRoot: root, sessionId: "session-1", credential: "ok", operationId: "new-operation", confirmIrrecoverable: true });
+  assert.equal(result.deletedEvents, 0);
+  assert.deepEqual(readWorkflowJournal(root, "session-1"), []);
+  assert.deepEqual(readdirSync(join(root, ".pi", "hive", "sessions", "session-1")).filter((name) => name.startsWith(".journal-pruned-")), []);
+});
+
+test("in-memory rebuild supports histories above ten thousand while keeping output bounded", () => {
+  const drafts: WorkflowEventEnvelope[] = [];
+  for (let index = 0; index < 10_001; index++) {
+    const draft = createWorkflowEvent({
+      eventId: `large-node-${index}`,
+      projectId: "project-large-node",
+      sessionId: "session-large-node",
+      runId: "run-large-node",
+      type: index === 0 ? "run.started" : index === 10_000 ? "terminal.recorded" : "artifact.recorded",
+      producer: "harness",
+      timestamp: new Date(Date.UTC(2026, 6, 22, 0, 0, index)).toISOString(),
+      payload: index === 10_000 ? { formatVersion: 1, status: "completed" } : { formatVersion: 1 },
+    });
+    drafts.push(sealWorkflowEvent(draft, index + 1, drafts.at(-1)?.eventHash ?? null));
+  }
+  const projection = rebuildWorkflowProjection([drafts.map((event) => toWorkflowTelemetryEvent(event))]);
+  const page = projection.history({ limit: 500 });
+  assert.equal(page.items.length, 500);
+  assert.equal(page.hasMore, true);
+  assert.equal(projection.current().runs[0].status, "completed");
+
+  const bounded = new WorkflowTelemetryProjection({ eventLimit: 2 });
+  bounded.ingest(toWorkflowTelemetryEvent(drafts[0]));
+  bounded.ingest(toWorkflowTelemetryEvent(drafts[1]));
+  assert.throws(() => bounded.ingest(toWorkflowTelemetryEvent(drafts[2])), /event limit/i);
+});
+
+test("legacy telemetry files are ignored and preserved by workflow projection rebuild", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-legacy-preserve-"));
+  const legacyJsonl = join(root, "hive-events.jsonl");
+  const legacyDb = join(root, "telemetry.db");
+  writeFileSync(legacyJsonl, "{\"event_id\":\"legacy\",\"type\":\"planning\"}\n");
+  writeFileSync(legacyDb, "legacy database bytes");
+  const before = [readFileSync(legacyJsonl), readFileSync(legacyDb)];
+  const rebuilt = rebuildWorkflowProjection([]);
+  assert.equal(rebuilt.history({ limit: 1 }).items.length, 0);
+  assert.equal(existsSync(legacyJsonl), true);
+  assert.equal(existsSync(legacyDb), true);
+  assert.deepEqual(readFileSync(legacyJsonl), before[0]);
+  assert.deepEqual(readFileSync(legacyDb), before[1]);
+});
+
+test("persisted telemetry restoration fails closed at every bounded identity boundary", () => {
+  const persisted = JSON.parse(JSON.stringify(toWorkflowTelemetryEvent(chain([{
+    id: "persisted-boundaries",
+    payload: { formatVersion: 1, status: "running" },
+  }])[0], context)));
+  const invalidShapes: ReadonlyArray<readonly [string, (value: any) => void]> = [
+    ["missing dimensions", (value) => { value.dimensions = null; }],
+    ["non-string project", (value) => { value.dimensions.projectId = 1; }],
+    ["non-string session", (value) => { value.dimensions.sessionId = 1; }],
+    ["empty dimension", (value) => { value.dimensions.projectLabel = ""; }],
+    ["non-string dimension", (value) => { value.dimensions.projectLabel = 1; }],
+    ["oversized dimension", (value) => { value.dimensions.projectLabel = "x".repeat(WORKFLOW_TELEMETRY_LIMITS.dimensionBytes + 1); }],
+    ["non-string stream", (value) => { value.streamId = 1; }],
+    ["non-string event ID", (value) => { value.eventId = 1; }],
+    ["non-string event type", (value) => { value.eventType = 1; }],
+    ["non-string timestamp", (value) => { value.timestamp = 1; }],
+    ["invalid timestamp", (value) => { value.timestamp = "not-a-timestamp"; }],
+    ["non-string producer", (value) => { value.producer = 1; }],
+    ["fractional sequence", (value) => { value.sequence = 1.5; }],
+    ["zero sequence", (value) => { value.sequence = 0; }],
+    ["non-array refs", (value) => { value.refs = {}; }],
+    ["too many refs", (value) => { value.refs = Array.from({ length: WORKFLOW_TELEMETRY_LIMITS.refs + 1 }, () => "ref"); }],
+    ["non-string ref", (value) => { value.refs = [1]; }],
+    ["oversized ref", (value) => { value.refs = ["x".repeat(WORKFLOW_TELEMETRY_LIMITS.refBytes + 1)]; }],
+    ["non-finite metric", (value) => { value.metrics = { elapsedMs: Number.POSITIVE_INFINITY }; }],
+    ["negative metric", (value) => { value.metrics = { budgetRemaining: -1 }; }],
+    ["oversized metric", (value) => { value.metrics = { budgetLimit: WORKFLOW_TELEMETRY_LIMITS.numericMagnitude + 1 }; }],
+    ["fractional usage", (value) => { value.usage = { inputTokens: 1.5, outputTokens: 0, costMicroUsd: 0, precision: "estimated" }; }],
+  ];
+  assert.throws(() => restoreWorkflowTelemetryEvent(null), /shape/i, "null rows are rejected");
+  for (const [label, mutate] of invalidShapes) {
+    const candidate = structuredClone(persisted);
+    mutate(candidate);
+    assert.throws(() => restoreWorkflowTelemetryEvent(candidate), /shape/i, label);
+  }
+
+  const invalidHashes: ReadonlyArray<readonly [string, (value: any) => void]> = [
+    ["schema version", (value) => { value.schemaVersion = 2; }],
+    ["event hash", (value) => { value.eventHash = "invalid"; }],
+    ["payload hash", (value) => { value.payloadHash = "invalid"; }],
+    ["source hash", (value) => { value.sourceEventHash = "invalid"; }],
+    ["previous hash", (value) => { value.previousHash = "invalid"; }],
+    ["configuration hash", (value) => { value.dimensions.workflowConfigHash = "invalid"; }],
+    ["workspace hash", (value) => { value.dimensions.workspaceHash = "sha256:invalid"; }],
+    ["terminal hash", (value) => { value.terminal = { refs: [], terminalEventHash: "invalid" }; }],
+  ];
+  for (const [label, mutate] of invalidHashes) {
+    const candidate = structuredClone(persisted);
+    mutate(candidate);
+    assert.throws(() => restoreWorkflowTelemetryEvent(candidate), /hash format/i, label);
+  }
+  const wrongStream = structuredClone(persisted);
+  wrongStream.streamId = `wfs1-${"b".repeat(64)}`;
+  assert.throws(() => restoreWorkflowTelemetryEvent(wrongStream), /stream identity/i);
+});
+
+test("redaction handles non-JSON values, cycles, truncation, and unresolved path aliases safely", () => {
+  const cycle: Record<string, unknown> = { visible: "kept" };
+  cycle.self = cycle;
+  const redacted = redactJournalPayload({
+    array: ["first", "second"],
+    boolean: true,
+    cycle,
+    finite: 1,
+    function: () => "unsafe",
+    infinite: Number.POSITIVE_INFINITY,
+    nil: null,
+    missing: undefined,
+    bigint: 1n,
+    symbol: Symbol("unsafe"),
+    nested: { value: "too deep" },
+  }, { environment: {}, maxArrayItems: 1, maxDepth: 3 });
+  assert.deepEqual((redacted as any).array, ["first"]);
+  assert.equal((redacted as any).boolean, true);
+  assert.equal((redacted as any).finite, 1);
+  assert.equal((redacted as any).infinite, null);
+  assert.equal((redacted as any).nil, null);
+  for (const key of ["function", "missing", "bigint", "symbol"]) assert.equal((redacted as any)[key], null);
+  assert.equal((redacted as any).cycle.self, "[REDACTED]");
+  assert.equal((redacted as any).nested.value, "too deep");
+  assert.equal((redactJournalPayload({ nested: { value: "hidden by depth" } }, { environment: {}, maxDepth: 1 }) as any).nested, "[TRUNCATED]");
+  assert.equal(redactJournalPayload("😀😀", { environment: {}, maxStringBytes: 5 }), "😀", "UTF-8 truncation never emits a partial code point");
+  assert.equal((redactJournalPayload({ authorization: "authorized" }, { environment: {} }) as any).authorization, "authorized");
+
+  const projected = redactProjectionValue({ path: "configured/private/file", content: "already-authoritative", transcript: "omit" }, {
+    environment: { API_TOKEN: "already-authoritative" }, protectedPaths: ["configured/private"], projectRoot: "/untrusted/root",
+  });
+  assert.deepEqual(projected, { content: "already-authoritative", path: "configured/private/file" }, "projection ignores process policy and strips raw fields deterministically");
+
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-redaction-broken-link-"));
+  symlinkSync("missing-target", join(root, "unresolved-link"));
+  const unresolved = redactJournalPayload({ path: "unresolved-link/private.txt", content: "must-not-survive" }, { environment: {}, projectRoot: root });
+  assert.equal((unresolved as any).content, "[REDACTED]", "an unresolved symlink path fails closed");
+});
+
+test("a real structured terminal envelope projects every bounded artifact, evidence, checkpoint, and knowledge identity", () => {
+  const artifactDigest = `sha256:${"a".repeat(64)}`;
+  const knowledgeHash = `sha256:${"b".repeat(64)}`;
+  const evidenceIdentity = "tool-call-verified";
+  const [source] = chain([{ id: "structured-terminal-refs", type: "terminal.recorded", runId: "run-1", payload: {
+    formatVersion: 1,
+    status: "completed",
+    summary: "Terminal reference projection is complete.",
+    fileChanges: [],
+    changeCoverage: "recorded",
+    artifactRefs: [{ workspaceId: "workspace-verified", checkpoint: "checkpoint-verified", digest: artifactDigest }],
+    evidenceRefs: [{ kind: "tool", toolCallId: evidenceIdentity, claim: "The verified tool call proves completion." }, { kind: "journal", claim: "Authenticated journal evidence has no external ID." }],
+    data: {
+      checkpointRefs: [{ checkpointId: "checkpoint-extra", digest: `sha256:${"c".repeat(64)}` }],
+      knowledgeRefs: [{ knowledgeJobId: "knowledge-job-verified", contentHash: knowledgeHash }],
+    },
+    unsatisfiedGates: [], closedQuestionIds: [], partialState: {},
+    finishedByNodeId: "root", finishedAt: "2026-07-20T00:00:00.000Z", snapshotId: "snapshot-1", runId: "run-1",
+  } }]);
+  assert.doesNotThrow(() => terminalEnvelopeFromEvent(source), "the fixture is a real validated terminal envelope");
+  const event = toWorkflowTelemetryEvent(source, context);
+  const refs = new Set(event.terminal?.refs);
+  for (const expected of ["workspace-verified", "checkpoint-verified", artifactDigest, evidenceIdentity, "checkpoint-extra", "knowledge-job-verified", knowledgeHash]) {
+    assert.equal(refs.has(expected), true, `missing projected terminal reference ${expected}`);
+  }
+  assert.equal(event.refs.length, event.terminal?.refs.length);
+  assert.equal(event.refs.some((ref) => ref.includes("Authenticated journal evidence")), false, "raw evidence claims are not projected");
+  assert.ok(event.refs.length <= WORKFLOW_TELEMETRY_LIMITS.refs);
+  assert.ok(event.refs.every((ref) => Buffer.byteLength(ref, "utf8") <= WORKFLOW_TELEMETRY_LIMITS.refBytes));
+});
+
+test("telemetry extraction covers nested bounds, usage aliases, and lifecycle status fallbacks", () => {
+  const [usageSource] = chain([{ id: "fallback-usage", type: "budget.model.usage.recorded", payload: {
+    formatVersion: 1,
+    nested: { providerUsage: { input: 3, output: 2, costMicroUsd: 4, precision: "estimated", cacheReadTokens: 5, cacheWriteTokens: 6, reasoningTokens: 7 } },
+    durationMs: 9,
+    refs: [1, "kept-ref", null],
+  } }]);
+  const usageEvent = toWorkflowTelemetryEvent(usageSource);
+  assert.deepEqual(usageEvent.usage, {
+    inputTokens: 3, outputTokens: 2, costMicroUsd: 4, precision: "estimated",
+    cacheReadTokens: 5, cacheWriteTokens: 6, reasoningTokens: 7,
+  });
+  assert.deepEqual(usageEvent.metrics, { elapsedMs: 9 });
+  assert.deepEqual(usageEvent.refs, ["kept-ref"]);
+
+  const [invalidPrecision] = chain([{ id: "invalid-precision", payload: { formatVersion: 1, usage: { precision: "invented", inputTokens: 100 } } }]);
+  assert.equal(toWorkflowTelemetryEvent(invalidPrecision).usage, undefined, "unknown usage precision is ignored rather than misclassified");
+  const deeplyNestedPayload = { formatVersion: 1, one: { two: { three: { four: { five: { status: "must-not-project" } } } } } };
+  const [tooDeep] = chain([{ id: "too-deep", payload: deeplyNestedPayload }]);
+  assert.equal(toWorkflowTelemetryEvent(tooDeep).status, undefined, "recursive field discovery stops at its fixed depth");
+
+  const statuses = chain([
+    { id: "question-close", type: "question.transition", payload: { formatVersion: 1, operation: "close-pending" } },
+    { id: "approval-default", type: "approval.recorded", payload: { formatVersion: 1, operation: "decision" } },
+    { id: "session-created", type: "session.created", payload: { formatVersion: 1 } },
+    { id: "session-linked", type: "session.linked", payload: { formatVersion: 1 } },
+    { id: "session-recovered", type: "session.recovered", payload: { formatVersion: 1 } },
+    { id: "session-orphaned", type: "session.orphaned", payload: { formatVersion: 1 } },
+    { id: "terminal-without-status", type: "terminal.recorded", payload: { formatVersion: 1 } },
+  ]).map((event) => toWorkflowTelemetryEvent(event));
+  assert.deepEqual(statuses.map((event) => event.status), ["closed", "decided", "active", "active", "active", "orphaned", undefined]);
+  assert.deepEqual(statuses.at(-1)?.terminal, { refs: [] });
+
+  const correlatedDraft = createWorkflowEvent({
+    eventId: "correlated", projectId: "project-1", sessionId: "correlated-session", correlationId: "operation-correlation",
+    type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 },
+  });
+  assert.equal(toWorkflowTelemetryEvent(sealWorkflowEvent(correlatedDraft, 1, null)).correlationId, "operation-correlation");
+});
+
+test("projection integrity and filtering exercise collision, previous-hash, and page boundaries", () => {
+  const collisionProjection = new WorkflowTelemetryProjection();
+  const collisionLeft = createWorkflowEvent({ eventId: "same-event", projectId: "left", sessionId: "session", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 } });
+  const collisionRight = createWorkflowEvent({ eventId: "same-event", projectId: "right", sessionId: "session", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 } });
+  collisionProjection.ingest(toWorkflowTelemetryEvent(sealWorkflowEvent(collisionLeft, 1, null)));
+  assert.throws(() => collisionProjection.ingest(toWorkflowTelemetryEvent(sealWorkflowEvent(collisionRight, 1, null))), /reused an event ID/i);
+
+  const previousHashProjection = new WorkflowTelemetryProjection();
+  const firstDraft = createWorkflowEvent({ eventId: "hash-first", projectId: "hash-project", sessionId: "hash-session", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 } });
+  const secondDraft = createWorkflowEvent({ eventId: "hash-second", projectId: "hash-project", sessionId: "hash-session", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1 } });
+  previousHashProjection.ingest(toWorkflowTelemetryEvent(sealWorkflowEvent(firstDraft, 1, null)));
+  assert.throws(() => previousHashProjection.ingest(toWorkflowTelemetryEvent(sealWorkflowEvent(secondDraft, 2, "f".repeat(64)))), /previous hash mismatch/i);
+
+  const filterSource = chain([{ id: "filter-event", type: "task.started", runId: "filter-run", payload: {
+    formatVersion: 1, nodeId: "filter-node", taskId: "filter-task",
+  } }]).map((event) => toWorkflowTelemetryEvent(event, { workflowId: "filter-workflow" }));
+  const filtered = rebuildWorkflowProjection([filterSource]);
+  assert.equal(filtered.history({
+    limit: 1, projectId: "project-1", sessionId: "workflow-session-1", workflowId: "filter-workflow",
+    runId: "filter-run", nodeId: "filter-node", taskId: "filter-task", eventType: "task.started",
+  }).items.length, 1);
+  for (const query of [
+    { projectId: "wrong" }, { sessionId: "wrong" }, { workflowId: "wrong" }, { runId: "wrong" },
+    { nodeId: "wrong" }, { taskId: "wrong" }, { eventType: "artifact.recorded" },
+  ]) assert.equal(filtered.history({ limit: 1, ...query }).items.length, 0);
+  assert.throws(() => filtered.pruneProjection("invalid"), /cutoff is invalid/i);
+
+  const pageProjection = rebuildWorkflowProjection([
+    chain([{ id: "page-left", type: "run.started", payload: { formatVersion: 1 } }]).map((event) => toWorkflowTelemetryEvent(event)),
+    [toWorkflowTelemetryEvent(sealWorkflowEvent(createWorkflowEvent({ eventId: "page-right", projectId: "project-2", sessionId: "session-2", type: "run.started", producer: "harness", payload: { formatVersion: 1 } }), 1, null))],
+  ]);
+  const firstPage = pageProjection.currentPage({ kind: "sessions", limit: 1 });
+  assert.equal(firstPage.hasMore, true);
+  assert.ok(firstPage.nextCursor);
+  const secondPage = pageProjection.currentPage({ kind: "sessions", limit: 1, cursor: firstPage.nextCursor });
+  assert.equal(secondPage.items.length, 1);
+  assert.equal(secondPage.hasMore, false);
+});
+
+test("projection query cursors and in-memory limits reject each malformed boundary", () => {
+  const encoded = (value: unknown) => Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+  const stream = `wfs1-${"a".repeat(64)}`;
+  const timestamp = "2026-07-20T00:00:00.000Z";
+  const invalidHistory = [
+    [], [timestamp, stream, 1], [1, stream, 1, "event"], ["invalid", stream, 1, "event"],
+    [timestamp, 1, 1, "event"], [timestamp, "invalid", 1, "event"], [timestamp, stream, "1", "event"],
+    [timestamp, stream, 0, "event"], [timestamp, stream, 1, 1], [timestamp, stream, 1, ""],
+  ];
+  const invalidCurrent = [
+    [], ["project", "session", "run", "entity"], ["project", "session", "run", "entity", 1],
+    ["project", "session", "run", "entity", "invalid"],
+    ["x".repeat(8_193), "session", "run", "entity", `wfe1-${"a".repeat(64)}`],
+  ];
+  const projection = new WorkflowTelemetryProjection();
+  for (const value of invalidHistory) assert.throws(() => projection.history({ limit: 1, cursor: encoded(value) }), /history cursor is invalid/i);
+  for (const value of invalidCurrent) assert.throws(() => projection.currentPage({ kind: "sessions", limit: 1, cursor: encoded(value) }), /current cursor|byte limit/i);
+  for (const limit of [0, 1.5, WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT + 1]) assert.throws(() => new WorkflowTelemetryProjection({ eventLimit: limit }), /event limit is invalid/i);
+  for (const limit of [0, 1.5, 501]) assert.throws(() => projection.currentPage({ kind: "sessions", limit }), /current limit/i);
+  assert.throws(() => projection.currentPage({ kind: "invalid" as never, limit: 1 }), /kind is invalid/i);
+  assert.throws(() => projection.currentPage({ kind: "sessions", limit: 1, cursor: "x".repeat(8_193) }), /cursor exceeds/i);
+});


### PR DESCRIPTION
## Summary
- add generic versioned workflow telemetry envelopes with bounded deterministic redaction
- add journal-authoritative incremental/rebuild projection and disposable SQLite storage
- add stream integrity, retention, crash-safe journal prune, stable DTO pagination, and production synchronization
- preserve legacy telemetry without migration or destructive upgrade

## Validation
- strict RED → GREEN → REFACTOR with regression tests for every review fix
- nine fresh adversarial review rounds, no remaining code blockers
- `just coverage-core` passed above the 80% branch threshold
- `just verify` passed: 1,151 Node tests, 95 Bun tests, type/lint/package/license/schema gates

Rebase merge only.