### PR TITLE
feat(dashboard): add workflow server API

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -351,6 +351,7 @@ test-node-compat:
     tests/knowledge/okf-provider.test.ts \
     tests/orchestration/governance.test.ts \
     tests/observability/workflow-dashboard-api.test.ts \
+    tests/observability/workflow-daemon-security.test.ts \
     tests/observability/workflow-telemetry.test.ts \
     tests/core/limits.test.ts \
     tests/core/project-identity.test.ts \

--- a/src/engine/dashboard.ts
+++ b/src/engine/dashboard.ts
@@ -71,9 +71,7 @@ export function dashboardHost(): string {
   }
   const normalized = host.replace(/^\[(.*)\]$/, "$1").toLowerCase();
   const loopback = normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
-  if (!loopback && process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK !== "1") {
-    throw new Error(`Refusing non-loopback dashboard host "${host}". Set HIVE_TELEMETRY_ALLOW_NON_LOOPBACK=1 only if you accept network exposure.`);
-  }
+  if (!loopback) throw new Error(`Refusing non-loopback dashboard host "${host}"; first-release dashboard binding is loopback-only.`);
   return normalized;
 }
 

--- a/src/knowledge/proposals.ts
+++ b/src/knowledge/proposals.ts
@@ -90,6 +90,7 @@ export interface KnowledgeProposalState { readonly proposals: Readonly<Record<st
 export interface KnowledgeProposalControlRequest {
   readonly projectId: string;
   readonly sessionId: string;
+  readonly runId: string;
   readonly proposalId: string;
   readonly expectedState: "pending";
   readonly decision: "approve" | "deny";
@@ -105,7 +106,7 @@ export interface KnowledgeProposalStatusRequest {
   readonly limit?: number;
   readonly cursor?: string;
 }
-export interface KnowledgeProposalDetailRequest { readonly projectId: string; readonly sessionId: string; readonly proposalId: string }
+export interface KnowledgeProposalDetailRequest { readonly projectId: string; readonly sessionId: string; readonly runId: string; readonly proposalId: string }
 export interface KnowledgeProposalSummary {
   readonly proposalId: string; readonly runId: string; readonly updateId: string; readonly bundleId: string;
   readonly state: DurableKnowledgeProposal["state"]; readonly createdAt: string; readonly updateHash: string;
@@ -880,11 +881,15 @@ export function restoreKnowledgeProposalState(events: readonly WorkflowEventEnve
         || typeof raw.operationId !== "string" || typeof raw.requestHash !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(raw.requestHash) || typeof raw.decidedAt !== "string" || !Number.isFinite(Date.parse(raw.decidedAt))) throw new Error("Knowledge proposal decision provenance is invalid");
       validId(raw.operationId, "Knowledge proposal decision operation ID");
       const expectedRequestHash = sha256("pi-hive-knowledge-proposal-control-v1", {
+        projectId: current.projectId, sessionId: current.sessionId, runId: current.runId, proposalId, expectedState: "pending",
+        decision: raw.decision, operationId: raw.operationId, channel: "dashboard", identity: raw.identity,
+      });
+      const legacyRequestHash = sha256("pi-hive-knowledge-proposal-control-v1", {
         projectId: current.projectId, sessionId: current.sessionId, proposalId, expectedState: "pending",
         decision: raw.decision, operationId: raw.operationId, channel: "dashboard", identity: raw.identity,
       });
       if (event.projectId !== current.projectId || event.sessionId !== current.sessionId || event.runId !== current.runId || event.correlationId !== raw.operationId
-        || raw.requestHash !== expectedRequestHash || Object.values(proposals).some((proposal) => proposal.decision?.operationId === raw.operationId)) throw new Error("Knowledge proposal decision event, authenticated request hash, or session-wide operation identity is invalid");
+        || (raw.requestHash !== expectedRequestHash && raw.requestHash !== legacyRequestHash) || Object.values(proposals).some((proposal) => proposal.decision?.operationId === raw.operationId)) throw new Error("Knowledge proposal decision event, authenticated request hash, or session-wide operation identity is invalid");
       const decision = raw as unknown as KnowledgeProposalDecision;
       proposals[proposalId] = Object.freeze({ ...current, state: decision.decision === "approve" ? "approved" : "denied", decision });
     } else if (event.payload.operation === "proposal-applied") {
@@ -939,22 +944,24 @@ export class KnowledgeProposalService {
     return proposal;
   }
   decide(request: KnowledgeProposalControlRequest): DurableKnowledgeProposal {
-    if (!record(request) || !exact(request, ["projectId", "sessionId", "proposalId", "expectedState", "decision", "operationId", "channel", "claimedIdentity", "credential"]) || request.channel !== "dashboard") throw new Error("Knowledge proposal decision request schema requires the exact authenticated dashboard human-control DTO");
+    if (!record(request) || !exact(request, ["projectId", "sessionId", "runId", "proposalId", "expectedState", "decision", "operationId", "channel", "claimedIdentity", "credential"]) || request.channel !== "dashboard") throw new Error("Knowledge proposal decision request schema requires the exact authenticated dashboard human-control DTO");
     if (Buffer.byteLength(canonicalJson(request), "utf8") > KNOWLEDGE_PROPOSAL_LIMITS.controlRequestBytes || typeof request.claimedIdentity !== "string" || Buffer.byteLength(request.claimedIdentity, "utf8") > 512
       || typeof request.credential !== "string" || Buffer.byteLength(request.credential, "utf8") > 8_192) throw new Error("Knowledge proposal control request exceeds its aggregate byte bound");
     if (request.projectId !== this.options.projectId || request.sessionId !== this.options.sessionId || request.expectedState !== "pending" || (request.decision !== "approve" && request.decision !== "deny")) throw new Error("Knowledge proposal control identity or expected CAS state is invalid");
-    validId(request.proposalId, "Knowledge proposal ID"); validId(request.operationId, "Knowledge proposal operation ID");
+    validId(request.runId, "Knowledge proposal run ID"); validId(request.proposalId, "Knowledge proposal ID"); validId(request.operationId, "Knowledge proposal operation ID");
     const identity = this.options.authenticateControl(request);
     if (!identity || typeof identity !== "string" || Buffer.byteLength(identity, "utf8") > 512) throw new Error("Knowledge proposal control authentication failed");
-    const requestHash = sha256("pi-hive-knowledge-proposal-control-v1", { projectId: request.projectId, sessionId: request.sessionId, proposalId: request.proposalId, expectedState: request.expectedState, decision: request.decision, operationId: request.operationId, channel: request.channel, identity });
+    const requestHash = sha256("pi-hive-knowledge-proposal-control-v1", { projectId: request.projectId, sessionId: request.sessionId, runId: request.runId, proposalId: request.proposalId, expectedState: request.expectedState, decision: request.decision, operationId: request.operationId, channel: request.channel, identity });
     const before = restoreKnowledgeProposalState(readWorkflowJournal(this.options.projectRoot, this.options.sessionId));
     const operationReplay = Object.values(before.proposals).find((proposal) => proposal.decision?.operationId === request.operationId);
     if (operationReplay) {
-      if (operationReplay.proposalId !== request.proposalId || operationReplay.decision?.requestHash !== requestHash) throw new Error("Knowledge proposal decision operation replay conflicts session-wide");
+      const legacyRequestHash = sha256("pi-hive-knowledge-proposal-control-v1", { projectId: request.projectId, sessionId: request.sessionId, proposalId: request.proposalId, expectedState: request.expectedState, decision: request.decision, operationId: request.operationId, channel: request.channel, identity });
+      if (operationReplay.proposalId !== request.proposalId || operationReplay.runId !== request.runId
+        || (operationReplay.decision?.requestHash !== requestHash && operationReplay.decision?.requestHash !== legacyRequestHash)) throw new Error("Knowledge proposal decision operation replay conflicts session-wide");
       return operationReplay;
     }
     const existing = before.proposals[request.proposalId];
-    if (!existing) throw new Error("Knowledge proposal is missing");
+    if (!existing || existing.runId !== request.runId) throw new Error("Exact knowledge proposal project/session/run identity is missing");
     if (existing.state !== "pending") throw new Error("Knowledge proposal exact pending CAS was already decided");
     const decision: KnowledgeProposalDecision = Object.freeze({ decision: request.decision, identity, operationId: request.operationId, requestHash, decidedAt: this.options.now?.() ?? new Date().toISOString() });
     try {
@@ -967,7 +974,7 @@ export class KnowledgeProposalService {
         const reused = Object.values(state.proposals).find((proposal) => proposal.decision?.operationId === request.operationId);
         if (reused) throw new Error("Knowledge proposal decision operation ID is already used session-wide");
         const current = state.proposals[request.proposalId];
-        if (!current || current.state !== "pending") throw new Error("Knowledge proposal exact pending CAS was already decided");
+        if (!current || current.runId !== request.runId || current.state !== "pending") throw new Error("Knowledge proposal exact pending CAS was already decided");
       });
     } catch (error) {
       const raced = restoreKnowledgeProposalState(readWorkflowJournal(this.options.projectRoot, this.options.sessionId)).proposals[request.proposalId];
@@ -996,10 +1003,11 @@ export class KnowledgeProposalService {
   }
 
   detail(request: KnowledgeProposalDetailRequest): DurableKnowledgeProposal {
-    if (!record(request) || !exact(request, ["projectId", "sessionId", "proposalId"]) || request.projectId !== this.options.projectId || request.sessionId !== this.options.sessionId) throw new Error("Knowledge proposal detail request has an unknown field or wrong service identity");
+    if (!record(request) || !exact(request, ["projectId", "sessionId", "runId", "proposalId"]) || request.projectId !== this.options.projectId || request.sessionId !== this.options.sessionId) throw new Error("Knowledge proposal detail request has an unknown field or wrong service identity");
+    const runId = validId(request.runId, "Knowledge proposal run ID");
     const proposalId = validId(request.proposalId, "Knowledge proposal ID");
     const proposal = restoreKnowledgeProposalState(readWorkflowJournal(this.options.projectRoot, this.options.sessionId)).proposals[proposalId];
-    if (!proposal) throw new Error("Knowledge proposal is missing");
+    if (!proposal || proposal.runId !== runId) throw new Error("Exact knowledge proposal project/session/run identity is missing");
     return proposal;
   }
 

--- a/src/observability/projection.ts
+++ b/src/observability/projection.ts
@@ -60,8 +60,26 @@ export interface WorkflowHistoryPage {
   readonly hasMore: boolean;
 }
 
-export interface WorkflowCurrentPageQuery { readonly kind: keyof WorkflowProjectionCurrent; readonly limit: number; readonly cursor?: string }
+export interface WorkflowCurrentPageQuery {
+  readonly kind: keyof WorkflowProjectionCurrent;
+  readonly limit: number;
+  readonly cursor?: string;
+  readonly projectId?: string;
+  readonly sessionId?: string;
+  readonly workflowId?: string;
+  readonly runId?: string;
+  readonly nodeId?: string;
+  readonly taskId?: string;
+  readonly status?: string;
+}
 export interface WorkflowCurrentPage { readonly items: readonly WorkflowProjectionCurrentRow[]; readonly nextCursor?: string; readonly hasMore: boolean }
+export interface WorkflowUsageQuery {
+  readonly projectId?: string;
+  readonly sessionId?: string;
+  readonly workflowId?: string;
+  readonly runId?: string;
+  readonly nodeId?: string;
+}
 
 export class ProjectionStreamError extends Error {
   readonly streamId: string;
@@ -300,19 +318,36 @@ export class WorkflowTelemetryProjection {
   currentPage(query: WorkflowCurrentPageQuery): WorkflowCurrentPage {
     if (!Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error(`Workflow current limit must be 1..${WORKFLOW_PROJECTION_PAGE_LIMIT}`);
     if (!(query.kind in this.materialized)) throw new Error("Workflow current kind is invalid");
-    if (query.cursor && Buffer.byteLength(query.cursor, "utf8") > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current cursor exceeds its byte limit");
+    const values = [query.cursor, query.projectId, query.sessionId, query.workflowId, query.runId, query.nodeId, query.taskId, query.status].filter((value): value is string => value !== undefined);
+    if (values.some((value) => Buffer.byteLength(value, "utf8") > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value, "utf8"), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current query exceeds its byte limit");
     const cursorOrder = query.cursor ? workflowProjectionCurrentCursorOrderKey(query.cursor) : undefined;
     const entries = [...this.materialized[query.kind]].map(([key, value]) => ({ key, value, order: workflowProjectionCurrentOrderKey(value, key) }))
       .sort((a, b) => a.order < b.order ? -1 : a.order > b.order ? 1 : 0)
-      .filter((entry) => !cursorOrder || entry.order > cursorOrder);
+      .filter((entry) => (!cursorOrder || entry.order > cursorOrder)
+        && (!query.projectId || entry.value.projectId === query.projectId)
+        && (!query.sessionId || entry.value.sessionId === query.sessionId)
+        && (!query.workflowId || entry.value.workflowId === query.workflowId)
+        && (!query.runId || entry.value.runId === query.runId)
+        && (!query.nodeId || entry.value.nodeId === query.nodeId)
+        && (!query.taskId || entry.value.taskId === query.taskId)
+        && (!query.status || entry.value.status === query.status));
     const selected = entries.slice(0, query.limit + 1);
     const hasMore = selected.length > query.limit;
     const page = selected.slice(0, query.limit);
     return Object.freeze({ items: Object.freeze(page.map((entry) => entry.value)), ...(hasMore && page.length ? { nextCursor: encodeWorkflowCurrentCursor(page.at(-1)!.value, page.at(-1)!.key) } : {}), hasMore });
   }
 
-  usage(): WorkflowProjectionUsageTotals {
-    return structuredClone(this.totals);
+  usage(query: WorkflowUsageQuery = {}): WorkflowProjectionUsageTotals {
+    const values = Object.values(query).filter((value): value is string => value !== undefined);
+    if (values.some((value) => Buffer.byteLength(value, "utf8") > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value, "utf8"), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow usage query exceeds its byte limit");
+    if (!values.length) return structuredClone(this.totals);
+    const output: WorkflowProjectionUsageTotals = { estimated: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 }, providerConfirmed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 } };
+    for (const event of this.events) {
+      const d = event.dimensions;
+      if (event.usage && (!query.projectId || d.projectId === query.projectId) && (!query.sessionId || d.sessionId === query.sessionId)
+        && (!query.workflowId || d.workflowId === query.workflowId) && (!query.runId || d.runId === query.runId) && (!query.nodeId || d.nodeId === query.nodeId)) usageBucket(event.usage, output);
+    }
+    return output;
   }
 
   history(query: WorkflowHistoryQuery): WorkflowHistoryPage {

--- a/src/observability/security.ts
+++ b/src/observability/security.ts
@@ -74,6 +74,12 @@ export function isAuthorizedWrite(req: Request, token: string): boolean {
   return match ? timingSafeEqualStr(match[1].trim(), token) : false;
 }
 
+/** Browser mutation proof. A custom header plus exact same-origin metadata prevents form CSRF. */
+export function isAuthorizedCsrf(req: Request, token: string): boolean {
+  const value = req.headers.get("x-pi-hive-csrf")?.trim() ?? "";
+  return Boolean(token) && timingSafeEqualStr(value, token);
+}
+
 // The method-based write gate (J7/Decision 3), factored out of the server's
 // fetch handler so it is unit-testable in isolation (M8c). Any method other than
 // GET/HEAD is a mutation and must clear same-origin + the bearer token, exactly

--- a/src/observability/server/config.ts
+++ b/src/observability/server/config.ts
@@ -17,9 +17,7 @@ function validatedHost(): string {
   if (!raw || raw.includes("://") || /[\s/?#]/.test(raw) || raw.length > 253) throw new Error(`Invalid HIVE_TELEMETRY_HOST: ${raw || "<empty>"}`);
   const host = raw.replace(/^\[(.*)\]$/, "$1").toLowerCase();
   const loopback = host === "localhost" || host === "127.0.0.1" || host === "::1";
-  if (!loopback && process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK !== "1") {
-    throw new Error(`Refusing non-loopback dashboard host "${raw}" without HIVE_TELEMETRY_ALLOW_NON_LOOPBACK=1`);
-  }
+  if (!loopback) throw new Error(`Refusing non-loopback dashboard host "${raw}"; first-release dashboard binding is loopback-only`);
   return host;
 }
 

--- a/src/observability/server/http-handler.ts
+++ b/src/observability/server/http-handler.ts
@@ -5,7 +5,7 @@ import {
   PACKAGE_VERSION, PROJECT_CWD, PROTOCOL_VERSION, REGISTRY_PATH,
   STARTUP_NONCE, expectedHostHeader,
 } from "./config";
-import { encoder, eventFrame, SSE_BUFFER_BYTES, subscribers } from "./sse";
+import { encoder, eventFrame, registerSubscriber, removeSubscriber, SSE_BUFFER_BYTES } from "./sse";
 import type { Subscriber } from "./types";
 import {
   allSnapshots,
@@ -34,6 +34,8 @@ import { resolveProjectCwd } from "./plan-bridge";
 import { handlePlanReview, isAuthorizedPlanReviewMutation } from "./review-wiring";
 import { clearProjectOverride, listProjectOverrides, setProjectOverride } from "./db";
 import { OpenSpecCommandError } from "../../engine/openspec";
+import { createWorkflowApi, type WorkflowApiOptions } from "./workflow-routes";
+import { createProductionWorkflowApiOptions } from "./workflow-service";
 import type {
   DashboardBootstrap,
   DashboardDelegationsResponse,
@@ -74,11 +76,14 @@ function fleetPage(url: URL): { offset: number; limit: number } {
 export interface DashboardHttpHandlerOptions {
   onActivity?: () => void;
   scheduleServerStop?: () => void;
+  workflowApiOptions?: WorkflowApiOptions;
 }
+export type DashboardHttpHandler = ((req: Request) => Promise<Response>) & Readonly<{ dispose(): void }>;
 
 /** Create the dashboard request handler without binding a port or starting timers. */
-export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions = {}) {
-  return async function handleDashboardRequest(req: Request): Promise<Response> {
+export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions = {}): DashboardHttpHandler {
+  const workflowApi = createWorkflowApi(options.workflowApiOptions ?? createProductionWorkflowApiOptions());
+  const handleDashboardRequest = async function handleDashboardRequest(req: Request): Promise<Response> {
     options.onActivity?.();
     const url = new URL(req.url);
 
@@ -99,12 +104,16 @@ export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions 
     const gated = writeGateResponse(req, url, DAEMON_TOKEN, (error, status) => json({ error }, status), reviewCapability);
     if (gated) return gated;
 
+    const workflowResponse = await workflowApi.handle(req, url);
+    if (workflowResponse) return workflowResponse;
+
     if (req.method === "POST" && url.pathname === "/shutdown") {
       let body: any;
       try { body = await req.json(); } catch { return json({ error: "invalid json body" }, 400); }
       if (body?.startupNonce !== STARTUP_NONCE) return json({ error: "daemon identity mismatch" }, 409);
       // Return the acknowledgement before closing the listener. The bearer token
       // and startup nonce jointly prove authority over this exact daemon instance.
+      workflowApi.dispose();
       options.scheduleServerStop?.();
       return json({ ok: true, pid: process.pid, startupNonce: STARTUP_NONCE }, 202);
     }
@@ -209,7 +218,7 @@ export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions 
     // a same-origin GET — the token never appears in a URL or in cached HTML.
     // The browser attaches it as the Bearer header on POST/DELETE.
     if (url.pathname === "/bootstrap.json") {
-      const response = json({ token: DAEMON_TOKEN || null, bootCwd: PROJECT_CWD || null } satisfies DashboardBootstrap);
+      const response = json({ token: DAEMON_TOKEN || null, csrfToken: DAEMON_TOKEN || null, bootCwd: PROJECT_CWD || null } satisfies DashboardBootstrap);
       response.headers.set("cache-control", "no-store");
       return response;
     }
@@ -361,10 +370,14 @@ export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions 
       return applyBrowserSecurityHeaders(new Response(new ReadableStream<Uint8Array>({
         start(controller) {
           sub = controller;
-          subscribers.add(controller);
+          if (!registerSubscriber("legacy", controller)) {
+            controller.enqueue(encoder.encode(eventFrame("resync-required", { reason: "subscriber-capacity" })));
+            controller.close();
+            return;
+          }
           controller.enqueue(encoder.encode(eventFrame("hello", { mode: "global", registry: REGISTRY_PATH, cursor: maxEventCursor() })));
         },
-        cancel() { if (sub) subscribers.delete(sub); },
+        cancel() { if (sub) removeSubscriber(sub); },
       }, {
         highWaterMark: SSE_BUFFER_BYTES,
         size(chunk) { return chunk?.byteLength ?? 0; },
@@ -389,4 +402,5 @@ export function createDashboardHttpHandler(options: DashboardHttpHandlerOptions 
 
     return json({ error: "not found" }, 404);
   };
+  return Object.assign(handleDashboardRequest, { dispose(): void { workflowApi.dispose(); } });
 }

--- a/src/observability/server/index.ts
+++ b/src/observability/server/index.ts
@@ -1,7 +1,7 @@
 import { HOST, IDLE_TIMEOUT_MS, PORT, REGISTRY_PATH } from "./config";
 import { createDashboardHttpHandler } from "./http-handler";
 import { sourcePaths, startTelemetryRuntime, stopTelemetryRuntime } from "./runtime";
-import { broadcastPing, subscribers } from "./sse";
+import { broadcastPing, closeAllSubscribers, hasLiveSubscribers } from "./sse";
 
 void startTelemetryRuntime();
 
@@ -16,6 +16,8 @@ function scheduleServerStop(): void {
   setTimeout(() => {
     clearInterval(heartbeatTimer);
     clearInterval(idleTimer);
+    handleRequest.dispose();
+    closeAllSubscribers();
     stopTelemetryRuntime();
     void server.stop(true);
     process.exit(0);
@@ -42,7 +44,7 @@ const server = Bun.serve({
 // The daemon is shared across Pi sessions, so a single session shutdown cannot
 // terminate it. Stop only after bounded inactivity with no browser stream.
 const idleTimer: ReturnType<typeof setInterval> = setInterval(() => {
-  if (subscribers.size === 0 && Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) scheduleServerStop();
+  if (!hasLiveSubscribers() && Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) scheduleServerStop();
 }, Math.min(60_000, Math.max(1_000, Math.floor(IDLE_TIMEOUT_MS / 4))));
 
 console.log(`pi-hive telemetry dashboard: http://${HOST}:${PORT}`);

--- a/src/observability/server/runtime.ts
+++ b/src/observability/server/runtime.ts
@@ -11,6 +11,8 @@ import { readJsonlPage } from "../../core/fs";
 import type { HiveStateSnapshot, HiveTelemetryEvent, TelemetryRegistryRow, TelemetrySessionSummary, TopologyNode } from "../../shared/telemetry";
 import { BOOT_SESSION_ID, CAPTURE_THINKING, CONVERSATION_LOG, DB_PATH, PROJECT_CWD, REGISTRY_PATH, RETENTION_DAYS, SINGLE_LOG_PATH, WORKFLOW_DB_PATH } from "./config";
 import { createConfiguredWorkflowProjectionSynchronizer, workflowProjectionRootCandidates, type ConfiguredWorkflowProjectionSynchronizer } from "./workflow-runtime";
+import { encodeWorkflowHistoryCursor } from "../projection";
+import { broadcastWorkflowEvent } from "./sse";
 import {
   db,
   dbEventRow,
@@ -1014,7 +1016,10 @@ export function readWorkflowProjectionRuntimeDiagnostics(): readonly Readonly<{ 
 function syncWorkflowProjectionRuntime(): void {
   const projectRoots = workflowProjectionRootCandidates(PROJECT_CWD, [...sources.values()].flatMap((source) => source.meta.project_root ? [source.meta.project_root] : source.meta.cwd ? [source.meta.cwd] : []));
   try {
-    workflowProjectionSynchronizer ??= createConfiguredWorkflowProjectionSynchronizer({ databasePath: WORKFLOW_DB_PATH, legacyPaths: [DB_PATH, REGISTRY_PATH], retentionDays: RETENTION_DAYS });
+    workflowProjectionSynchronizer ??= createConfiguredWorkflowProjectionSynchronizer({
+      databasePath: WORKFLOW_DB_PATH, legacyPaths: [DB_PATH, REGISTRY_PATH], retentionDays: RETENTION_DAYS,
+      onEvent: (event) => broadcastWorkflowEvent(event, encodeWorkflowHistoryCursor(event)),
+    });
     const result = workflowProjectionSynchronizer.sync(projectRoots);
     workflowProjectionRuntimeDiagnostics = Object.freeze([...(result.diagnostics ?? [])].slice(0, 256));
   } catch (error) {

--- a/src/observability/server/sse.ts
+++ b/src/observability/server/sse.ts
@@ -2,25 +2,136 @@ import type { Subscriber } from "./types";
 
 export const encoder = new TextEncoder();
 export const subscribers = new Set<Subscriber>();
+export const workflowSubscribers = new Set<Subscriber>();
 // Each browser stream may queue at most this many bytes. A slow client is
 // disconnected and catches up from SQLite by cursor on reconnect rather than
 // growing the daemon heap without bound.
 export const SSE_BUFFER_BYTES = 256 * 1024;
+export const SSE_MAX_SUBSCRIBERS = 64;
+export const SSE_CONNECTION_IDLE_MS = 60_000;
+export const SSE_CONNECTION_LIFETIME_MS = 5 * 60_000;
 
-export function eventFrame(event: string, data: unknown, id?: number): string {
+export interface WorkflowStreamTimerScheduler {
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(timer: unknown): void;
+}
+export interface WorkflowStreamLimits {
+  readonly bufferBytes?: number;
+  readonly maxSubscribers?: number;
+  readonly idleMs?: number;
+  readonly lifetimeMs?: number;
+  readonly scheduler?: WorkflowStreamTimerScheduler;
+}
+
+type SubscriberChannel = "legacy" | "workflow";
+interface Subscription {
+  readonly channel: SubscriberChannel;
+  readonly lifetimeTimer: unknown;
+  readonly limits: Required<Pick<WorkflowStreamLimits, "maxSubscribers" | "idleMs" | "lifetimeMs">> & Readonly<{ scheduler: WorkflowStreamTimerScheduler }>;
+  idleTimer: unknown;
+}
+const subscriptions = new Map<Subscriber, Subscription>();
+const defaultScheduler: WorkflowStreamTimerScheduler = Object.freeze({
+  setTimeout(callback: () => void, delayMs: number) {
+    const timer = setTimeout(callback, delayMs);
+    timer.unref?.();
+    return timer;
+  },
+  clearTimeout(timer: unknown) { clearTimeout(timer as ReturnType<typeof setTimeout>); },
+});
+
+function effectiveLimits(input: WorkflowStreamLimits | undefined): Subscription["limits"] {
+  const maxSubscribers = input?.maxSubscribers ?? SSE_MAX_SUBSCRIBERS;
+  const idleMs = input?.idleMs ?? SSE_CONNECTION_IDLE_MS;
+  const lifetimeMs = input?.lifetimeMs ?? SSE_CONNECTION_LIFETIME_MS;
+  const bufferBytes = input?.bufferBytes ?? SSE_BUFFER_BYTES;
+  if (!Number.isSafeInteger(maxSubscribers) || maxSubscribers < 1 || maxSubscribers > SSE_MAX_SUBSCRIBERS
+    || !Number.isSafeInteger(idleMs) || idleMs < 1 || idleMs > SSE_CONNECTION_IDLE_MS
+    || !Number.isSafeInteger(lifetimeMs) || lifetimeMs < 1 || lifetimeMs > SSE_CONNECTION_LIFETIME_MS
+    || !Number.isSafeInteger(bufferBytes) || bufferBytes < 1 || bufferBytes > SSE_BUFFER_BYTES) throw new Error("Workflow stream limits are invalid");
+  return Object.freeze({ maxSubscribers, idleMs, lifetimeMs, scheduler: input?.scheduler ?? defaultScheduler });
+}
+
+export function eventFrame(event: string, data: unknown, id?: number | string): string {
   const idLine = id != null ? `id: ${id}\n` : "";
   return `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-function enqueueBounded(sub: Subscriber, encoded: Uint8Array): void {
+function channelSet(channel: SubscriberChannel): Set<Subscriber> {
+  return channel === "workflow" ? workflowSubscribers : subscribers;
+}
+
+export function removeSubscriber(sub: Subscriber): void {
+  subscribers.delete(sub);
+  workflowSubscribers.delete(sub);
+  const subscription = subscriptions.get(sub);
+  if (!subscription) return;
+  subscription.limits.scheduler.clearTimeout(subscription.idleTimer);
+  subscription.limits.scheduler.clearTimeout(subscription.lifetimeTimer);
+  subscriptions.delete(sub);
+}
+
+function closeSubscriber(sub: Subscriber): void {
+  try { sub.close(); } catch { /* already closed */ }
+  removeSubscriber(sub);
+}
+
+function idleTimer(sub: Subscriber, limits: Subscription["limits"]): unknown {
+  return limits.scheduler.setTimeout(() => closeSubscriber(sub), limits.idleMs);
+}
+
+function touchSubscriber(sub: Subscriber): void {
+  const subscription = subscriptions.get(sub);
+  if (!subscription) return;
+  subscription.limits.scheduler.clearTimeout(subscription.idleTimer);
+  subscription.idleTimer = idleTimer(sub, subscription.limits);
+}
+
+export function registerSubscriber(channel: SubscriberChannel, sub: Subscriber, input?: WorkflowStreamLimits): boolean {
+  const limits = effectiveLimits(input);
+  if (subscriptions.size >= limits.maxSubscribers || subscriptions.has(sub)) return false;
+  const lifetimeTimer = limits.scheduler.setTimeout(() => closeSubscriber(sub), limits.lifetimeMs);
+  subscriptions.set(sub, { channel, lifetimeTimer, limits, idleTimer: idleTimer(sub, limits) });
+  channelSet(channel).add(sub);
+  return true;
+}
+
+export function hasLiveSubscribers(): boolean {
+  return subscribers.size > 0 || workflowSubscribers.size > 0;
+}
+
+export type WorkflowMaintenanceResyncReason = "projection-rebuild" | "projection-prune";
+
+export function invalidateWorkflowSubscribers(reason: WorkflowMaintenanceResyncReason): void {
+  const encoded = encoder.encode(eventFrame("resync-required", { apiVersion: 1, reason, history: "/api/v1/history" }));
+  for (const sub of [...workflowSubscribers]) {
+    enqueueBounded(sub, encoded);
+    closeSubscriber(sub);
+  }
+}
+
+export function closeWorkflowSubscribers(): void {
+  for (const sub of [...workflowSubscribers]) closeSubscriber(sub);
+}
+
+export function closeAllSubscribers(): void {
+  for (const sub of [...subscriptions.keys()]) closeSubscriber(sub);
+}
+
+export function enqueueBounded(sub: Subscriber, encoded: Uint8Array): boolean {
   const available = sub.desiredSize;
   if (available != null && available < encoded.byteLength) {
-    try { sub.close(); } catch { /* already closed */ }
-    subscribers.delete(sub);
-    return;
+    closeSubscriber(sub);
+    return false;
   }
-  try { sub.enqueue(encoded); }
-  catch { subscribers.delete(sub); }
+  try {
+    sub.enqueue(encoded);
+    touchSubscriber(sub);
+    return true;
+  } catch {
+    removeSubscriber(sub);
+    return false;
+  }
 }
 
 export function broadcastFrame(frame: string): void {
@@ -33,13 +144,18 @@ export function broadcastEvent(event: string, data: unknown): void {
 }
 
 // Broadcast an event frame carrying its global cursor as the SSE `id:` — clients
-// track it to request an exact, lossless catch-up (?after=<id>) on reconnect (B5).
+// track it to request an exact, lossless catch-up on reconnect.
 export function broadcastEventWithId(event: string, data: unknown, id: number): void {
   broadcastFrame(eventFrame(event, data, id));
 }
 
+export function broadcastWorkflowEvent(data: unknown, cursor: string): void {
+  const encoded = encoder.encode(eventFrame("workflow", data, cursor));
+  for (const sub of Array.from(workflowSubscribers)) enqueueBounded(sub, encoded);
+}
+
 export function broadcastPing(): void {
-  if (!subscribers.size) return;
+  if (!subscribers.size && !workflowSubscribers.size) return;
   const ping = encoder.encode(": ping\n\n");
-  for (const sub of Array.from(subscribers)) enqueueBounded(sub, ping);
+  for (const sub of [...subscribers, ...workflowSubscribers]) enqueueBounded(sub, ping);
 }

--- a/src/observability/server/workflow-db.ts
+++ b/src/observability/server/workflow-db.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { chmodSync, existsSync, lstatSync, mkdirSync, realpathSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { withCrossProcessFileLock } from "../../core/file-lock";
@@ -19,6 +19,7 @@ import {
   type WorkflowProjectionCurrent,
   type WorkflowProjectionCurrentRow,
   type WorkflowProjectionUsageTotals,
+  type WorkflowUsageQuery,
   type WorkflowCurrentPage,
   type WorkflowCurrentPageQuery,
 } from "../projection";
@@ -148,9 +149,23 @@ CREATE TABLE workflow_prune_watermarks (
   cutoff TEXT NOT NULL,
   state_hash TEXT NOT NULL
 );
+CREATE TABLE workflow_operation_receipts (
+  scope TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  state TEXT NOT NULL CHECK(state IN ('in_progress', 'completed', 'unknown')),
+  claimed_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  owner_token TEXT,
+  lease_expires_at TEXT,
+  response_json BLOB,
+  response_hash TEXT,
+  PRIMARY KEY(scope, operation_id)
+);
+CREATE INDEX workflow_operation_receipts_updated ON workflow_operation_receipts(updated_at, scope, operation_id);
 `;
 
-const PRUNE_SCHEMA = `CREATE TABLE IF NOT EXISTS workflow_prune_watermarks (
+const ADDITIVE_SCHEMA = `CREATE TABLE IF NOT EXISTS workflow_prune_watermarks (
   stream_id TEXT PRIMARY KEY,
   project_id TEXT NOT NULL,
   session_id TEXT NOT NULL,
@@ -159,7 +174,49 @@ const PRUNE_SCHEMA = `CREATE TABLE IF NOT EXISTS workflow_prune_watermarks (
   through_hash TEXT NOT NULL,
   cutoff TEXT NOT NULL,
   state_hash TEXT NOT NULL
-);`;
+);
+CREATE TABLE IF NOT EXISTS workflow_operation_receipts (
+  scope TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  state TEXT NOT NULL CHECK(state IN ('in_progress', 'completed', 'unknown')),
+  claimed_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  owner_token TEXT,
+  lease_expires_at TEXT,
+  response_json BLOB,
+  response_hash TEXT,
+  PRIMARY KEY(scope, operation_id)
+);
+CREATE INDEX IF NOT EXISTS workflow_operation_receipts_updated ON workflow_operation_receipts(updated_at, scope, operation_id);`;
+
+export const WORKFLOW_OPERATION_RECEIPT_LIMITS = Object.freeze({
+  count: 4_096,
+  responseBytes: 1_024 * 1_024,
+  totalResponseBytes: 64 * 1_024 * 1_024,
+  retentionMs: 30 * 86_400_000,
+  leaseMs: 120_000,
+  heartbeatMs: 10_000,
+  concurrentWaitMs: 1_000,
+  pollMs: 10,
+});
+
+export interface WorkflowOperationReceiptLimits {
+  readonly count?: number;
+  readonly responseBytes?: number;
+  readonly totalResponseBytes?: number;
+  readonly retentionMs?: number;
+  readonly leaseMs?: number;
+  readonly heartbeatMs?: number;
+  readonly concurrentWaitMs?: number;
+  readonly pollMs?: number;
+}
+export interface WorkflowOperationRuntime {
+  readonly now?: () => number;
+  readonly setInterval?: (callback: () => void, delayMs: number) => unknown;
+  readonly clearInterval?: (timer: unknown) => void;
+}
+type EffectiveWorkflowOperationReceiptLimits = Required<WorkflowOperationReceiptLimits>;
 
 type CurrentKind = keyof WorkflowProjectionCurrent;
 const CURRENT_KINDS: readonly CurrentKind[] = ["sessions", "runs", "nodes", "tasks", "workspaces", "questions", "approvals", "knowledge"];
@@ -232,6 +289,23 @@ interface PruneWatermark {
 function watermarkHash(value: PruneWatermark): string {
   return createHash("sha256").update("pi-hive-workflow-prune-watermark-v1\0").update(canonicalJson(value)).digest("hex");
 }
+function operationResponseHash(value: unknown): string {
+  return createHash("sha256").update("pi-hive-workflow-operation-response-v1\0").update(canonicalJson(value)).digest("hex");
+}
+function operationError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { status: 409, code });
+}
+
+export type WorkflowOperationClaim = Readonly<
+  | { state: "claimed"; ownerToken: string }
+  | { state: "completed"; result: unknown }
+  | { state: "in_progress" }
+  | { state: "unknown" }
+>;
+export type WorkflowStreamCatchUp = Readonly<
+  | { state: "ready"; events: readonly WorkflowTelemetryEvent[] }
+  | { state: "resync-required"; reason: "cursor-invalid" | "cursor-expired" | "catch-up-limit-exceeded" }
+>;
 
 export class WorkflowProjectionIntegrityError extends Error {
   constructor(message: string, options?: ErrorOptions) { super(message, options); this.name = "WorkflowProjectionIntegrityError"; }
@@ -245,13 +319,32 @@ export class WorkflowProjectionSchemaError extends Error {
 export interface OpenWorkflowProjectionDatabaseOptions {
   readonly path: string;
   readonly legacyPaths?: readonly string[];
+  readonly operationLimits?: WorkflowOperationReceiptLimits;
+  readonly operationRuntime?: WorkflowOperationRuntime;
+}
+
+function effectiveOperationLimits(input: WorkflowOperationReceiptLimits | undefined): EffectiveWorkflowOperationReceiptLimits {
+  const limits = { ...WORKFLOW_OPERATION_RECEIPT_LIMITS, ...(input ?? {}) };
+  const positive = ["count", "responseBytes", "totalResponseBytes", "retentionMs", "leaseMs", "heartbeatMs", "concurrentWaitMs", "pollMs"] as const;
+  if (positive.some((key) => !Number.isSafeInteger(limits[key]) || limits[key] < 1 || limits[key] > WORKFLOW_OPERATION_RECEIPT_LIMITS[key])) throw new Error("Workflow operation receipt limits are invalid");
+  if (limits.responseBytes > limits.totalResponseBytes || limits.heartbeatMs >= limits.leaseMs) throw new Error("Workflow operation receipt lease or response limits are invalid");
+  return Object.freeze(limits);
 }
 
 export class WorkflowProjectionDatabase {
   readonly database: Database;
   readonly path: string;
+  private readonly operationLimits: EffectiveWorkflowOperationReceiptLimits;
+  private readonly operationNow: () => number;
+  private readonly operationSetInterval: (callback: () => void, delayMs: number) => unknown;
+  private readonly operationClearInterval: (timer: unknown) => void;
+  private readonly activeOperations = new Map<string, Readonly<{ requestHash: string; promise: Promise<unknown> }>>();
 
   constructor(options: OpenWorkflowProjectionDatabaseOptions) {
+    this.operationLimits = effectiveOperationLimits(options.operationLimits);
+    this.operationNow = options.operationRuntime?.now ?? Date.now;
+    this.operationSetInterval = options.operationRuntime?.setInterval ?? ((callback, delayMs) => setInterval(callback, delayMs));
+    this.operationClearInterval = options.operationRuntime?.clearInterval ?? ((timer) => clearInterval(timer as ReturnType<typeof setInterval>));
     this.path = canonicalDatabasePath(options.path);
     if ((options.legacyPaths ?? []).some((path) => comparablePath(path) === this.path
       || (existsSync(path) && existsSync(this.path) && statSync(path).dev === statSync(this.path).dev && statSync(path).ino === statSync(this.path).ino))) throw new Error("Workflow projection must use a separate database and cannot open a legacy telemetry file or alias");
@@ -271,7 +364,10 @@ export class WorkflowProjectionDatabase {
           const version = database.query(`SELECT value FROM workflow_projection_metadata WHERE key = 'schema_version'`).get() as { value: string } | null;
           if (Number(version?.value ?? 0) !== WORKFLOW_SQLITE_SCHEMA_VERSION) throw new WorkflowProjectionSchemaError(`Unsupported workflow projection schema version ${version?.value ?? "missing"}`);
         }
-        database.exec(PRUNE_SCHEMA);
+        database.exec(ADDITIVE_SCHEMA);
+        const receiptColumns = new Set((database.query(`PRAGMA table_info(workflow_operation_receipts)`).all() as Array<{ name: string }>).map((column) => column.name));
+        if (!receiptColumns.has("owner_token")) database.run(`ALTER TABLE workflow_operation_receipts ADD COLUMN owner_token TEXT`);
+        if (!receiptColumns.has("lease_expires_at")) database.run(`ALTER TABLE workflow_operation_receipts ADD COLUMN lease_expires_at TEXT`);
         database.run("PRAGMA journal_mode = WAL");
         privateSqliteFiles(this.path);
         opened = database;
@@ -281,6 +377,9 @@ export class WorkflowProjectionDatabase {
     this.database = opened;
     try {
       if (this.schemaVersion() !== WORKFLOW_SQLITE_SCHEMA_VERSION) throw new WorkflowProjectionSchemaError("Unsupported workflow projection schema version");
+      const operationNow = this.operationNow();
+      if (!Number.isFinite(operationNow)) throw new Error("Workflow operation receipt clock is invalid");
+      this.pruneExpiredCompletedReceipts(new Date(operationNow));
       this.assertPersistedIntegrity();
     } catch (error) {
       this.database.close();
@@ -290,6 +389,29 @@ export class WorkflowProjectionDatabase {
   }
 
   private assertPersistedIntegrity(): void {
+    const receiptRows = this.database.query(`SELECT *, json(response_json) AS authenticated_response_json FROM workflow_operation_receipts ORDER BY scope, operation_id`).all() as any[];
+    let receiptResponseBytes = 0;
+    for (const row of receiptRows) {
+      const validIdentity = typeof row.scope === "string" && /^[a-z][a-z0-9-]{0,63}$/u.test(row.scope)
+        && typeof row.operation_id === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(row.operation_id)
+        && /^[0-9a-f]{64}$/u.test(row.request_hash)
+        && Number.isFinite(Date.parse(row.claimed_at)) && Number.isFinite(Date.parse(row.updated_at));
+      const completed = row.state === "completed";
+      const leased = row.state === "in_progress" && typeof row.owner_token === "string" && /^[0-9a-f-]{36}$/u.test(row.owner_token)
+        && typeof row.lease_expires_at === "string" && Number.isFinite(Date.parse(row.lease_expires_at));
+      const legacyUnowned = row.state === "in_progress" && row.owner_token === null && row.lease_expires_at === null;
+      const inactiveOwnership = row.state !== "in_progress" && row.owner_token === null && row.lease_expires_at === null;
+      let validResponse = !completed && row.response_json === null && row.response_hash === null;
+      if (completed && typeof row.authenticated_response_json === "string" && /^[0-9a-f]{64}$/u.test(row.response_hash ?? "")) {
+        try {
+          const bytes = Buffer.byteLength(row.authenticated_response_json, "utf8");
+          receiptResponseBytes += bytes;
+          validResponse = bytes <= this.operationLimits.responseBytes && operationResponseHash(JSON.parse(row.authenticated_response_json)) === row.response_hash;
+        } catch { validResponse = false; }
+      }
+      if (!validIdentity || !["in_progress", "completed", "unknown"].includes(row.state) || (!leased && !legacyUnowned && !inactiveOwnership) || !validResponse) throw new Error("Workflow projection persisted operation-receipt integrity failure");
+    }
+    if (receiptRows.length > this.operationLimits.count || receiptResponseBytes > this.operationLimits.totalResponseBytes) throw new Error("Workflow projection persisted operation-receipt capacity exceeded");
     const watermarkRows = this.database.query(`SELECT * FROM workflow_prune_watermarks ORDER BY stream_id`).all() as any[];
     const watermarks = new Map<string, PruneWatermark>();
     for (const row of watermarkRows) {
@@ -408,6 +530,148 @@ export class WorkflowProjectionDatabase {
   }
   schemaSql(): string {
     return (this.database.query(`SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name`).all() as Array<{ sql: string }>).map((row) => row.sql).join("\n");
+  }
+
+  private operationDate(): Date {
+    const value = this.operationNow();
+    if (!Number.isFinite(value)) throw new Error("Workflow operation receipt clock is invalid");
+    return new Date(value);
+  }
+
+  private pruneExpiredCompletedReceipts(now: Date): number {
+    const cutoff = new Date(now.getTime() - this.operationLimits.retentionMs).toISOString();
+    return this.database.query(`DELETE FROM workflow_operation_receipts WHERE state = 'completed' AND updated_at < ?`).run(cutoff).changes;
+  }
+
+  private receiptCapacityError(message: string): Error {
+    return Object.assign(new Error(message), { status: 503, code: "OPERATION_RECEIPT_CAPACITY" });
+  }
+
+  private claimOperation(scope: string, operationId: string, requestHash: string, now: Date): WorkflowOperationClaim {
+    if (!/^[a-z][a-z0-9-]{0,63}$/u.test(scope) || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(operationId) || !/^[0-9a-f]{64}$/u.test(requestHash)) {
+      throw new Error("Workflow operation receipt identity is invalid");
+    }
+    const nowIso = now.toISOString();
+    return this.database.transaction(() => {
+      const row = this.database.query(`SELECT request_hash, state, owner_token, lease_expires_at, json(response_json) AS response_json, response_hash
+        FROM workflow_operation_receipts WHERE scope = ? AND operation_id = ?`).get(scope, operationId) as any;
+      if (!row) {
+        this.pruneExpiredCompletedReceipts(now);
+        const count = Number((this.database.query(`SELECT COUNT(*) AS count FROM workflow_operation_receipts`).get() as { count: number }).count);
+        if (count >= this.operationLimits.count) throw this.receiptCapacityError("workflow operation receipt count capacity is exhausted");
+        const ownerToken = randomUUID();
+        const leaseExpiresAt = new Date(now.getTime() + this.operationLimits.leaseMs).toISOString();
+        this.database.query(`INSERT INTO workflow_operation_receipts
+          (scope, operation_id, request_hash, state, claimed_at, updated_at, owner_token, lease_expires_at, response_json, response_hash)
+          VALUES (?, ?, ?, 'in_progress', ?, ?, ?, ?, NULL, NULL)`).run(scope, operationId, requestHash, nowIso, nowIso, ownerToken, leaseExpiresAt);
+        return Object.freeze({ state: "claimed" as const, ownerToken });
+      }
+      if (row.request_hash !== requestHash) throw operationError("operation ID reuse conflicts with prior input", "OPERATION_CONFLICT");
+      if (row.state === "completed") {
+        let result: unknown;
+        try { result = JSON.parse(row.response_json); }
+        catch { throw new WorkflowProjectionIntegrityError("Workflow operation receipt response is corrupt"); }
+        if (operationResponseHash(result) !== row.response_hash) throw new WorkflowProjectionIntegrityError("Workflow operation receipt response integrity failure");
+        return Object.freeze({ state: "completed" as const, result });
+      }
+      if (row.state === "unknown") return Object.freeze({ state: "unknown" as const });
+      const leaseExpiresAt = Date.parse(row.lease_expires_at ?? "");
+      if (!row.owner_token || !Number.isFinite(leaseExpiresAt) || now.getTime() >= leaseExpiresAt) {
+        this.database.query(`UPDATE workflow_operation_receipts SET state = 'unknown', updated_at = ?, owner_token = NULL, lease_expires_at = NULL
+          WHERE scope = ? AND operation_id = ? AND request_hash = ? AND state = 'in_progress' AND owner_token IS ?`)
+          .run(nowIso, scope, operationId, requestHash, row.owner_token ?? null);
+        return Object.freeze({ state: "unknown" as const });
+      }
+      return Object.freeze({ state: "in_progress" as const });
+    }).immediate();
+  }
+
+  private renewOperation(scope: string, operationId: string, requestHash: string, ownerToken: string, now: Date): boolean {
+    const leaseExpiresAt = new Date(now.getTime() + this.operationLimits.leaseMs).toISOString();
+    return this.database.query(`UPDATE workflow_operation_receipts SET updated_at = ?, lease_expires_at = ?
+      WHERE scope = ? AND operation_id = ? AND request_hash = ? AND state = 'in_progress' AND owner_token = ?`)
+      .run(now.toISOString(), leaseExpiresAt, scope, operationId, requestHash, ownerToken).changes === 1;
+  }
+
+  private finalizeOperation(scope: string, operationId: string, requestHash: string, ownerToken: string, result: unknown, now: Date): unknown {
+    let serialized: string;
+    let stored: unknown;
+    try {
+      serialized = JSON.stringify(result);
+      if (serialized === undefined || Buffer.byteLength(serialized, "utf8") > this.operationLimits.responseBytes) throw new Error();
+      stored = JSON.parse(serialized);
+    } catch { throw new Error("Workflow operation response is not bounded JSON"); }
+    const responseHash = operationResponseHash(stored);
+    this.database.transaction(() => {
+      this.pruneExpiredCompletedReceipts(now);
+      const receipt = this.database.query(`SELECT request_hash, state, owner_token FROM workflow_operation_receipts WHERE scope = ? AND operation_id = ?`).get(scope, operationId) as { request_hash: string; state: string; owner_token: string | null } | null;
+      if (!receipt || receipt.request_hash !== requestHash || receipt.state !== "in_progress" || receipt.owner_token !== ownerToken) throw operationError("operation receipt cannot be finalized from its current ownership state", "OPERATION_OUTCOME_UNKNOWN");
+      const persistedBytes = Number((this.database.query(`SELECT COALESCE(SUM(length(CAST(json(response_json) AS BLOB))), 0) AS bytes FROM workflow_operation_receipts WHERE state = 'completed'`).get() as { bytes: number }).bytes);
+      if (!Number.isSafeInteger(persistedBytes) || persistedBytes + Buffer.byteLength(serialized, "utf8") > this.operationLimits.totalResponseBytes) throw this.receiptCapacityError("workflow operation receipt response-byte capacity is exhausted");
+      this.database.query(`UPDATE workflow_operation_receipts SET state = 'completed', updated_at = ?, owner_token = NULL, lease_expires_at = NULL, response_json = jsonb(?), response_hash = ?
+        WHERE scope = ? AND operation_id = ? AND request_hash = ? AND state = 'in_progress' AND owner_token = ?`)
+        .run(now.toISOString(), serialized, responseHash, scope, operationId, requestHash, ownerToken);
+    }).immediate();
+    return stored;
+  }
+
+  private markOperationUnknown(scope: string, operationId: string, requestHash: string, ownerToken: string, now: Date): void {
+    this.database.query(`UPDATE workflow_operation_receipts SET state = 'unknown', updated_at = ?, owner_token = NULL, lease_expires_at = NULL
+      WHERE scope = ? AND operation_id = ? AND request_hash = ? AND state = 'in_progress' AND owner_token = ?`).run(now.toISOString(), scope, operationId, requestHash, ownerToken);
+  }
+
+  private async executeOperation<T>(scope: string, operationId: string, requestHash: string, invoke: () => T | Promise<T>): Promise<T> {
+    const waitUntil = this.operationNow() + this.operationLimits.concurrentWaitMs;
+    while (true) {
+      const claim = this.claimOperation(scope, operationId, requestHash, this.operationDate());
+      if (claim.state === "completed") return structuredClone(claim.result) as T;
+      if (claim.state === "unknown") throw operationError("operation outcome is unknown and cannot be retried safely", "OPERATION_OUTCOME_UNKNOWN");
+      if (claim.state === "claimed") {
+        let heartbeatError: unknown;
+        const timer = this.operationSetInterval(() => {
+          try {
+            if (!this.renewOperation(scope, operationId, requestHash, claim.ownerToken, this.operationDate())) heartbeatError = operationError("operation lease ownership was lost", "OPERATION_OUTCOME_UNKNOWN");
+          } catch (error) { heartbeatError = error; }
+        }, this.operationLimits.heartbeatMs);
+        try {
+          const result = await invoke();
+          if (heartbeatError) throw heartbeatError;
+          if (!this.renewOperation(scope, operationId, requestHash, claim.ownerToken, this.operationDate())) throw operationError("operation lease ownership was lost", "OPERATION_OUTCOME_UNKNOWN");
+          return this.finalizeOperation(scope, operationId, requestHash, claim.ownerToken, result, this.operationDate()) as T;
+        } catch (error) {
+          this.markOperationUnknown(scope, operationId, requestHash, claim.ownerToken, this.operationDate());
+          throw error;
+        } finally { this.operationClearInterval(timer); }
+      }
+      if (this.operationNow() >= waitUntil) throw operationError("identical operation is still in progress", "OPERATION_IN_PROGRESS");
+      await new Promise((resolve) => setTimeout(resolve, this.operationLimits.pollMs));
+    }
+  }
+
+  runOperation<T>(scope: string, operationId: string, requestHash: string, invoke: () => T | Promise<T>): Promise<T> {
+    const key = `${scope}\0${operationId}`;
+    const active = this.activeOperations.get(key);
+    if (active) {
+      if (active.requestHash !== requestHash) return Promise.reject(operationError("operation ID reuse conflicts with active input", "OPERATION_CONFLICT"));
+      return active.promise.then((result) => structuredClone(result) as T);
+    }
+    const executing = this.executeOperation(scope, operationId, requestHash, invoke);
+    const coordinated = executing.finally(() => { if (this.activeOperations.get(key)?.promise === coordinated) this.activeOperations.delete(key); });
+    this.activeOperations.set(key, Object.freeze({ requestHash, promise: coordinated }));
+    return coordinated.then((result) => structuredClone(result) as T);
+  }
+
+  streamCatchUp(cursor: string, limit: number): WorkflowStreamCatchUp {
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error("Workflow stream catch-up limit is invalid");
+    let decoded: readonly [string, string, number, string];
+    try { decoded = decodeWorkflowHistoryCursor(cursor); }
+    catch { return Object.freeze({ state: "resync-required", reason: "cursor-invalid" }); }
+    const retained = this.database.query(`SELECT event_id FROM workflow_events WHERE timestamp = ? AND stream_id = ? AND sequence = ? AND event_id = ?`)
+      .get(decoded[0], decoded[1], decoded[2], decoded[3]);
+    if (!retained) return Object.freeze({ state: "resync-required", reason: "cursor-expired" });
+    const page = this.history({ cursor, limit });
+    if (page.hasMore) return Object.freeze({ state: "resync-required", reason: "catch-up-limit-exceeded" });
+    return Object.freeze({ state: "ready", events: Object.freeze([...page.items]) });
   }
 
   streamStatus(streamId: string): ProjectionStreamStatus {
@@ -561,15 +825,60 @@ export class WorkflowProjectionDatabase {
     return Object.fromEntries(CURRENT_KINDS.map((kind) => [kind, this.currentPage({ kind, limit: WORKFLOW_PROJECTION_PAGE_LIMIT }).items])) as unknown as WorkflowProjectionCurrent;
   }
 
+  aggregateCurrentPage(resource: "projects" | "workflows", query: Omit<WorkflowCurrentPageQuery, "kind">): WorkflowCurrentPage {
+    if (!Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error("Workflow aggregate page query is invalid");
+    const values = [query.cursor, query.projectId, query.sessionId, query.workflowId, query.status].filter((value): value is string => value !== undefined);
+    if (values.some((value) => Buffer.byteLength(value) > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow aggregate query exceeds its byte limit");
+    let cursorProject = "", cursorWorkflow = "";
+    if (query.cursor) {
+      try {
+        const parsed = JSON.parse(Buffer.from(query.cursor, "base64url").toString("utf8")) as unknown;
+        if (!Array.isArray(parsed) || parsed.length !== 3 || parsed[0] !== resource || typeof parsed[1] !== "string" || typeof parsed[2] !== "string"
+          || Buffer.from(JSON.stringify(parsed), "utf8").toString("base64url") !== query.cursor) throw new Error();
+        cursorProject = parsed[1]; cursorWorkflow = parsed[2];
+      } catch { throw new Error("Workflow aggregate cursor is invalid"); }
+    }
+    const where = ["kind = 'sessions'"];
+    const parameters: Record<string, string | number> = { $limit: query.limit + 1 };
+    const filters = [["project_id", "$project", query.projectId], ["session_id", "$session", query.sessionId], ["workflow_id", "$workflow", query.workflowId]] as const;
+    for (const [column, parameter, value] of filters) if (value) { where.push(`${column} = ${parameter}`); parameters[parameter] = value; }
+    if (resource === "workflows") where.push("workflow_id IS NOT NULL");
+    if (query.status) parameters.$status = query.status;
+    const workflowExpression = resource === "workflows" ? "workflow_id" : "''";
+    if (query.cursor) {
+      where.push(`(project_id > $cursor_project OR (project_id = $cursor_project AND ${workflowExpression} > $cursor_workflow))`);
+      parameters.$cursor_project = cursorProject; parameters.$cursor_workflow = cursorWorkflow;
+    }
+    const rows = this.database.query(`WITH ranked AS (
+      SELECT entity_key, current_hash, json(current_json) AS current_json, project_id, ${workflowExpression} AS aggregate_workflow,
+        ROW_NUMBER() OVER (PARTITION BY project_id, ${workflowExpression}
+          ORDER BY julianday(updated_at) DESC, updated_at DESC, current_order_key DESC) AS rank
+      FROM workflow_current WHERE ${where.join(" AND ")}
+    ) SELECT entity_key, current_hash, current_json, project_id, aggregate_workflow FROM ranked WHERE rank = 1
+      ${query.status ? "AND json_extract(current_json, '$.status') = $status" : ""}
+      ORDER BY project_id, aggregate_workflow LIMIT $limit`).all(parameters) as Array<{ entity_key: string; current_hash: string; current_json: string; project_id: string; aggregate_workflow: string }>;
+    const hasMore = rows.length > query.limit;
+    const selected = rows.slice(0, query.limit);
+    const items = selected.map((entry) => parseCurrent("sessions", entry.entity_key, entry.current_json, entry.current_hash));
+    const last = selected.at(-1);
+    const nextCursor = hasMore && last ? Buffer.from(JSON.stringify([resource, last.project_id, last.aggregate_workflow]), "utf8").toString("base64url") : undefined;
+    return { items, ...(nextCursor ? { nextCursor } : {}), hasMore };
+  }
+
   currentPage(query: WorkflowCurrentPageQuery): WorkflowCurrentPage {
     if (!CURRENT_KINDS.includes(query.kind) || !Number.isSafeInteger(query.limit) || query.limit < 1 || query.limit > WORKFLOW_PROJECTION_PAGE_LIMIT) throw new Error("Workflow current page query is invalid");
-    if (query.cursor && Buffer.byteLength(query.cursor) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current cursor exceeds its byte limit");
+    const values = [query.cursor, query.projectId, query.sessionId, query.workflowId, query.runId, query.nodeId, query.taskId, query.status].filter((value): value is string => value !== undefined);
+    if (values.some((value) => Buffer.byteLength(value) > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow current query exceeds its byte limit");
     const where: string[] = ["kind = $kind"];
     const parameters: Record<string, string | number> = { $kind: query.kind, $limit: query.limit + 1 };
     if (query.cursor) {
       where.push(`current_order_key > $current_order_key`);
       parameters.$current_order_key = workflowProjectionCurrentCursorOrderKey(query.cursor);
     }
+    const filters = [["project_id", "$project", query.projectId], ["session_id", "$session", query.sessionId], ["workflow_id", "$workflow", query.workflowId],
+      ["run_id", "$run", query.runId], ["node_id", "$node", query.nodeId], ["task_id", "$task", query.taskId]] as const;
+    for (const [column, parameter, value] of filters) if (value) { where.push(`${column} = ${parameter}`); parameters[parameter] = value; }
+    if (query.status) { where.push(`json_extract(current_json, '$.status') = $status`); parameters.$status = query.status; }
     const rows = this.database.query(`SELECT entity_key, current_hash, json(current_json) AS current_json FROM workflow_current
       WHERE ${where.join(" AND ")} ORDER BY current_order_key LIMIT $limit`).all(parameters) as Array<{ entity_key: string; current_hash: string; current_json: string }>;
     const hasMore = rows.length > query.limit;
@@ -578,9 +887,15 @@ export class WorkflowProjectionDatabase {
     return { items: selected.map((entry) => entry.value), ...(hasMore && last ? { nextCursor: encodeWorkflowCurrentCursor(last.value, last.entity_key) } : {}), hasMore };
   }
 
-  usage(): WorkflowProjectionUsageTotals {
+  usage(query: WorkflowUsageQuery = {}): WorkflowProjectionUsageTotals {
+    const values = Object.values(query).filter((value): value is string => value !== undefined);
+    if (values.some((value) => Buffer.byteLength(value) > WORKFLOW_PROJECTION_VALUE_BYTES) || values.reduce((sum, value) => sum + Buffer.byteLength(value), 0) > WORKFLOW_PROJECTION_QUERY_BYTES) throw new Error("Workflow usage query exceeds its byte limit");
     const output: WorkflowProjectionUsageTotals = { estimated: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 }, providerConfirmed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0 } };
-    const rows = this.database.query(`SELECT precision, input_tokens, output_tokens, cost_micro_usd FROM workflow_usage ORDER BY event_id`).all() as Array<{ precision: string; input_tokens: number; output_tokens: number; cost_micro_usd: number }>;
+    const where: string[] = [];
+    const parameters: Record<string, string> = {};
+    const filters = [["project_id", "$project", query.projectId], ["session_id", "$session", query.sessionId], ["workflow_id", "$workflow", query.workflowId], ["run_id", "$run", query.runId], ["node_id", "$node", query.nodeId]] as const;
+    for (const [column, parameter, value] of filters) if (value) { where.push(`${column} = ${parameter}`); parameters[parameter] = value; }
+    const rows = this.database.query(`SELECT precision, input_tokens, output_tokens, cost_micro_usd FROM workflow_usage ${where.length ? `WHERE ${where.join(" AND ")}` : ""} ORDER BY event_id`).all(parameters) as Array<{ precision: string; input_tokens: number; output_tokens: number; cost_micro_usd: number }>;
     for (const row of rows) {
       const key = row.precision === "provider-confirmed" ? "providerConfirmed" : "estimated";
       const bucket = output[key] as { inputTokens: number; outputTokens: number; costMicroUsd: number };
@@ -598,18 +913,33 @@ export class WorkflowProjectionDatabase {
       this.database.run(`DELETE FROM workflow_usage`); this.database.run(`DELETE FROM workflow_current`); this.database.run(`DELETE FROM workflow_events`); this.database.run(`DELETE FROM workflow_event_identities`); this.database.run(`DELETE FROM workflow_streams`); this.database.run(`DELETE FROM workflow_prune_watermarks`);
     })();
   }
+  /** Publishes a complete replacement in one SQLite write transaction. Any failure restores the prior valid projection. */
+  replaceProjectionAtomically<T>(build: () => T): T {
+    return this.database.transaction(() => {
+      this.reset();
+      const result = build();
+      this.assertPersistedIntegrity();
+      return result;
+    }).immediate();
+  }
+  /** Rebuild one authoritative stream without retaining any other stream in memory. */
+  rebuildStream(stream: readonly WorkflowTelemetryEvent[]): Readonly<{ streamId: string; diagnostic: string }> | undefined {
+    if (!stream[0]) return undefined;
+    try { this.database.transaction(() => { for (const event of stream) this.ingest(event); })(); }
+    catch (error) {
+      const diagnostic = String(error instanceof Error ? error.message : error).slice(0, 2_048);
+      this.markStreamBlocked(stream[0].streamId, stream[0].dimensions.projectId, stream[0].dimensions.sessionId, diagnostic, stream[0].dimensions.projectRoot);
+      return Object.freeze({ streamId: stream[0].streamId, diagnostic });
+    }
+    return undefined;
+  }
   rebuild(streams: readonly (readonly WorkflowTelemetryEvent[])[]): Readonly<{ diagnostics: readonly Readonly<{ streamId: string; diagnostic: string }>[] }> {
     this.reset();
     const diagnostics: Array<Readonly<{ streamId: string; diagnostic: string }>> = [];
     const ordered = [...streams].map((events) => [...events].sort((a, b) => a.sequence - b.sequence)).sort((a, b) => String(a[0]?.streamId ?? "").localeCompare(String(b[0]?.streamId ?? "")));
     for (const stream of ordered) {
-      if (!stream[0]) continue;
-      try { this.database.transaction(() => { for (const event of stream) this.ingest(event); })(); }
-      catch (error) {
-        const diagnostic = String(error instanceof Error ? error.message : error).slice(0, 2_048);
-        this.markStreamBlocked(stream[0].streamId, stream[0].dimensions.projectId, stream[0].dimensions.sessionId, diagnostic, stream[0].dimensions.projectRoot);
-        diagnostics.push(Object.freeze({ streamId: stream[0].streamId, diagnostic }));
-      }
+      const diagnostic = this.rebuildStream(stream);
+      if (diagnostic) diagnostics.push(diagnostic);
     }
     return Object.freeze({ diagnostics: Object.freeze(diagnostics) });
   }

--- a/src/observability/server/workflow-routes.ts
+++ b/src/observability/server/workflow-routes.ts
@@ -1,0 +1,280 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "../../config/snapshot-canonical";
+import {
+  WORKFLOW_DASHBOARD_API_VERSION,
+  WORKFLOW_DASHBOARD_MAX_BODY_BYTES,
+  WORKFLOW_DASHBOARD_MAX_PAGE_SIZE,
+  type WorkflowDashboardResource,
+  type WorkflowDashboardResourcePage,
+} from "../../shared/dashboard-api";
+import type {
+  ProjectionStreamStatus,
+  WorkflowCurrentPage,
+  WorkflowCurrentPageQuery,
+  WorkflowHistoryPage,
+  WorkflowHistoryQuery,
+  WorkflowProjectionCurrent,
+  WorkflowProjectionUsageTotals,
+  WorkflowUsageQuery,
+} from "../projection";
+import { applyBrowserSecurityHeaders, isAuthorizedCsrf, isAuthorizedWrite, isSameOriginRequest } from "../security";
+
+export interface WorkflowProjectionApi {
+  currentPage(query: WorkflowCurrentPageQuery): WorkflowCurrentPage;
+  resourcePage?(resource: "projects" | "workflows", query: Omit<WorkflowCurrentPageQuery, "kind">): WorkflowCurrentPage;
+  history(query: WorkflowHistoryQuery): WorkflowHistoryPage;
+  usage(query: WorkflowUsageQuery): WorkflowProjectionUsageTotals;
+  status(): Readonly<{ streams: readonly ProjectionStreamStatus[]; diagnostics: readonly unknown[] }>;
+  stream(lastEventId?: string): Response;
+  runOperation<T>(scope: string, operationId: string, requestHash: string, invoke: () => T | Promise<T>): Promise<T>;
+  close(): void;
+}
+
+export interface WorkflowControlApi {
+  readQuestion(input: Record<string, unknown>): unknown | Promise<unknown>;
+  readCheckpoint(input: Record<string, unknown>): unknown | Promise<unknown>;
+  readKnowledge(input: Record<string, unknown>): unknown | Promise<unknown>;
+  answerQuestion(input: Record<string, unknown>): unknown | Promise<unknown>;
+  decideCheckpoint(input: Record<string, unknown>): unknown | Promise<unknown>;
+  decideKnowledge(input: Record<string, unknown>): unknown | Promise<unknown>;
+  rebuildProjection(input: Record<string, unknown>): unknown | Promise<unknown>;
+  pruneProjection(input: Record<string, unknown>): unknown | Promise<unknown>;
+  pruneJournal(input: Record<string, unknown>): unknown | Promise<unknown>;
+}
+
+export interface WorkflowApiOptions {
+  readonly token: string;
+  readonly projection: WorkflowProjectionApi;
+  readonly controls: WorkflowControlApi;
+  readonly maxBodyBytes?: number;
+  readonly maxRequestsPerWindow?: number;
+  readonly rateWindowMs?: number;
+  readonly now?: () => number;
+}
+
+const RESOURCE_KINDS: Readonly<Record<WorkflowDashboardResource, keyof WorkflowProjectionCurrent>> = Object.freeze({
+  projects: "sessions", workflows: "sessions", sessions: "sessions", runs: "runs", nodes: "nodes", tasks: "tasks",
+  artifacts: "workspaces", checkpoints: "approvals", questions: "questions", approvals: "approvals", knowledge: "knowledge",
+});
+const READ_PATH = /^\/api\/v1\/(projects|workflows|sessions|runs|nodes|tasks|artifacts|checkpoints|questions|approvals|knowledge)$/u;
+const QUERY_BYTES = 8_192;
+const QUERY_PARAMETERS = 16;
+const RESOURCE_FILTERS: Readonly<Record<WorkflowDashboardResource, readonly string[]>> = Object.freeze({
+  projects: ["projectId", "status"],
+  workflows: ["projectId", "workflowId", "status"],
+  sessions: ["projectId", "sessionId", "workflowId", "status"],
+  runs: ["projectId", "sessionId", "workflowId", "runId", "status"],
+  nodes: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "status"],
+  tasks: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+  artifacts: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+  checkpoints: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+  questions: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+  approvals: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+  knowledge: ["projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "status"],
+});
+
+function response(data: unknown, status = 200): Response {
+  return applyBrowserSecurityHeaders(new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json", "cache-control": "no-store" } }), "api");
+}
+function failure(code: string, message: string, status: number): Response {
+  return response({ apiVersion: WORKFLOW_DASHBOARD_API_VERSION, error: { code, message: message.slice(0, 2_048) } }, status);
+}
+function exactObject(value: unknown, required: readonly string[], optional: readonly string[] = []): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("request body must be a JSON object");
+  const record = value as Record<string, unknown>;
+  const allowed = new Set([...required, ...optional]);
+  if (required.some((key) => !(key in record)) || Object.keys(record).some((key) => !allowed.has(key))) throw new Error("request body has missing or unknown fields");
+  return record;
+}
+function identifier(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(value)) throw new Error(`${label} is invalid`);
+  return value;
+}
+function operationId(value: unknown): string { return identifier(value, "operationId"); }
+function pageLimit(url: URL): number {
+  const raw = url.searchParams.get("limit") ?? "100";
+  if (!/^[1-9][0-9]*$/u.test(raw)) throw new Error("limit must be an integer");
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1 || value > WORKFLOW_DASHBOARD_MAX_PAGE_SIZE) throw new Error(`limit must be 1..${WORKFLOW_DASHBOARD_MAX_PAGE_SIZE}`);
+  return value;
+}
+function queryValues(url: URL, supported: readonly string[]): Record<string, string> {
+  if (Buffer.byteLength(url.search, "utf8") > QUERY_BYTES) throw new Error("raw query exceeds its byte limit");
+  const parameters = [...url.searchParams.entries()];
+  if (parameters.length > QUERY_PARAMETERS) throw new Error("query parameter count exceeds its limit");
+  const allowed = new Set(["limit", ...supported]);
+  const seen = new Set<string>();
+  const output: Record<string, string> = {};
+  for (const [key, value] of parameters) {
+    if (!allowed.has(key)) throw new Error(`unsupported query parameter for this route: ${key}`);
+    if (seen.has(key)) throw new Error(`duplicate query parameter is ambiguous: ${key}`);
+    seen.add(key);
+    if (key === "limit") continue;
+    if (!value || Buffer.byteLength(value, "utf8") > 1_024) throw new Error(`${key} is invalid`);
+    output[key] = value;
+  }
+  return output;
+}
+async function readBody(req: Request, maxBytes: number): Promise<unknown> {
+  const contentType = req.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+  if (contentType !== "application/json") throw Object.assign(new Error("content-type must be application/json"), { status: 415, code: "UNSUPPORTED_MEDIA_TYPE" });
+  const declared = req.headers.get("content-length");
+  if (declared !== null && (!/^[0-9]+$/u.test(declared) || !Number.isSafeInteger(Number(declared)) || Number(declared) > maxBytes)) throw Object.assign(new Error("request body exceeds its byte limit"), { status: 413, code: "BODY_TOO_LARGE" });
+  const reader = req.body?.getReader();
+  if (!reader) throw new Error("request body is required");
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (!(chunk.value instanceof Uint8Array)) throw new Error("request body stream is invalid");
+      if (chunk.value.byteLength > maxBytes - total) {
+        await reader.cancel("request body exceeds its byte limit");
+        throw Object.assign(new Error("request body exceeds its byte limit"), { status: 413, code: "BODY_TOO_LARGE" });
+      }
+      total += chunk.value.byteLength;
+      chunks.push(chunk.value);
+    }
+  } catch (error) {
+    try { await reader.cancel(error); } catch { /* already closed */ }
+    throw error;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+  try { return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)); }
+  catch { throw new Error("request body is not valid UTF-8 JSON"); }
+}
+function statusFor(error: unknown): number {
+  const explicit = Number((error as { status?: unknown })?.status);
+  if (Number.isSafeInteger(explicit) && explicit >= 400 && explicit <= 599) return explicit;
+  const message = error instanceof Error ? error.message : String(error);
+  if (/already|CAS|conflict|stale|reuse|decided|pending state|identity mismatch/iu.test(message)) return 409;
+  if (/\b(?:object is missing|is missing|not found)\b/iu.test(message)) return 404;
+  if (/authentication|authorized|credential/iu.test(message)) return 401;
+  return 400;
+}
+function codeFor(error: unknown, status: number): string {
+  const explicit = (error as { code?: unknown })?.code;
+  if (typeof explicit === "string" && /^[A-Z0-9_]{1,64}$/u.test(explicit)) return explicit;
+  return status === 409 ? "CAS_CONFLICT" : status === 404 ? "NOT_FOUND" : status === 401 ? "UNAUTHORIZED" : "INVALID_REQUEST";
+}
+
+export function createWorkflowApi(options: WorkflowApiOptions): Readonly<{ handle(req: Request, url: URL): Promise<Response | null>; dispose(): void }> {
+  if (!options.token || Buffer.byteLength(options.token, "utf8") < 32) throw new Error("Workflow API requires a high-entropy daemon token");
+  const maxBodyBytes = options.maxBodyBytes ?? WORKFLOW_DASHBOARD_MAX_BODY_BYTES;
+  if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes < 1 || maxBodyBytes > WORKFLOW_DASHBOARD_MAX_BODY_BYTES) throw new Error("Workflow API body limit is invalid");
+  const maxRequests = options.maxRequestsPerWindow ?? 600;
+  const rateWindowMs = options.rateWindowMs ?? 60_000;
+  if (!Number.isSafeInteger(maxRequests) || maxRequests < 1 || maxRequests > 100_000 || !Number.isSafeInteger(rateWindowMs) || rateWindowMs < 100 || rateWindowMs > 3_600_000) throw new Error("Workflow API rate limit is invalid");
+  const now = options.now ?? Date.now;
+  let rateWindowStarted = now();
+  let rateCount = 0;
+  let closed = false;
+
+  const replay = async (scope: string, input: Record<string, unknown>, invoke: () => unknown | Promise<unknown>): Promise<unknown> => {
+    const id = operationId(input.operationId);
+    const hash = createHash("sha256").update("pi-hive-dashboard-operation-v1\0").update(scope).update("\0").update(canonicalJson(input)).digest("hex");
+    return options.projection.runOperation(scope, id, hash, invoke);
+  };
+
+  return Object.freeze({
+    dispose(): void {
+      if (closed) return;
+      closed = true;
+      options.projection.close();
+    },
+    async handle(req: Request, url: URL): Promise<Response | null> {
+      if (!url.pathname.startsWith("/api/v1/")) return null;
+      if (closed) return failure("SERVICE_UNAVAILABLE", "workflow API is closed", 503);
+      const version = req.headers.get("x-pi-hive-api-version");
+      if (version !== String(WORKFLOW_DASHBOARD_API_VERSION)) return failure("INCOMPATIBLE_API_VERSION", `Dashboard API version ${WORKFLOW_DASHBOARD_API_VERSION} is required`, 426);
+      if (!isSameOriginRequest(req, url)) return failure("CROSS_ORIGIN", "cross-origin request blocked", 403);
+      if (!isAuthorizedWrite(req, options.token)) return failure("UNAUTHORIZED", "authentication required", 401);
+      const requestTime = now();
+      if (!Number.isFinite(requestTime)) return failure("CLOCK_INVALID", "rate-limit clock is invalid", 500);
+      if (requestTime - rateWindowStarted >= rateWindowMs || requestTime < rateWindowStarted) { rateWindowStarted = requestTime; rateCount = 0; }
+      rateCount += 1;
+      if (rateCount > maxRequests) {
+        const limited = failure("RATE_LIMITED", "authenticated request rate exceeded", 429);
+        limited.headers.set("retry-after", String(Math.max(1, Math.ceil((rateWindowStarted + rateWindowMs - requestTime) / 1_000))));
+        return limited;
+      }
+      try {
+        if (req.method === "GET") {
+          const resourceMatch = READ_PATH.exec(url.pathname);
+          if (resourceMatch) {
+            const resource = resourceMatch[1] as WorkflowDashboardResource;
+            const values = queryValues(url, ["cursor", ...RESOURCE_FILTERS[resource]]);
+            const page = (resource === "projects" || resource === "workflows") && options.projection.resourcePage
+              ? options.projection.resourcePage(resource, { limit: pageLimit(url), ...values })
+              : options.projection.currentPage({ kind: RESOURCE_KINDS[resource], limit: pageLimit(url), ...values });
+            return response({ apiVersion: 1, resource, items: page.items, ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}), hasMore: page.hasMore } satisfies WorkflowDashboardResourcePage);
+          }
+          if (url.pathname === "/api/v1/activity" || url.pathname === "/api/v1/history") {
+            const values = queryValues(url, ["cursor", "projectId", "sessionId", "workflowId", "runId", "nodeId", "taskId", "eventType"]);
+            const page = options.projection.history({ limit: pageLimit(url), ...values } as WorkflowHistoryQuery);
+            return response({ apiVersion: 1, items: page.items, ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}), hasMore: page.hasMore });
+          }
+          if (url.pathname === "/api/v1/usage") {
+            const values = queryValues(url, ["projectId", "sessionId", "workflowId", "runId", "nodeId"]);
+            return response({ apiVersion: 1, usage: options.projection.usage(values) });
+          }
+          if (url.pathname === "/api/v1/projection/status") {
+            queryValues(url, []);
+            return response({ apiVersion: 1, ...options.projection.status() });
+          }
+          if (url.pathname === "/api/v1/stream") {
+            queryValues(url, []);
+            const lastEventId = req.headers.get("last-event-id") ?? undefined;
+            if (lastEventId !== undefined && Buffer.byteLength(lastEventId, "utf8") > 1_024) throw new Error("Last-Event-ID is invalid");
+            return applyBrowserSecurityHeaders(options.projection.stream(lastEventId), "api");
+          }
+          const detail = /^\/api\/v1\/(questions|approvals|knowledge)\/([^/]+)$/u.exec(url.pathname);
+          if (detail) {
+            const values = queryValues(url, ["projectId", "sessionId", "runId"]);
+            if (!values.projectId || !values.sessionId || !values.runId) throw new Error("detail query requires exact project/session/run identity");
+            const objectId = decodeURIComponent(detail[2]);
+            const input = detail[1] === "questions" ? { projectId: values.projectId, sessionId: values.sessionId, runId: values.runId, questionId: objectId }
+              : detail[1] === "approvals" ? { projectId: values.projectId, sessionId: values.sessionId, runId: values.runId, requestId: objectId }
+                : { projectId: values.projectId, sessionId: values.sessionId, runId: values.runId, proposalId: objectId };
+            const object = detail[1] === "questions" ? await options.controls.readQuestion(input)
+              : detail[1] === "approvals" ? await options.controls.readCheckpoint(input) : await options.controls.readKnowledge(input);
+            return response({ apiVersion: 1, object });
+          }
+          return failure("NOT_FOUND", "route not found", 404);
+        }
+        if (req.method !== "POST") return failure("METHOD_NOT_ALLOWED", "method not allowed", 405);
+        queryValues(url, []);
+        if (!isAuthorizedCsrf(req, options.token)) return failure("CSRF", "CSRF proof required", 403);
+        const raw = await readBody(req, maxBodyBytes);
+        const credential = options.token;
+        let result: unknown;
+        if (url.pathname === "/api/v1/controls/questions/answer") {
+          const input = exactObject(raw, ["projectId", "sessionId", "runId", "questionId", "expectedState", "value", "operationId", "claimedIdentity"]);
+          result = await replay("question", input, () => options.controls.answerQuestion({ ...input, channel: "dashboard", credential }));
+        } else if (url.pathname === "/api/v1/controls/approvals/decide") {
+          const input = exactObject(raw, ["projectId", "sessionId", "runId", "requestId", "expectedRequestSequence", "digest", "expectedWorkspaceHash", "decision", "operationId"], ["feedback"]);
+          result = await replay("approval", input, () => options.controls.decideCheckpoint({ ...input, credential }));
+        } else if (url.pathname === "/api/v1/controls/knowledge/decide") {
+          const input = exactObject(raw, ["projectId", "sessionId", "runId", "proposalId", "expectedState", "decision", "operationId", "claimedIdentity"]);
+          result = await replay("knowledge", input, () => options.controls.decideKnowledge({ ...input, channel: "dashboard", credential }));
+        } else if (url.pathname === "/api/v1/maintenance/projection/rebuild") {
+          const input = exactObject(raw, ["operationId"]);
+          result = await replay("projection-rebuild", input, () => options.controls.rebuildProjection(input));
+        } else if (url.pathname === "/api/v1/maintenance/projection/prune") {
+          const input = exactObject(raw, ["operationId", "cutoff"]);
+          result = await replay("projection-prune", input, () => options.controls.pruneProjection(input));
+        } else if (url.pathname === "/api/v1/maintenance/journals/prune") {
+          const input = exactObject(raw, ["projectId", "sessionId", "operationId", "confirmIrrecoverable"]);
+          result = await replay("journal-prune", input, () => options.controls.pruneJournal({ ...input, credential }));
+        } else return failure("NOT_FOUND", "route not found", 404);
+        return response({ apiVersion: 1, result });
+      } catch (error) {
+        const status = statusFor(error);
+        return failure(codeFor(error, status), error instanceof Error ? error.message : String(error), status);
+      }
+    },
+  });
+}

--- a/src/observability/server/workflow-runtime.ts
+++ b/src/observability/server/workflow-runtime.ts
@@ -2,7 +2,9 @@ import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readdirSync, rmSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { loadConfigProject } from "../../config/manifest";
+import { withCrossProcessFileLock } from "../../core/file-lock";
 import { readWorkflowJournal, readWorkflowJournalFrom, workflowJournalDirectory } from "../../workflows/journal";
+import { listSessionLinks, type WorkflowSessionLink } from "../../workflows/sessions";
 import { toWorkflowTelemetryEvent, type WorkflowTelemetryEvent } from "../events";
 import { WorkflowProjectionIntegrityError, openWorkflowProjectionDatabase } from "./workflow-db";
 
@@ -19,6 +21,7 @@ export interface ConfiguredWorkflowProjectionSynchronizerOptions {
   readonly retentionDays?: number;
   readonly now?: () => Date;
   readonly pruneIntervalMs?: number;
+  readonly onEvent?: (event: WorkflowTelemetryEvent) => void;
 }
 export interface WorkflowProjectionSyncDiagnostic { readonly projectRoot: string; readonly sessionId: string; readonly diagnostic: string }
 export interface SyncConfiguredWorkflowProjectionResult { readonly active: boolean; readonly events: number; readonly streams: number; readonly diagnostics?: readonly WorkflowProjectionSyncDiagnostic[] }
@@ -27,7 +30,7 @@ export interface ConfiguredWorkflowProjectionSynchronizer {
   close(): void;
 }
 
-interface JournalReference { readonly projectRoot: string; readonly sessionId: string; readonly journalPath: string }
+interface JournalReference { readonly projectRoot: string; readonly sessionId: string; readonly journalPath: string; readonly link?: WorkflowSessionLink }
 interface JournalFingerprint {
   readonly directory: string;
   readonly eventCount: number;
@@ -60,6 +63,7 @@ function journalReferences(projectRoot: string): Readonly<{ references: JournalR
   if (!existsSync(sessionsRoot) || !lstatSync(sessionsRoot).isDirectory() || lstatSync(sessionsRoot).isSymbolicLink()) return { references: [], diagnostics: [] };
   const references: JournalReference[] = [];
   const diagnostics: WorkflowProjectionSyncDiagnostic[] = [];
+  const workflowLinks = listSessionLinks(projectRoot).filter((entry): entry is WorkflowSessionLink => entry.kind === "workflow");
   for (const sessionId of readdirSync(sessionsRoot).sort()) {
     try {
       const sessionPath = join(sessionsRoot, sessionId);
@@ -67,7 +71,9 @@ function journalReferences(projectRoot: string): Readonly<{ references: JournalR
       if (!lstatSync(sessionPath).isDirectory() || lstatSync(sessionPath).isSymbolicLink() || !existsSync(journalPath)) continue;
       const journalStat = lstatSync(journalPath);
       if (!journalStat.isDirectory() || journalStat.isSymbolicLink()) throw new Error("Workflow journal path invalid");
-      references.push(Object.freeze({ projectRoot, sessionId, journalPath }));
+      const links = workflowLinks.filter((entry) => entry.workflowSessionId === sessionId);
+      if (links.length > 1) throw new Error("Workflow journal has ambiguous session-link context");
+      references.push(Object.freeze({ projectRoot, sessionId, journalPath, ...(links[0] ? { link: links[0] } : {}) }));
     } catch (error) {
       diagnostics.push(Object.freeze({ projectRoot, sessionId: sessionId.slice(0, 256), diagnostic: boundedDiagnostic(error) }));
     }
@@ -112,10 +118,17 @@ function priorEventsUnchanged(prior: JournalFingerprint | undefined, current: Jo
 }
 
 function telemetry(events: readonly import("../../workflows/events").WorkflowEventEnvelope[], reference: JournalReference): WorkflowTelemetryEvent[] {
+  const link = reference.link;
   return events.map((event) => toWorkflowTelemetryEvent(event, {
     projectRoot: reference.projectRoot,
     projectLabel: basename(reference.projectRoot),
-    workflowConfigVersion: "1",
+    ...(link ? {
+      piSessionId: link.piSessionId,
+      workflowId: link.workflowId,
+      snapshotId: link.activationHash,
+      workflowConfigHash: link.activationHash,
+      workflowConfigVersion: String(link.formatVersion),
+    } : {}),
   }));
 }
 
@@ -162,6 +175,7 @@ class PersistentConfiguredWorkflowProjectionSynchronizer implements ConfiguredWo
     const roots = configuredRoots(projectRoots);
     if (!roots.length) return Object.freeze({ active: false, events: 0, streams: 0 });
     const projection = this.openProjection();
+    return withCrossProcessFileLock(`${projection.path}.projection`, () => {
     const discovered = roots.map(journalReferences);
     const references = discovered.flatMap((entry) => entry.references);
     const diagnostics = discovered.flatMap((entry) => entry.diagnostics);
@@ -197,7 +211,7 @@ class PersistentConfiguredWorkflowProjectionSynchronizer implements ConfiguredWo
           continue;
         }
         try {
-          for (const event of events.slice(existing?.status.lastSequence ?? 0)) if (projection.ingest(event) === "inserted") processed += 1;
+          for (const event of events.slice(existing?.status.lastSequence ?? 0)) if (projection.ingest(event) === "inserted") { processed += 1; this.options.onEvent?.(event); }
         } catch (error) {
           const diagnostic = boundedDiagnostic(error);
           diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic }));
@@ -231,7 +245,7 @@ class PersistentConfiguredWorkflowProjectionSynchronizer implements ConfiguredWo
           if (existing?.status.state === "blocked") {
             diagnostics.push(Object.freeze({ projectRoot: reference.projectRoot, sessionId: reference.sessionId, diagnostic: existing.status.diagnostic ?? "Workflow projection stream is blocked" }));
           } else {
-            for (const event of events) if (projection.ingest(event) === "inserted") processed += 1;
+            for (const event of events) if (projection.ingest(event) === "inserted") { processed += 1; this.options.onEvent?.(event); }
           }
           const after = fingerprint(reference, currentFingerprint);
           if (sameFingerprint(currentFingerprint, after)) this.fingerprints.set(reference.journalPath, after);
@@ -246,6 +260,7 @@ class PersistentConfiguredWorkflowProjectionSynchronizer implements ConfiguredWo
 
     this.pruneIfDue(projection);
     return Object.freeze({ active: true, events: processed, streams: references.length, ...(diagnostics.length ? { diagnostics: Object.freeze(diagnostics.slice(0, 256)) } : {}) });
+    }, { timeoutMs: 30_000, staleMs: 120_000 });
   }
 
   close(): void {

--- a/src/observability/server/workflow-service.ts
+++ b/src/observability/server/workflow-service.ts
@@ -1,0 +1,409 @@
+import { closeSync, constants, existsSync, fstatSync, lstatSync, openSync, opendirSync, readSync } from "node:fs";
+import { basename, join } from "node:path";
+import { CheckpointApprovalService } from "../../artifacts/approvals";
+import type { CheckpointPolicy } from "../../artifacts/checkpoints";
+import { hashArtifactWorkspace } from "../../artifacts/hashes";
+import { BUILTIN_ARTIFACT_REGISTRY, type ResolvedArtifactProfile } from "../../artifacts/registry";
+import type { ActivationSnapshotFileV1 } from "../../config/snapshot";
+import { readActivationSnapshot } from "../../config/snapshot-store";
+import { canonicalJson } from "../../config/snapshot-canonical";
+import { KnowledgeProposalService } from "../../knowledge/proposals";
+import { createWorkflowJournalPruneService } from "../journal-prune";
+import { toWorkflowTelemetryEvent } from "../events";
+import { encodeWorkflowHistoryCursor, type WorkflowCurrentPageQuery, type WorkflowHistoryQuery, type WorkflowUsageQuery } from "../projection";
+import { QuestionService } from "../../workflows/questions";
+import { WORKFLOW_EVENT_LIMITS, verifyWorkflowEvent, type WorkflowEventEnvelope } from "../../workflows/events";
+import { listSessionLinks, type WorkflowSessionLink } from "../../workflows/sessions";
+import { withCrossProcessFileLock } from "../../core/file-lock";
+import { DAEMON_TOKEN, DB_PATH, PROJECT_CWD, REGISTRY_PATH, WORKFLOW_DB_PATH } from "./config";
+import { openWorkflowProjectionDatabase, type WorkflowProjectionDatabase } from "./workflow-db";
+import { readWorkflowProjectionRuntimeDiagnostics } from "./runtime";
+import { closeWorkflowSubscribers, encoder, enqueueBounded, eventFrame, invalidateWorkflowSubscribers, registerSubscriber, removeSubscriber, SSE_BUFFER_BYTES, type WorkflowStreamLimits } from "./sse";
+import type { WorkflowApiOptions, WorkflowControlApi, WorkflowProjectionApi } from "./workflow-routes";
+
+function record(value: unknown): value is Record<string, unknown> { return Boolean(value) && typeof value === "object" && !Array.isArray(value); }
+function id(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(value)) throw new Error(`${label} is invalid`);
+  return value;
+}
+function finiteTimestamp(value: unknown, label: string): string {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) throw new Error(`${label} is invalid`);
+  return value;
+}
+interface SessionAuthority { readonly projectRoot: string; readonly projectId: string; readonly sessionId: string }
+
+export const WORKFLOW_PROJECTION_REBUILD_LIMITS = Object.freeze({
+  streams: 4_096,
+  events: 262_144,
+  bytes: 512 * 1_024 * 1_024,
+  names: 270_336,
+  pathBytes: 64 * 1_024 * 1_024,
+});
+
+export interface WorkflowProjectionRebuildLimits {
+  readonly streams?: number;
+  readonly events?: number;
+  readonly bytes?: number;
+  readonly names?: number;
+  readonly pathBytes?: number;
+}
+
+export interface ProductionWorkflowServiceOptions {
+  readonly token?: string;
+  readonly databasePath?: string;
+  readonly legacyPaths?: readonly string[];
+  readonly projectCwd?: string;
+  readonly diagnostics?: () => readonly unknown[];
+  readonly rebuildLimits?: WorkflowProjectionRebuildLimits;
+  readonly streamLimits?: WorkflowStreamLimits;
+}
+
+interface WorkflowJournalReference { readonly projectRoot: string; readonly sessionId: string; readonly journalPath: string; readonly link?: WorkflowSessionLink }
+interface EffectiveRebuildLimits { readonly streams: number; readonly events: number; readonly bytes: number; readonly names: number; readonly pathBytes: number }
+interface RebuildBudget { events: number; bytes: number; names: number; pathBytes: number }
+
+function rebuildLimitError(message: string): Error {
+  return Object.assign(new Error(message), { status: 413, code: "PROJECTION_REBUILD_LIMIT" });
+}
+
+function effectiveRebuildLimits(input: WorkflowProjectionRebuildLimits | undefined): EffectiveRebuildLimits {
+  const limits = {
+    streams: input?.streams ?? WORKFLOW_PROJECTION_REBUILD_LIMITS.streams,
+    events: input?.events ?? WORKFLOW_PROJECTION_REBUILD_LIMITS.events,
+    bytes: input?.bytes ?? WORKFLOW_PROJECTION_REBUILD_LIMITS.bytes,
+    names: input?.names ?? WORKFLOW_PROJECTION_REBUILD_LIMITS.names,
+    pathBytes: input?.pathBytes ?? WORKFLOW_PROJECTION_REBUILD_LIMITS.pathBytes,
+  };
+  for (const [name, value] of Object.entries(limits)) {
+    const ceiling = WORKFLOW_PROJECTION_REBUILD_LIMITS[name as keyof EffectiveRebuildLimits];
+    if (!Number.isSafeInteger(value) || value < 1 || value > ceiling) throw new Error(`Workflow projection rebuild ${name} limit is invalid`);
+  }
+  return Object.freeze(limits);
+}
+
+class ProductionWorkflowProjection implements WorkflowProjectionApi {
+  private database?: WorkflowProjectionDatabase;
+  private closed = false;
+  constructor(private readonly options: Required<Pick<ProductionWorkflowServiceOptions, "databasePath" | "legacyPaths" | "projectCwd" | "diagnostics">> & Readonly<{ rebuildLimits: EffectiveRebuildLimits; streamLimits?: WorkflowStreamLimits }>) {}
+  private db(): WorkflowProjectionDatabase {
+    if (this.closed) throw new Error("Workflow projection service is closed");
+    return this.database ??= openWorkflowProjectionDatabase({ path: this.options.databasePath, legacyPaths: this.options.legacyPaths });
+  }
+  currentPage(query: WorkflowCurrentPageQuery) { return this.db().currentPage(query); }
+  resourcePage(resource: "projects" | "workflows", query: Omit<WorkflowCurrentPageQuery, "kind">) { return this.db().aggregateCurrentPage(resource, query); }
+  history(query: WorkflowHistoryQuery) { return this.db().history(query); }
+  usage(query: WorkflowUsageQuery) { return this.db().usage(query); }
+  status() {
+    const database = this.db();
+    const rows = database.database.query(`SELECT stream_id FROM workflow_streams ORDER BY stream_id LIMIT 4097`).all() as Array<{ stream_id: string }>;
+    if (rows.length > 4_096) throw new Error("Workflow projection stream status exceeds its bound");
+    return Object.freeze({ streams: Object.freeze(rows.map((row) => database.streamStatus(row.stream_id))), diagnostics: this.options.diagnostics() });
+  }
+  stream(lastEventId?: string): Response {
+    let subscriber: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const catchUpFromDatabase = (cursor: string) => this.db().streamCatchUp(cursor, 500);
+    const streamLimits = this.options.streamLimits;
+    const bufferBytes = streamLimits?.bufferBytes ?? SSE_BUFFER_BYTES;
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        subscriber = controller;
+        const catchUp = lastEventId === undefined ? undefined : catchUpFromDatabase(lastEventId);
+        if (catchUp?.state === "resync-required") {
+          controller.enqueue(encoder.encode(eventFrame("resync-required", { apiVersion: 1, reason: catchUp.reason, history: "/api/v1/history" })));
+          controller.close();
+          return;
+        }
+        // Avoid a live-event gap: compute the retained suffix and register in the
+        // same synchronous turn, then enqueue the suffix before returning.
+        const catchUpFrames = catchUp?.state === "ready"
+          ? catchUp.events.map((event) => eventFrame("workflow", event, encodeWorkflowHistoryCursor(event))) : [];
+        const encoded = [encoder.encode(eventFrame("hello", { apiVersion: 1, catchUp: "/api/v1/history" })), ...catchUpFrames.map((frame) => encoder.encode(frame))];
+        if (encoded.reduce((sum, frame) => sum + frame.byteLength, 0) > bufferBytes) {
+          controller.enqueue(encoder.encode(eventFrame("resync-required", { apiVersion: 1, reason: "catch-up-buffer-exceeded", history: "/api/v1/history" })));
+          controller.close();
+          return;
+        }
+        if (!registerSubscriber("workflow", controller, streamLimits)) {
+          controller.enqueue(encoder.encode(eventFrame("resync-required", { apiVersion: 1, reason: "subscriber-capacity", history: "/api/v1/history" })));
+          controller.close();
+          return;
+        }
+        for (const frame of encoded) if (!enqueueBounded(controller, frame)) break;
+      },
+      cancel() { if (subscriber) removeSubscriber(subscriber); },
+    }, { highWaterMark: bufferBytes, size(chunk) { return chunk?.byteLength ?? 0; } }), { headers: { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" } });
+  }
+  runOperation<T>(scope: string, operationId: string, requestHash: string, invoke: () => T | Promise<T>): Promise<T> {
+    return this.db().runOperation(scope, operationId, requestHash, invoke);
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    closeWorkflowSubscribers();
+    this.database?.close();
+    this.database = undefined;
+  }
+  authority(projectId: string, sessionId: string): SessionAuthority {
+    const rows = this.db().database.query(`SELECT project_id, session_id, project_root FROM workflow_streams WHERE project_id = ? AND session_id = ? LIMIT 2`).all(projectId, sessionId) as Array<{ project_id: string; session_id: string; project_root: string | null }>;
+    if (rows.length !== 1 || !rows[0].project_root) throw new Error("Exact project/session object is missing from the workflow projection");
+    return Object.freeze({ projectRoot: rows[0].project_root, projectId: rows[0].project_id, sessionId: rows[0].session_id });
+  }
+  private accountRebuildName(budget: RebuildBudget, name: string, path: string): void {
+    budget.names += 1;
+    budget.pathBytes += Buffer.byteLength(name, "utf8") + Buffer.byteLength(path, "utf8");
+    if (!Number.isSafeInteger(budget.pathBytes) || budget.names > this.options.rebuildLimits.names || budget.pathBytes > this.options.rebuildLimits.pathBytes) {
+      throw rebuildLimitError("Workflow projection rebuild aggregate name or path-byte limit exceeded");
+    }
+  }
+
+  private rebuildSources(): Readonly<{ references: readonly WorkflowJournalReference[]; events: number; bytes: number }> {
+    const roots = new Set<string>([this.options.projectCwd]);
+    for (const row of this.db().database.query(`SELECT DISTINCT project_root FROM workflow_streams WHERE project_root IS NOT NULL ORDER BY project_root LIMIT 4097`).all() as Array<{ project_root: string }>) roots.add(row.project_root);
+    if (roots.size > WORKFLOW_PROJECTION_REBUILD_LIMITS.streams) throw rebuildLimitError("Workflow projection rebuild project limit exceeded");
+    const references: WorkflowJournalReference[] = [];
+    const budget: RebuildBudget = { events: 0, bytes: 0, names: 0, pathBytes: 0 };
+    for (const projectRoot of [...roots].sort()) {
+      const sessionsRoot = join(projectRoot, ".pi", "hive", "sessions");
+      if (!existsSync(sessionsRoot)) continue;
+      const rootStat = lstatSync(sessionsRoot);
+      if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("Workflow projection rebuild sessions root is invalid");
+      const links = listSessionLinks(projectRoot).filter((entry): entry is WorkflowSessionLink => entry.kind === "workflow");
+      const sessions = opendirSync(sessionsRoot);
+      try {
+        for (let entry = sessions.readSync(); entry; entry = sessions.readSync()) {
+          const sessionId = entry.name;
+          const sessionPath = join(sessionsRoot, sessionId);
+          this.accountRebuildName(budget, sessionId, sessionPath);
+          const stat = lstatSync(sessionPath);
+          const journalPath = join(sessionPath, "journal");
+          if (!stat.isDirectory() || stat.isSymbolicLink() || !existsSync(journalPath)) continue;
+          if (references.length >= this.options.rebuildLimits.streams) throw rebuildLimitError("Workflow projection rebuild stream limit exceeded");
+          const journalStat = lstatSync(journalPath);
+          if (!journalStat.isDirectory() || journalStat.isSymbolicLink()) throw new Error("Workflow projection rebuild journal path is invalid");
+          const journal = opendirSync(journalPath);
+          try {
+            for (let eventEntry = journal.readSync(); eventEntry; eventEntry = journal.readSync()) {
+              const eventPath = join(journalPath, eventEntry.name);
+              this.accountRebuildName(budget, eventEntry.name, eventPath);
+              if (!eventEntry.name.endsWith(".json")) continue;
+              const eventStat = lstatSync(eventPath);
+              if (!eventStat.isFile() || eventStat.isSymbolicLink()) throw new Error("Workflow projection rebuild event path is invalid");
+              budget.events += 1;
+              budget.bytes += eventStat.size;
+              if (!Number.isSafeInteger(budget.bytes) || budget.events > this.options.rebuildLimits.events || budget.bytes > this.options.rebuildLimits.bytes) {
+                throw rebuildLimitError("Workflow projection rebuild aggregate event or byte limit exceeded");
+              }
+            }
+          } finally { journal.closeSync(); }
+          const matchingLinks = links.filter((link) => link.workflowSessionId === sessionId);
+          if (matchingLinks.length > 1) throw new Error("Workflow projection rebuild session-link context is ambiguous");
+          references.push(Object.freeze({ projectRoot, sessionId, journalPath, ...(matchingLinks[0] ? { link: matchingLinks[0] } : {}) }));
+        }
+      } finally { sessions.closeSync(); }
+    }
+    return Object.freeze({ references: Object.freeze(references), events: budget.events, bytes: budget.bytes });
+  }
+
+  private readRebuildJournal(reference: WorkflowJournalReference, budget: RebuildBudget): readonly WorkflowEventEnvelope[] {
+    const names: string[] = [];
+    const directory = opendirSync(reference.journalPath);
+    try {
+      for (let entry = directory.readSync(); entry; entry = directory.readSync()) {
+        const path = join(reference.journalPath, entry.name);
+        this.accountRebuildName(budget, entry.name, path);
+        if (!entry.name.endsWith(".json")) continue;
+        budget.events += 1;
+        if (budget.events > this.options.rebuildLimits.events) throw rebuildLimitError("Workflow projection rebuild aggregate event limit changed during replay");
+        names.push(entry.name);
+      }
+    } finally { directory.closeSync(); }
+    names.sort();
+    const output: WorkflowEventEnvelope[] = [];
+    let previous: string | null = null;
+    let projectId: string | undefined;
+    for (const [index, name] of names.entries()) {
+      const path = join(reference.journalPath, name);
+      let descriptor: number | undefined;
+      try {
+        descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+        const before = fstatSync(descriptor, { bigint: true });
+        const remaining = this.options.rebuildLimits.bytes - budget.bytes;
+        if (!before.isFile() || before.size < 1n || before.size > BigInt(WORKFLOW_EVENT_LIMITS.eventBytes) || before.size > BigInt(remaining)) {
+          if (before.size > BigInt(remaining)) throw rebuildLimitError("Workflow projection rebuild aggregate byte limit changed during replay");
+          throw new Error("Workflow projection rebuild event size is invalid");
+        }
+        const bytes = Buffer.alloc(Number(before.size));
+        let offset = 0;
+        while (offset < bytes.length) {
+          const read = readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+          if (read < 1) throw new Error("Workflow projection rebuild event changed during read");
+          offset += read;
+        }
+        const after = fstatSync(descriptor, { bigint: true });
+        if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || before.mtimeNs !== after.mtimeNs || BigInt(bytes.length) !== after.size) throw new Error("Workflow projection rebuild event changed during read");
+        budget.bytes += bytes.length;
+        if (budget.bytes > this.options.rebuildLimits.bytes) throw rebuildLimitError("Workflow projection rebuild aggregate byte limit changed during replay");
+        const event = JSON.parse(bytes.toString("utf8")) as WorkflowEventEnvelope;
+        verifyWorkflowEvent(event);
+        if (event.sequence !== index + 1 || event.previousHash !== previous || event.sessionId !== reference.sessionId || (projectId !== undefined && event.projectId !== projectId)
+          || name !== `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`) throw new Error("Workflow projection rebuild journal chain or identity is corrupt");
+        previous = event.eventHash; projectId = event.projectId; output.push(event);
+      } catch (error) {
+        if ((error as { code?: unknown })?.code === "PROJECTION_REBUILD_LIMIT") throw error;
+        throw new Error(`Workflow projection rebuild journal corruption: ${error instanceof Error ? error.message : String(error)}`);
+      } finally { if (descriptor !== undefined) closeSync(descriptor); }
+    }
+    return Object.freeze(output);
+  }
+
+  rebuild(): Readonly<{ events: number; streams: number; diagnostics: readonly unknown[] }> {
+    const database = this.db();
+    const result = withCrossProcessFileLock(`${database.path}.projection`, () => {
+      // Discovery uses bounded streaming iteration. Replay independently re-accounts
+      // every name, event, and exact bytes read so concurrent growth cannot cross a limit.
+      const sources = this.rebuildSources();
+      const budget: RebuildBudget = { events: 0, bytes: 0, names: 0, pathBytes: 0 };
+      return database.replaceProjectionAtomically(() => {
+        let rebuiltStreams = 0;
+        for (const reference of sources.references) {
+          const source = this.readRebuildJournal(reference, budget);
+          if (!source.length) continue;
+          const link = reference.link;
+          const context = {
+            projectRoot: reference.projectRoot,
+            projectLabel: basename(reference.projectRoot),
+            ...(link ? {
+              piSessionId: link.piSessionId,
+              workflowId: link.workflowId,
+              snapshotId: link.activationHash,
+              workflowConfigHash: link.activationHash,
+              workflowConfigVersion: String(link.formatVersion),
+            } : {}),
+          };
+          const events = source.map((event) => toWorkflowTelemetryEvent(event, context));
+          for (const event of events) database.ingest(event);
+          rebuiltStreams += 1;
+        }
+        return Object.freeze({ events: budget.events, streams: rebuiltStreams, diagnostics: Object.freeze([]) });
+      });
+    }, { timeoutMs: 30_000, staleMs: 120_000 });
+    invalidateWorkflowSubscribers("projection-rebuild");
+    return result;
+  }
+  prune(cutoff: string) {
+    const result = this.db().pruneProjection(cutoff);
+    invalidateWorkflowSubscribers("projection-prune");
+    return result;
+  }
+}
+
+function selectedArtifact(snapshot: ActivationSnapshotFileV1): ResolvedArtifactProfile {
+  const workflow = snapshot.payload.workflow as { artifact?: unknown };
+  if (!record(workflow.artifact)) throw new Error("Activation snapshot has no artifact profile");
+  const artifact = workflow.artifact;
+  if (typeof artifact.contractVersion !== "string" || typeof artifact.adapter !== "string" || typeof artifact.adapterVersion !== "string"
+    || typeof artifact.profile !== "string" || typeof artifact.profileVersion !== "string" || typeof artifact.optionsSchemaVersion !== "string"
+    || artifact.viewVersion !== 1 || !Array.isArray(artifact.checkpoints) || !Array.isArray(artifact.actionIds)) throw new Error("Activation snapshot artifact selection is invalid");
+  const resolved = BUILTIN_ARTIFACT_REGISTRY.resolveProfile({ contractVersion: artifact.contractVersion, adapterId: artifact.adapter, adapterVersion: artifact.adapterVersion, profileId: artifact.profile, profileVersion: artifact.profileVersion });
+  if (resolved.profile.optionsSchemaVersion !== artifact.optionsSchemaVersion || resolved.profile.viewVersion !== artifact.viewVersion
+    || canonicalJson(resolved.profile.checkpointIds) !== canonicalJson(artifact.checkpoints)
+    || canonicalJson(resolved.profile.actions.map((action) => action.id)) !== canonicalJson(artifact.actionIds)) throw new Error("Activation snapshot artifact profile identity is incompatible");
+  return resolved;
+}
+function checkpointPolicies(snapshot: ActivationSnapshotFileV1, selected: ResolvedArtifactProfile): Readonly<Record<string, CheckpointPolicy>> {
+  const artifact = (snapshot.payload.workflow as { artifact?: unknown }).artifact;
+  if (!record(artifact) || !record(artifact.approvals)) throw new Error("Activation snapshot checkpoint policies are invalid");
+  const output: Record<string, CheckpointPolicy> = {};
+  for (const checkpointId of selected.profile.checkpointIds) {
+    const policy = artifact.approvals[checkpointId];
+    if (policy !== "required" && policy !== "optional" && policy !== "none") throw new Error("Activation snapshot checkpoint policy is invalid");
+    output[checkpointId] = policy;
+  }
+  if (Object.keys(artifact.approvals).some((checkpointId) => !selected.profile.checkpointIds.includes(checkpointId))) throw new Error("Activation snapshot checkpoint policy is unknown");
+  return Object.freeze(output);
+}
+function snapshotFor(authority: SessionAuthority): ActivationSnapshotFileV1 {
+  const links = listSessionLinks(authority.projectRoot).filter((entry): entry is import("../../workflows/sessions").WorkflowSessionLink => entry.kind === "workflow" && entry.workflowSessionId === authority.sessionId);
+  if (links.length !== 1) throw new Error("Exact workflow session activation link is missing");
+  return readActivationSnapshot(authority.projectRoot, links[0].activationHash);
+}
+
+class ProductionWorkflowControls implements WorkflowControlApi {
+  constructor(private readonly projection: ProductionWorkflowProjection, private readonly token: string) {}
+  private identity(credential: unknown): string | undefined { return credential === this.token ? "local-dashboard" : undefined; }
+  readQuestion(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    const runId = id(input.runId, "runId");
+    const question = new QuestionService({ ...authority, runId, snapshot: snapshotFor(authority), authenticateControl: () => undefined }).restore().questions[id(input.questionId, "questionId")];
+    if (!question || question.runId !== runId) throw new Error("Exact question object is missing");
+    return question;
+  }
+  readCheckpoint(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    const runId = id(input.runId, "runId");
+    const snapshot = snapshotFor(authority);
+    const selected = selectedArtifact(snapshot);
+    const service = this.checkpointService(authority, snapshot, selected);
+    const request = service.restore().requests[id(input.requestId, "requestId")];
+    if (!request || request.runId !== runId) throw new Error("Exact approval request object is missing");
+    return request;
+  }
+  readKnowledge(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    return new KnowledgeProposalService({ ...authority, authenticateControl: () => undefined }).detail({ projectId: authority.projectId, sessionId: authority.sessionId, runId: id(input.runId, "runId"), proposalId: id(input.proposalId, "proposalId") });
+  }
+  answerQuestion(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    const runId = id(input.runId, "runId");
+    return new QuestionService({ ...authority, runId, snapshot: snapshotFor(authority), authenticateControl: (request) => this.identity(request.credential) }).answer(input as never);
+  }
+  private checkpointService(authority: SessionAuthority, snapshot: ActivationSnapshotFileV1, selected: ResolvedArtifactProfile): CheckpointApprovalService {
+    return new CheckpointApprovalService({
+      ...authority, adapterId: selected.adapter.id, adapterVersion: selected.adapter.version, profileId: selected.profile.id, profileVersion: selected.profile.version,
+      profileSchemaVersion: selected.profile.optionsSchemaVersion, checkpointPolicies: checkpointPolicies(snapshot, selected),
+      ...(selected.adapter.checkpointDescriptor ? { resolveDescriptor: ({ checkpointId, binding }: { checkpointId: string; binding: import("../../artifacts/types").ArtifactWorkspaceBinding }) => {
+        if (!binding.path) throw new Error("Physical checkpoint descriptor requires a bound workspace path");
+        return selected.adapter.checkpointDescriptor!({ binding, checkpointId, hashes: hashArtifactWorkspace(binding.path) });
+      } } : {}),
+      authenticateControl: ({ credential }) => this.identity(credential) ? { approverId: "local-dashboard", authenticationId: "daemon-token", mechanism: "bearer-csrf" } : undefined,
+    });
+  }
+  async decideCheckpoint(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    const runId = id(input.runId, "runId");
+    const snapshot = snapshotFor(authority);
+    const selected = selectedArtifact(snapshot);
+    const service = this.checkpointService(authority, snapshot, selected);
+    const { projectId: _projectId, sessionId: _sessionId, runId: _runId, credential, ...decision } = input;
+    const current = service.restore().requests[id(input.requestId, "requestId")];
+    if (!current || current.runId !== runId) throw new Error("Exact approval request object is missing");
+    return service.decide(decision as never, { channel: "dashboard", mode: "headless", dashboardAvailable: true, credential });
+  }
+  decideKnowledge(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    id(input.runId, "runId");
+    return new KnowledgeProposalService({ ...authority, authenticateControl: (request) => this.identity(request.credential) }).decide(input as never);
+  }
+  rebuildProjection(_input: Record<string, unknown>) { return this.projection.rebuild(); }
+  pruneProjection(input: Record<string, unknown>) { return this.projection.prune(finiteTimestamp(input.cutoff, "projection cutoff")); }
+  pruneJournal(input: Record<string, unknown>) {
+    const authority = this.projection.authority(id(input.projectId, "projectId"), id(input.sessionId, "sessionId"));
+    return createWorkflowJournalPruneService({ authenticate: (credential) => this.identity(credential) }).prune({
+      projectRoot: authority.projectRoot, sessionId: authority.sessionId, credential: String(input.credential ?? ""),
+      operationId: id(input.operationId, "operationId"), confirmIrrecoverable: input.confirmIrrecoverable === true,
+    });
+  }
+}
+
+export function createProductionWorkflowApiOptions(options: ProductionWorkflowServiceOptions = {}): WorkflowApiOptions {
+  const token = options.token ?? DAEMON_TOKEN;
+  const projection = new ProductionWorkflowProjection({
+    databasePath: options.databasePath ?? WORKFLOW_DB_PATH,
+    legacyPaths: options.legacyPaths ?? [DB_PATH, REGISTRY_PATH],
+    projectCwd: options.projectCwd ?? PROJECT_CWD,
+    diagnostics: options.diagnostics ?? readWorkflowProjectionRuntimeDiagnostics,
+    rebuildLimits: effectiveRebuildLimits(options.rebuildLimits),
+    ...(options.streamLimits ? { streamLimits: options.streamLimits } : {}),
+  });
+  return Object.freeze({ token, projection, controls: new ProductionWorkflowControls(projection, token) });
+}

--- a/src/shared/daemon-protocol.ts
+++ b/src/shared/daemon-protocol.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-export const DAEMON_PROTOCOL_VERSION = 1;
+export const DAEMON_PROTOCOL_VERSION = 2;
 
 export interface DaemonIdentity {
   protocolVersion: number;

--- a/src/shared/dashboard-api.ts
+++ b/src/shared/dashboard-api.ts
@@ -14,6 +14,22 @@ import type {
 
 export const WORKFLOW_DASHBOARD_API_VERSION = 1 as const;
 export const WORKFLOW_DASHBOARD_MAX_PAGE_SIZE = 500 as const;
+export const WORKFLOW_DASHBOARD_MAX_BODY_BYTES = 65_536 as const;
+
+export type WorkflowDashboardResource = "projects" | "workflows" | "sessions" | "runs" | "nodes" | "tasks" | "artifacts" | "checkpoints" | "questions" | "approvals" | "knowledge";
+
+export interface WorkflowDashboardResourcePage {
+  readonly apiVersion: 1;
+  readonly resource: WorkflowDashboardResource;
+  readonly items: readonly WorkflowProjectionCurrentRow[];
+  readonly nextCursor?: string;
+  readonly hasMore: boolean;
+}
+
+export interface WorkflowDashboardError {
+  readonly apiVersion: 1;
+  readonly error: Readonly<{ code: string; message: string }>;
+}
 
 export interface WorkflowDashboardHistoryPage {
   readonly apiVersion: 1;
@@ -52,6 +68,8 @@ export interface WorkflowDashboardProjectionMaintenance {
 
 export interface DashboardBootstrap {
   token: string | null;
+  /** The v1 browser client echoes this only in the custom CSRF header. */
+  csrfToken?: string | null;
   bootCwd: string | null;
 }
 

--- a/tests/dashboard/dashboard.test.ts
+++ b/tests/dashboard/dashboard.test.ts
@@ -473,7 +473,7 @@ test("token reads and IPv6 dashboard URLs fail safely", () => {
   }
 });
 
-test("host and port validation fail closed; non-loopback requires dangerous opt-in", () => {
+test("host and port validation fail closed and non-loopback is always refused", () => {
   process.env.HIVE_TELEMETRY_PORT = "NaN";
   assert.throws(() => dashboardPort(), /Invalid HIVE_TELEMETRY_PORT/);
   process.env.HIVE_TELEMETRY_PORT = "70000";
@@ -483,7 +483,7 @@ test("host and port validation fail closed; non-loopback requires dangerous opt-
   process.env.HIVE_TELEMETRY_HOST = "0.0.0.0";
   assert.throws(() => dashboardHost(), /Refusing non-loopback/);
   process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK = "1";
-  assert.equal(dashboardHost(), "0.0.0.0");
+  assert.throws(() => dashboardHost(), /loopback-only|Refusing non-loopback/);
   delete process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK;
   process.env.HIVE_TELEMETRY_HOST = "http://evil";
   assert.throws(() => dashboardHost(), /Invalid HIVE_TELEMETRY_HOST/);

--- a/tests/knowledge/knowledge-proposals.test.ts
+++ b/tests/knowledge/knowledge-proposals.test.ts
@@ -200,22 +200,23 @@ test("reviewed proposals use authenticated exact CAS; approval, denial, replay, 
   });
   const pending = service.create(f.update);
   assert.equal(pending.state, "pending");
-  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "model-attempt", channel: "model" as never, claimedIdentity: "model", credential: "secret" }), /channel|dashboard|human/i);
-  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "unauth", channel: "dashboard", claimedIdentity: "human", credential: "wrong" }), /auth/i);
+  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "model-attempt", channel: "model" as never, claimedIdentity: "model", credential: "secret" }), /channel|dashboard|human/i);
+  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "unauth", channel: "dashboard", claimedIdentity: "human", credential: "wrong" }), /auth/i);
 
-  const approved = service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "decision-1", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", runId: "wrong-run", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "wrong-run-decision", channel: "dashboard", claimedIdentity: "human", credential: "secret" }), /exact|identity|missing/i);
+  const approved = service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "decision-1", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   assert.equal(approved.state, "approved");
   assert.equal(approved.decision?.identity, "human");
-  const replay = service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "decision-1", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  const replay = service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "decision-1", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   assert.deepEqual(replay, approved);
-  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "deny", operationId: "decision-2", channel: "dashboard", claimedIdentity: "other", credential: "secret" }), /CAS|decided|pending/i);
+  assert.throws(() => service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "deny", operationId: "decision-2", channel: "dashboard", claimedIdentity: "other", credential: "secret" }), /CAS|decided|pending/i);
   const applied = await service.applyApproved(pending.proposalId, new OkfKnowledgeMutator({ projectRoot: f.projectRoot, snapshot: snapshot("reviewed"), mutationQueue: mutationQueue([]) }));
   assert.equal(applied.state, "applied");
   assert.equal(applied.applied?.updateId, "update-1");
   assert.deepEqual(await service.applyApproved(pending.proposalId, new OkfKnowledgeMutator({ projectRoot: f.projectRoot, snapshot: snapshot("reviewed"), mutationQueue: mutationQueue([]) })), applied);
 
   const deniedPending = service.create(authorizeUpdate(f, "update-2", "job-2", "candidate-2", "A second reviewed conclusion can be denied independently."));
-  assert.equal(service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: deniedPending.proposalId, expectedState: "pending", decision: "deny", operationId: "decision-3", channel: "dashboard", claimedIdentity: "human", credential: "secret" }).state, "denied");
+  assert.equal(service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-2", proposalId: deniedPending.proposalId, expectedState: "pending", decision: "deny", operationId: "decision-3", channel: "dashboard", claimedIdentity: "human", credential: "secret" }).state, "denied");
   const restored = restoreKnowledgeProposalState(readWorkflowJournal(f.projectRoot, "session-1"));
   assert.deepEqual(Object.values(restored.proposals).map((entry) => entry.state), ["applied", "denied"]);
 });
@@ -225,7 +226,7 @@ test("proposal decision replay recomputes the authenticated request hash and rej
   const service = new KnowledgeProposalService({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", createProposalId: () => "proposal-hash",
     authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined });
   const pending = service.create(f.update);
-  service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "hash-decision", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "hash-decision", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   const tampered = readWorkflowJournal(f.projectRoot, "session-1").map((event) => (event.payload as any).operation === "proposal-decided"
     ? ({ ...event, payload: { ...(event.payload as any), decision: { ...(event.payload as any).decision, requestHash: `sha256:${"9".repeat(64)}` } } })
     : event);
@@ -244,7 +245,7 @@ test("concurrent same-process exact applyApproved calls return the one durable a
     authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
   });
   service.create(f.update);
-  service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: "proposal-apply-race", expectedState: "pending", decision: "approve", operationId: "approve-apply-race", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: "proposal-apply-race", expectedState: "pending", decision: "approve", operationId: "approve-apply-race", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   const apply = () => service.applyApproved("proposal-apply-race", new OkfKnowledgeMutator({ projectRoot: f.projectRoot, snapshot: snapshot("reviewed"), mutationQueue: mutationQueue([]) }));
   const [first, second] = await Promise.all([apply(), apply()]);
   assert.equal(first.state, "applied");
@@ -263,7 +264,7 @@ test("proposal application publishes the authoritative mutation-committed result
     authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
   });
   service.create(f.update);
-  service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: "proposal-authoritative-result", expectedState: "pending", decision: "approve", operationId: "approve-authoritative-result", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: "proposal-authoritative-result", expectedState: "pending", decision: "approve", operationId: "approve-authoritative-result", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   let committed!: () => void;
   const didCommit = new Promise<void>((resolve) => { committed = resolve; });
   let release!: () => void;
@@ -293,7 +294,7 @@ test("concurrent cross-process exact applyApproved calls are idempotent by propo
     authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
   });
   service.create(f.update);
-  service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: "proposal-cross-apply", expectedState: "pending", decision: "approve", operationId: "approve-cross-apply", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: "proposal-cross-apply", expectedState: "pending", decision: "approve", operationId: "approve-cross-apply", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   const run = () => new Promise<{ code: number | null; output: string; error: string }>((resolve) => {
     const script = `
       import { KnowledgeProposalService, OkfKnowledgeMutator } from './src/knowledge/proposals.ts';
@@ -349,7 +350,7 @@ test("decision DTOs are exact and operation replay is session-wide", () => {
   });
   const first = service.create(f.update);
   const second = service.create(authorizeUpdate(f, "update-2", "job-2", "candidate-2", "A second stable proposal exists for replay checks."));
-  const request = { projectId: "project-1", sessionId: "session-1", proposalId: first.proposalId, expectedState: "pending" as const, decision: "approve" as const, operationId: "global-operation", channel: "dashboard" as const, claimedIdentity: "human", credential: "secret" };
+  const request = { projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: first.proposalId, expectedState: "pending" as const, decision: "approve" as const, operationId: "global-operation", channel: "dashboard" as const, claimedIdentity: "human", credential: "secret" };
   service.decide(request);
   assert.throws(() => service.decide({ ...request, proposalId: second.proposalId }), /operation.*replay|reuse|conflict/i);
   assert.throws(() => service.decide({ ...request, injectedAuthority: true } as never), /unknown|schema|field/i);
@@ -367,7 +368,9 @@ test("proposal status/detail DTOs are exact, bounded, and cursor paginated", () 
   assert.equal(first.total, 2);
   assert.ok(first.nextCursor);
   assert.equal(service.status({ projectId: "project-1", sessionId: "session-1", state: "pending", limit: 1, cursor: first.nextCursor }).items.length, 1);
-  assert.equal(service.detail({ projectId: "project-1", sessionId: "session-1", proposalId: first.items[0].proposalId }).proposalId, first.items[0].proposalId);
+  assert.equal(service.detail({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: first.items[0].proposalId }).proposalId, first.items[0].proposalId);
+  assert.throws(() => service.detail({ projectId: "project-1", sessionId: "session-1", runId: "wrong-run", proposalId: first.items[0].proposalId }), /exact|identity|missing/i);
+  assert.throws(() => service.detail({ projectId: "project-1", sessionId: "session-1", proposalId: first.items[0].proposalId } as never), /unknown|schema|field/i);
   assert.throws(() => service.status({ projectId: "project-1", sessionId: "session-1", limit: 1, authority: true } as never), /unknown|schema|field/i);
 });
 
@@ -376,7 +379,7 @@ test("cross-process approve/deny CAS elects one decision and replays only its ex
   const service = new KnowledgeProposalService({ projectRoot: f.projectRoot, projectId: "project-1", sessionId: "session-1", createProposalId: () => "proposal-race", authenticateControl: () => undefined });
   service.create(f.update);
   const run = (decision: "approve" | "deny", operationId: string) => new Promise<{ code: number | null; output: string }>((resolve) => {
-    const request = { projectId: "project-1", sessionId: "session-1", proposalId: "proposal-race", expectedState: "pending", decision, operationId, channel: "dashboard", claimedIdentity: "human", credential: "secret" };
+    const request = { projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: "proposal-race", expectedState: "pending", decision, operationId, channel: "dashboard", claimedIdentity: "human", credential: "secret" };
     const script = `
       import { KnowledgeProposalService } from './src/knowledge/proposals.ts';
       const service = new KnowledgeProposalService({ projectRoot: ${JSON.stringify(f.projectRoot)}, projectId: 'project-1', sessionId: 'session-1', authenticateControl: (request) => request.credential === 'secret' ? request.claimedIdentity : undefined });
@@ -639,7 +642,7 @@ test("proposal-applied reducer independently requires the exact prior mutation c
     authenticateControl: (request) => request.credential === "secret" ? request.claimedIdentity : undefined,
   });
   const pending = service.create(f.update);
-  const approved = service.decide({ projectId: "project-1", sessionId: "session-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "approve-forged-application", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
+  const approved = service.decide({ projectId: "project-1", sessionId: "session-1", runId: "run-job-1", proposalId: pending.proposalId, expectedState: "pending", decision: "approve", operationId: "approve-forged-application", channel: "dashboard", claimedIdentity: "human", credential: "secret" });
   const forged = createWorkflowEvent({
     projectId: "project-1", sessionId: "session-1", runId: "run-1", type: "knowledge.transition", producer: "harness", correlationId: f.update.updateId,
     payload: { formatVersion: 1, operation: "proposal-applied", proposalId: pending.proposalId, updateHash: approved.updateHash, decisionOperationId: approved.decision!.operationId,

--- a/tests/observability/server-routes.spec.ts
+++ b/tests/observability/server-routes.spec.ts
@@ -15,7 +15,7 @@ mkdirSync(fallbackAgentDir, { recursive: true });
 const fallbackEnv: Record<string, string> = {
   HIVE_TELEMETRY_HOST: "127.0.0.1",
   HIVE_TELEMETRY_PORT: "43217",
-  HIVE_TELEMETRY_TOKEN: "dashboard-handler-test-token",
+  HIVE_TELEMETRY_TOKEN: "dashboard-handler-test-token-with-entropy",
   HIVE_DAEMON_STARTUP_NONCE: "dashboard-handler-startup",
   HIVE_PROJECT_CWD: fallbackProject,
   HIVE_TELEMETRY_DB: join(root, "telemetry.db"),

--- a/tests/observability/workflow-daemon-security.test.ts
+++ b/tests/observability/workflow-daemon-security.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { dashboardHost } from "../../src/engine/dashboard.ts";
+
+const priorHost = process.env.HIVE_TELEMETRY_HOST;
+const priorOverride = process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK;
+afterEach(() => {
+  if (priorHost === undefined) delete process.env.HIVE_TELEMETRY_HOST; else process.env.HIVE_TELEMETRY_HOST = priorHost;
+  if (priorOverride === undefined) delete process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK; else process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK = priorOverride;
+});
+
+test("first-release dashboard binding cannot be widened by an environment override", () => {
+  process.env.HIVE_TELEMETRY_HOST = "192.168.1.9";
+  process.env.HIVE_TELEMETRY_ALLOW_NON_LOOPBACK = "1";
+  assert.throws(() => dashboardHost(), /non-loopback/i);
+});
+
+test("dashboard accepts only explicit loopback host spellings", () => {
+  for (const host of ["127.0.0.1", "localhost", "::1", "[::1]"]) {
+    process.env.HIVE_TELEMETRY_HOST = host;
+    assert.ok(["127.0.0.1", "localhost", "::1"].includes(dashboardHost()));
+  }
+});

--- a/tests/observability/workflow-dashboard-api.test.ts
+++ b/tests/observability/workflow-dashboard-api.test.ts
@@ -2,10 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   WORKFLOW_DASHBOARD_API_VERSION,
+  WORKFLOW_DASHBOARD_MAX_BODY_BYTES,
   WORKFLOW_DASHBOARD_MAX_PAGE_SIZE,
 } from "../../src/shared/dashboard-api.ts";
+import { DAEMON_PROTOCOL_VERSION } from "../../src/shared/daemon-protocol.ts";
 
 test("workflow dashboard DTO contract is versioned and bounded for W25 consumers", () => {
+  assert.equal(DAEMON_PROTOCOL_VERSION, 2);
   assert.equal(WORKFLOW_DASHBOARD_API_VERSION, 1);
   assert.equal(WORKFLOW_DASHBOARD_MAX_PAGE_SIZE, 500);
+  assert.equal(WORKFLOW_DASHBOARD_MAX_BODY_BYTES, 65_536);
 });

--- a/tests/observability/workflow-production-integration.spec.ts
+++ b/tests/observability/workflow-production-integration.spec.ts
@@ -1,0 +1,436 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hashActivationPayload } from "../../src/config/snapshot-canonical";
+import { writeActivationSnapshot } from "../../src/config/snapshot-store";
+import type { ActivationSnapshotFileV1 } from "../../src/config/snapshot";
+import { createDashboardHttpHandler } from "../../src/observability/server/http-handler";
+import { createProductionWorkflowApiOptions, type ProductionWorkflowServiceOptions } from "../../src/observability/server/workflow-service";
+import { createConfiguredWorkflowProjectionSynchronizer } from "../../src/observability/server/workflow-runtime";
+import { broadcastWorkflowEvent, closeAllSubscribers, hasLiveSubscribers } from "../../src/observability/server/sse";
+import { DAEMON_TOKEN, expectedHostHeader } from "../../src/observability/server/config";
+import { toWorkflowTelemetryEvent } from "../../src/observability/events";
+import { encodeWorkflowHistoryCursor } from "../../src/observability/projection";
+import { CheckpointApprovalService } from "../../src/artifacts/approvals";
+import { createMarkdownPlanAdapter, MARKDOWN_PLAN_PROFILES } from "../../src/artifacts/adapters/markdown-plan";
+import { hashArtifactWorkspace } from "../../src/artifacts/hashes";
+import { WorkspaceLeaseRuntime } from "../../src/artifacts/leases";
+import { bindPhysicalArtifactWorkspace } from "../../src/artifacts/workspaces";
+import { DelegationRuntime } from "../../src/workflows/delegation";
+import { QuestionService } from "../../src/workflows/questions";
+import { appendWorkflowEvent, readWorkflowJournal } from "../../src/workflows/journal";
+import { createWorkflowEvent, sealWorkflowEvent } from "../../src/workflows/events";
+import { WorkflowRunLifecycle } from "../../src/workflows/runs";
+import { upsertWorkflowLink } from "../../src/workflows/sessions";
+import { hashAttemptInput } from "../../src/workflows/attempts";
+import { loadOkfBundle } from "../../src/knowledge/okf";
+import { parseCuratorOutput } from "../../src/knowledge/curator";
+import { createCuratorPlan } from "../../src/knowledge/enrichment";
+import { KnowledgeProposalService } from "../../src/knowledge/proposals";
+
+const projectId = "project-production";
+const questionSession = "session-question";
+const knowledgeSession = "session-knowledge";
+const pruneSession = "session-prune";
+const approvalSession = "session-approval";
+const approvalRunId = "run-approval";
+const runId = "run-question";
+
+function snapshot(): ActivationSnapshotFileV1 {
+  const effective = { filesystem: [], shell: [], git: false, "external-network": false, "human-input": true, artifact: [], knowledge: [] };
+  const provenance = { filesystem: ["agent-ceiling", "workflow-node-omitted-deny"], shell: ["agent-ceiling", "workflow-node-omitted-deny"], git: ["agent-ceiling", "workflow-node-omitted-deny"], "external-network": ["agent-ceiling", "workflow-node-omitted-deny"], "human-input": ["agent-ceiling", "workflow-node"], artifact: ["agent-ceiling", "workflow-node-omitted-deny"], knowledge: ["agent-ceiling", "workflow-node-omitted-deny"] };
+  const payload = {
+    versions: { snapshot: 1, packageContract: "pi-hive-package-contract-v1", schema: 1, capability: 1, catalogHash: "pi-hive-catalog-hash-v1", artifact: "pi-hive-artifact-contract-v1", contextPolicy: "pi-hive-context-policy-v1", package: "0.1.0" },
+    project: { projectId, rootRef: "." },
+    workflow: { id: "production", artifact: { adapter: "markdown-plan", adapterVersion: "1", profile: "author", profileVersion: "1", binding: "new", options: {}, optionsSchemaVersion: "1", contractVersion: "pi-hive-artifact-contract-v1", checkpoints: ["plan"], actionIds: MARKDOWN_PLAN_PROFILES.author.actions.map((action) => action.id), viewVersion: 1, approvals: { plan: "required" } }, team: { rootId: "root", nodes: [
+      { id: "root", agentId: "lead", memberIds: ["worker"], capabilities: { "human-input": true }, responsibilities: [], skills: { resolved: [] }, knowledge: { resolved: [] }, budgets: {} },
+      { id: "worker", agentId: "worker-agent", parentId: "root", memberIds: [], capabilities: { "human-input": true }, responsibilities: [], skills: { resolved: [] }, knowledge: { resolved: [] }, budgets: {} },
+    ] } },
+    agents: [
+      { id: "lead", name: "Lead", tags: [], frontmatter: { capabilities: { "human-input": true } }, prompt: "lead", sourceHash: "a".repeat(64), canonicalSourceHash: "b".repeat(64), promptHash: "c".repeat(64) },
+      { id: "worker-agent", name: "Worker", tags: [], frontmatter: { capabilities: { "human-input": true } }, prompt: "worker", sourceHash: "d".repeat(64), canonicalSourceHash: "e".repeat(64), promptHash: "f".repeat(64) },
+    ],
+    skills: [], knowledge: [],
+    authority: { capabilityContractVersion: 1, nodes: [
+      { nodeId: "root", capabilities: { effective, provenance, budgets: {}, attachments: { skills: [], knowledge: [] }, directMemberIds: ["worker"] }, tools: ["delegate_agent", "human_question", "route_agent", "team_status", "workflow_finish", "workflow_status"] },
+      { nodeId: "worker", capabilities: { effective, provenance, budgets: {}, attachments: { skills: [], knowledge: [] }, directMemberIds: [] }, tools: ["human_question"] },
+    ] },
+    models: [
+      { nodeId: "root", modelId: "provider/model", thinking: "off", staticTokens: 8192, dynamicReserve: 20000, contextWindow: 100000 },
+      { nodeId: "worker", modelId: "provider/model", thinking: "off", staticTokens: 8192, dynamicReserve: 20000, contextWindow: 100000 },
+    ],
+    sources: [],
+  } as any;
+  return { snapshotHash: hashActivationPayload(payload), createdAt: "2026-01-01T00:00:00.000Z", payload };
+}
+
+function link(projectRoot: string, sessionId: string, activationHash: string, workflowId: string) {
+  upsertWorkflowLink(projectRoot, {
+    kind: "workflow", formatVersion: 1, workflowSessionId: sessionId, workflowId, activationHash,
+    piSessionId: `pi-${sessionId}`, piSessionFile: join(projectRoot, `${sessionId}.jsonl`), normalParentId: "normal", normalParentFile: join(projectRoot, "normal.jsonl"),
+    status: "current", stale: false, model: "provider/model", thinking: "off", tools: [], createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z", name: `hive:${workflowId}`,
+  });
+}
+
+function seedKnowledgeProposal(projectRoot: string): void {
+  const questionSession = knowledgeSession;
+  const root = join(projectRoot, ".pi", "hive", "knowledge", "project");
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "existing.md"), "---\ntype: Knowledge\ntitle: Existing\n---\n\nExisting architecture.\n");
+  const declaration = { id: "project", providerId: "okf", path: ".pi/hive/knowledge/project", updatePolicy: "reviewed" } as const;
+  const loaded = loadOkfBundle({ projectRoot, declaration });
+  if (!loaded.ok) throw new Error("knowledge fixture did not load");
+  const expectedContentHash = `sha256:${loaded.bundle!.contentHash}`;
+  const sourceHash = `sha256:${createHash("sha256").update("production-source").digest("hex")}`;
+  const evidence = appendWorkflowEvent(projectRoot, createWorkflowEvent({ eventId: "knowledge-evidence", projectId, sessionId: questionSession, runId: "run-knowledge", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1, nodeId: "root", sourceHashes: [sourceHash] }, timestamp: "2026-01-01T00:00:03.000Z" }));
+  const conclusion = "Production dashboard decisions retain exact durable provenance.";
+  const candidate = { formatVersion: 1 as const, candidateId: "candidate-production", projectId, sessionId: questionSession, runId: "run-knowledge", nodeId: "root", agentId: "lead", scope: "shared" as const, conclusion, requestHash: hashAttemptInput({ scope: "shared", conclusion, evidenceEventIds: [evidence.eventId] }), citations: [{ eventId: evidence.eventId, eventHash: evidence.eventHash, payloadHash: evidence.payloadHash, sequence: evidence.sequence, type: evidence.type }], sourceHashes: [sourceHash], createdAt: "2026-01-01T00:00:03.000Z" };
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: questionSession, runId: "run-knowledge", type: "knowledge.transition", producer: "runtime", correlationId: "candidate-attempt", attemptId: "candidate-attempt", payload: { formatVersion: 1, operation: "candidate-recorded", candidate } as never, timestamp: candidate.createdAt }));
+  const terminal = appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: questionSession, runId: "run-knowledge", type: "terminal.recorded", producer: "harness", payload: { formatVersion: 1, status: "completed" }, timestamp: "2026-01-01T00:00:04.000Z" }));
+  const target = { bundleId: "project", providerId: "okf", path: ".pi/hive/knowledge/project", policy: "reviewed" as const, expectedContentHash };
+  const job = { formatVersion: 1 as const, jobId: "job-production", projectId, sessionId: questionSession, runId: "run-knowledge", terminalEventHash: terminal.eventHash, scope: "shared" as const, candidateIds: [candidate.candidateId], targets: [target], model: { nodeId: "root", modelId: "provider/model", thinking: "off", reason: "agent-lowest-participating-node;shared-workflow-root" as const }, state: "queued" as const, attemptCount: 0, staleReevaluations: 0, createdAt: "2026-01-01T00:00:04.000Z", updatedAt: "2026-01-01T00:00:04.000Z" };
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: questionSession, runId: "run-knowledge", type: "knowledge.transition", producer: "harness", payload: { formatVersion: 1, operation: "jobs-enqueued", terminalEventHash: terminal.eventHash, preservedCancelled: false, jobs: [job] } as never }));
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: questionSession, runId: "run-knowledge", type: "knowledge.transition", producer: "harness", correlationId: "knowledge-job-job-production", payload: { formatVersion: 1, operation: "job-transition", jobId: job.jobId, from: "queued", to: "active", attemptCount: 1, staleReevaluations: 0, reason: "production test", ownerNonce: "owner-production" } }));
+  const output = parseCuratorOutput(JSON.stringify({ formatVersion: 1, conclusions: [{ text: conclusion, citationIds: [candidate.candidateId] }] }), [candidate]);
+  const citations = [{ candidateId: candidate.candidateId, eventId: evidence.eventId, eventHash: evidence.eventHash, payloadHash: evidence.payloadHash, sourceHashes: [sourceHash] }];
+  const update = { formatVersion: 1 as const, updateId: "update-production", jobId: job.jobId, projectId, sessionId: questionSession, runId: "run-knowledge", bundleId: "project", providerId: "okf", expectedContentHash, curatorOutputHash: output.outputHash, conclusions: output.conclusions.map((entry) => ({ text: entry.text, citations })), createdAt: "2026-01-01T00:00:05.000Z" };
+  const plan = createCuratorPlan({ jobId: job.jobId, evaluation: 0, targets: [target], output, actions: [{ kind: "proposal", bundleId: "project", reason: "reviewed-policy", update }], createdAt: update.createdAt });
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ projectId, sessionId: questionSession, runId: "run-knowledge", type: "knowledge.transition", producer: "harness", correlationId: `curator-plan-${job.jobId}`, payload: { formatVersion: 1, operation: "curator-plan-recorded", jobId: job.jobId, ownerNonce: "owner-production", plan } as never, timestamp: plan.createdAt }));
+  new KnowledgeProposalService({ projectRoot, projectId, sessionId: questionSession, createProposalId: () => "proposal-production", authenticateControl: () => undefined }).create(update);
+}
+
+async function setup() {
+  const projectRoot = mkdtempSync(join(tmpdir(), "pi-hive-w25-production-"));
+  const databasePath = join(projectRoot, ".pi", "hive", "workflow.db");
+  const active = snapshot();
+  writeActivationSnapshot(projectRoot, active);
+  writeFileSync(join(projectRoot, ".pi", "hive", "hive-config.yaml"), "schema-version: 1\nagents: {}\nworkflows: {}\n");
+  link(projectRoot, questionSession, active.snapshotHash, "production-question");
+  link(projectRoot, knowledgeSession, active.snapshotHash, "production-knowledge");
+  link(projectRoot, pruneSession, active.snapshotHash, "production-prune");
+  link(projectRoot, approvalSession, active.snapshotHash, "production-approval");
+
+  const delegation = new DelegationRuntime({ projectRoot, projectId, sessionId: questionSession, runId, snapshot: active, createTaskId: () => "task-question" });
+  const task = delegation.accept(delegation.rootExecutionContext(), { targetNodeId: "worker", objective: "Ask the operator", deliverables: [] });
+  delegation.start(task.taskId, "attempt-question");
+  const questions = new QuestionService({ projectRoot, projectId, sessionId: questionSession, runId, snapshot: active, createQuestionId: () => "question-production", authenticateControl: () => undefined });
+  questions.create({ nodeId: "worker", taskId: task.taskId, definition: { prompt: "Continue production deployment?", kind: "confirm", required: true }, provenance: { source: "human_question", toolCallId: "tool-question" } });
+  seedKnowledgeProposal(projectRoot);
+
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ eventId: "prune-run-started", projectId, sessionId: pruneSession, runId: "run-prune", type: "run.started", producer: "runtime", timestamp: "2026-01-01T00:00:01.000Z", payload: { formatVersion: 1, workflowId: "production-prune", status: "running" } }));
+  appendWorkflowEvent(projectRoot, createWorkflowEvent({ eventId: "prune-run-terminal", projectId, sessionId: pruneSession, runId: "run-prune", type: "terminal.recorded", producer: "runtime", timestamp: "2026-01-01T00:00:02.000Z", payload: { formatVersion: 1, status: "completed" } }));
+
+  // Build a real W17 Markdown workspace and W18 durable pending approval. The
+  // production handler later reconstructs this service solely from snapshot + journal.
+  const adapter = createMarkdownPlanAdapter({ now: () => "2026-01-01T00:00:06.000Z" });
+  const created = bindPhysicalArtifactWorkspace({ projectRoot, adapter, profile: MARKDOWN_PLAN_PROFILES.author, runId: approvalRunId, configuredBinding: "new", options: {}, selection: { mode: "new", workspaceId: "production-plan" } });
+  const author = MARKDOWN_PLAN_PROFILES.author.actions.find((action) => action.id === "markdown-plan.plan.author")!;
+  await adapter.executeAction!({
+    binding: created, capabilities: ["read", "write"], hashes: hashArtifactWorkspace(created.path!), operationId: "author-production-plan", expectedWorkspaceHash: created.workspaceHash,
+    enqueueMutation: async <T>(_path: string, callback: () => T | Promise<T>) => callback(), verifyEvidence: () => [],
+  }, author, { title: "Production plan", summary: "Exercise the real durable dashboard approval boundary.", tasks: [{ id: "approve", text: "Approve the production plan" }] });
+  const binding = Object.freeze({ ...created, workspaceHash: hashArtifactWorkspace(created.path!).workspaceHash });
+  const approvalService = new CheckpointApprovalService({
+    projectRoot, projectId, sessionId: approvalSession, adapterId: "markdown-plan", adapterVersion: "1", profileId: "author", profileVersion: "1", profileSchemaVersion: "1",
+    checkpointPolicies: { plan: "required" }, resolveDescriptor: ({ checkpointId, binding: current }) => adapter.checkpointDescriptor!({ binding: current, checkpointId, hashes: hashArtifactWorkspace(current.path!) }),
+    authenticateControl: () => undefined, createRequestId: () => "approval-production",
+  });
+  const lifecycle = new WorkflowRunLifecycle({ projectRoot, projectId, sessionId: approvalSession, snapshotId: active.snapshotHash, rootNodeId: "root", createRunId: () => approvalRunId, createArtifactWorkspace: () => binding, checkpointSnapshots: approvalService.runSnapshotProvider() });
+  lifecycle.recordUserInput({ inputId: "approval-input", text: "Review production plan", source: "interactive" });
+  const approvalLease = new WorkspaceLeaseRuntime({ projectRoot, adapterId: "markdown-plan", workspaceId: binding.workspace.id, sessionId: approvalSession, runId: approvalRunId });
+  if (!approvalLease.acquire().ok) throw new Error("approval fixture lease was not acquired");
+  const approvalWorkspaceHash = hashArtifactWorkspace(binding.path!).workspaceHash;
+  const approvalRequest = await approvalService.requestApproval({ operationId: "request-approval-production", checkpointId: "plan", expectedWorkspaceHash: approvalWorkspaceHash });
+
+  const makeHandler = (overrides: Partial<ProductionWorkflowServiceOptions> = {}) => createDashboardHttpHandler({ workflowApiOptions: createProductionWorkflowApiOptions({ token: DAEMON_TOKEN, databasePath, legacyPaths: [], projectCwd: projectRoot, diagnostics: () => [], ...overrides }) });
+  return { projectRoot, databasePath, makeHandler, approvalService, approvalLease, approvalRequest, approvalWorkspaceHash };
+}
+
+function request(path: string, init: RequestInit = {}): Request {
+  const authority = expectedHostHeader();
+  const headers = new Headers(init.headers);
+  headers.set("host", authority);
+  headers.set("authorization", `Bearer ${DAEMON_TOKEN}`);
+  headers.set("x-pi-hive-api-version", "1");
+  return new Request(`http://${authority}${path}`, { ...init, headers });
+}
+function write(body: unknown): RequestInit {
+  return { method: "POST", headers: { origin: `http://${expectedHostHeader()}`, "content-type": "application/json", "x-pi-hive-csrf": DAEMON_TOKEN }, body: JSON.stringify(body) };
+}
+async function json(handler: ReturnType<typeof createDashboardHttpHandler>, path: string, init: RequestInit = {}) {
+  const response = await handler(request(path, init));
+  return { response, body: await response.json() as any };
+}
+
+async function readAvailableStream(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const chunks: Uint8Array[] = [];
+  for (let index = 0; index < 8; index += 1) {
+    const result = await Promise.race([reader.read(), new Promise<never>((_, reject) => setTimeout(() => reject(new Error("stream did not produce catch-up")), 250))]);
+    if (result.done) break;
+    chunks.push(result.value);
+    const text = new TextDecoder().decode(Buffer.concat(chunks));
+    if (text.includes("event: workflow")) break;
+  }
+  await reader.cancel();
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+test("production dashboard handler closes the control boundary over journals, SQLite, replay, SSE, and legacy routes", async () => {
+  const fixture = await setup();
+  let handler = fixture.makeHandler();
+
+  const legacy = await handler(request("/health"));
+  expect(legacy.status).toBe(200);
+  expect(await legacy.json()).toMatchObject({ ok: true });
+
+  const rebuilt = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "rebuild-production" }));
+  expect(rebuilt.response.status).toBe(200);
+  expect(rebuilt.body.result).toMatchObject({ streams: 4 });
+  expect(rebuilt.body.result.events).toBeGreaterThanOrEqual(5);
+  const workflowFiltered = await json(handler, `/api/v1/history?workflowId=production-question&limit=100`);
+  expect(workflowFiltered.response.status).toBe(200);
+  expect(workflowFiltered.body.items.length).toBeGreaterThan(0);
+  expect(workflowFiltered.body.items.every((event: any) => event.dimensions.workflowId === "production-question" && event.dimensions.workflowConfigVersion === "1")).toBe(true);
+
+  const detail = await json(handler, `/api/v1/questions/question-production?projectId=${projectId}&sessionId=${questionSession}&runId=${runId}`);
+  expect(detail.response.status).toBe(200);
+  expect(detail.body.object).toMatchObject({ questionId: "question-production", state: "pending" });
+
+  const approvalDetail = await json(handler, `/api/v1/approvals/${fixture.approvalRequest.requestId}?projectId=${projectId}&sessionId=${approvalSession}&runId=${approvalRunId}`);
+  expect(approvalDetail.response.status).toBe(200);
+  expect(approvalDetail.body.object).toMatchObject({ requestId: "approval-production", runId: approvalRunId, checkpointId: "plan" });
+  expect(approvalDetail.body.object.decision).toBeUndefined();
+  const approvalDecision = { projectId, sessionId: approvalSession, runId: approvalRunId, requestId: fixture.approvalRequest.requestId, expectedRequestSequence: fixture.approvalRequest.requestSequence, digest: fixture.approvalRequest.digest, expectedWorkspaceHash: fixture.approvalWorkspaceHash, decision: "approved", operationId: "approval-decision-production" };
+  const approvalApproved = await json(handler, "/api/v1/controls/approvals/decide", write(approvalDecision));
+  expect(approvalApproved.response.status, JSON.stringify(approvalApproved.body)).toBe(200);
+  expect(approvalApproved.body.result).toMatchObject({ requestId: "approval-production", decision: "approved", approverId: "local-dashboard", channel: "dashboard" });
+  expect(fixture.approvalService.restore().requests[fixture.approvalRequest.requestId].decision).toMatchObject({ operationId: "approval-decision-production", decision: "approved" });
+  expect(readWorkflowJournal(fixture.projectRoot, approvalSession).some((event) => event.type === "approval.recorded" && (event.payload as any).operation === "decision")).toBe(true);
+
+  const knowledgeDetail = await json(handler, `/api/v1/knowledge/proposal-production?projectId=${projectId}&sessionId=${knowledgeSession}&runId=run-knowledge`);
+  expect(knowledgeDetail.response.status).toBe(200);
+  expect(knowledgeDetail.body.object).toMatchObject({ proposalId: "proposal-production", runId: "run-knowledge", state: "pending" });
+  const wrongKnowledgeRun = await json(handler, `/api/v1/knowledge/proposal-production?projectId=${projectId}&sessionId=${knowledgeSession}&runId=wrong-run`);
+  expect(wrongKnowledgeRun.response.status).toBe(404);
+  const knowledgeDecision = { projectId, sessionId: knowledgeSession, runId: "run-knowledge", proposalId: "proposal-production", expectedState: "pending", decision: "approve", operationId: "knowledge-production", claimedIdentity: "operator" };
+  const knowledgeApproved = await json(handler, "/api/v1/controls/knowledge/decide", write(knowledgeDecision));
+  expect(knowledgeApproved.response.status).toBe(200);
+  expect(knowledgeApproved.body.result).toMatchObject({ proposalId: "proposal-production", state: "approved", decision: { identity: "local-dashboard" } });
+
+  const answer = { projectId, sessionId: questionSession, runId, questionId: "question-production", expectedState: "pending", value: true, operationId: "answer-production", claimedIdentity: "operator" };
+  const answered = await json(handler, "/api/v1/controls/questions/answer", write(answer));
+  expect(answered.response.status, JSON.stringify(answered.body)).toBe(200);
+  expect(answered.body.result).toMatchObject({ state: "answered", answer: { value: true, identity: "local-dashboard" } });
+
+  const sourceEvents = readWorkflowJournal(fixture.projectRoot, questionSession);
+  const firstCursor = encodeWorkflowHistoryCursor(toWorkflowTelemetryEvent(sourceEvents[0], { projectRoot: fixture.projectRoot, workflowId: "production-question" }));
+  const caughtUp = await handler(request("/api/v1/stream", { headers: { "last-event-id": firstCursor } }));
+  expect(caughtUp.status).toBe(200);
+  const streamText = await readAvailableStream(caughtUp);
+  expect(streamText).toContain("event: hello");
+  expect(streamText).toContain("event: workflow");
+  expect(streamText).toContain(sourceEvents[1].eventId);
+
+  const resync = await handler(request("/api/v1/stream", { headers: { "last-event-id": "invalid-cursor" } }));
+  expect(await resync.text()).toContain("event: resync-required");
+
+  const prune = { operationId: "projection-prune-production", cutoff: "2026-01-01T00:00:01.500Z" };
+  const pruned = await json(handler, "/api/v1/maintenance/projection/prune", write(prune));
+  expect(pruned.response.status).toBe(200);
+  handler.dispose();
+
+  handler = fixture.makeHandler();
+  const replayedPrune = await json(handler, "/api/v1/maintenance/projection/prune", write(prune));
+  expect(replayedPrune).toEqual(pruned);
+  const conflictingPrune = await json(handler, "/api/v1/maintenance/projection/prune", write({ ...prune, cutoff: "2026-02-01T00:00:00.000Z" }));
+  expect(conflictingPrune.response.status).toBe(409);
+  expect(conflictingPrune.body.error.code).toBe("OPERATION_CONFLICT");
+
+  const replayedAnswer = await json(handler, "/api/v1/controls/questions/answer", write(answer));
+  expect(replayedAnswer.body).toEqual(answered.body);
+  const replayedApproval = await json(handler, "/api/v1/controls/approvals/decide", write(approvalDecision));
+  expect(replayedApproval.body).toEqual(approvalApproved.body);
+  const conflictingApproval = await json(handler, "/api/v1/controls/approvals/decide", write({ ...approvalDecision, decision: "denied" }));
+  expect(conflictingApproval.response.status).toBe(409);
+  expect(conflictingApproval.body.error.code).toBe("OPERATION_CONFLICT");
+
+  const journalRequest = { projectId, sessionId: pruneSession, operationId: "journal-prune-production", confirmIrrecoverable: true };
+  const journalPruned = await json(handler, "/api/v1/maintenance/journals/prune", write(journalRequest));
+  expect(journalPruned.response.status).toBe(200);
+  expect(journalPruned.body.result).toMatchObject({ sessionId: pruneSession, deletedEvents: 2, authenticatedIdentity: "local-dashboard" });
+  expect(readWorkflowJournal(fixture.projectRoot, pruneSession)).toEqual([]);
+  handler.dispose();
+
+  handler = fixture.makeHandler();
+  const journalReplay = await json(handler, "/api/v1/maintenance/journals/prune", write(journalRequest));
+  expect(journalReplay.body).toEqual(journalPruned.body);
+  handler.dispose();
+  fixture.approvalLease.release();
+});
+
+test("successful production projection maintenance invalidates already-open workflow streams with bounded resync reasons", async () => {
+  closeAllSubscribers();
+  const fixture = await setup();
+  const handler = fixture.makeHandler();
+
+  const rebuildStream = await handler(request("/api/v1/stream"));
+  expect(hasLiveSubscribers()).toBe(true);
+  const rebuilt = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "rebuild-invalidates-stream" }));
+  expect(rebuilt.response.status).toBe(200);
+  const rebuildText = await rebuildStream.text();
+  expect(rebuildText).toContain("event: hello");
+  expect(rebuildText).toContain("event: resync-required");
+  expect(rebuildText).toContain('"reason":"projection-rebuild"');
+  expect(hasLiveSubscribers()).toBe(false);
+
+  const pruneStream = await handler(request("/api/v1/stream"));
+  expect(hasLiveSubscribers()).toBe(true);
+  const pruned = await json(handler, "/api/v1/maintenance/projection/prune", write({ operationId: "prune-invalidates-stream", cutoff: "2026-01-01T00:00:01.500Z" }));
+  expect(pruned.response.status).toBe(200);
+  const pruneText = await pruneStream.text();
+  expect(pruneText).toContain("event: hello");
+  expect(pruneText).toContain("event: resync-required");
+  expect(pruneText).toContain('"reason":"projection-prune"');
+  expect(hasLiveSubscribers()).toBe(false);
+
+  handler.dispose();
+  fixture.approvalLease.release();
+  closeAllSubscribers();
+});
+
+test("production projection rebuild preflights aggregate N/N+1 and streams journals independently", async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), "pi-hive-w25-rebuild-bound-"));
+  const journal = join(projectRoot, ".pi", "hive", "sessions", "aggregate-session", "journal");
+  mkdirSync(journal, { recursive: true });
+  let previous: ReturnType<typeof sealWorkflowEvent> | undefined;
+  const append = (index: number) => {
+    const event = sealWorkflowEvent(createWorkflowEvent({ eventId: `aggregate-${index}`, projectId: "project-aggregate", sessionId: "aggregate-session", runId: "aggregate-run", type: "budget.model.usage.recorded", producer: "harness", timestamp: "2026-01-01T00:00:00.000Z", payload: { formatVersion: 1, nodeId: "root", usage: { inputTokens: 1, outputTokens: 1, costMicroUsd: 1, precision: "estimated" } } }), index, previous?.eventHash ?? null);
+    previous = event;
+    writeFileSync(join(journal, `${String(event.sequence).padStart(16, "0")}-${event.eventHash}.json`), `${JSON.stringify(event)}\n`);
+  };
+  for (let index = 1; index <= 1_024; index += 1) append(index);
+  const databasePath = join(projectRoot, "workflow.db");
+  const make = () => createDashboardHttpHandler({ workflowApiOptions: createProductionWorkflowApiOptions({ token: DAEMON_TOKEN, databasePath, legacyPaths: [], projectCwd: projectRoot, diagnostics: () => [], rebuildLimits: { events: 1_024 } }) });
+  let handler = make();
+  const atLimit = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "aggregate-at-limit" }));
+  expect(atLimit.response.status).toBe(200);
+  expect(atLimit.body.result).toMatchObject({ events: 1_024, streams: 1 });
+  handler.dispose();
+
+  append(1_025);
+  handler = make();
+  const overLimit = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "aggregate-over-limit" }));
+  expect(overLimit.response.status).toBe(413);
+  expect(overLimit.body.error).toMatchObject({ code: "PROJECTION_REBUILD_LIMIT" });
+  expect(overLimit.body.error.message).toMatch(/aggregate event or byte limit/i);
+  handler.dispose();
+});
+
+test("failed maintenance rebuild rolls back the replacement and leaves already-open workflow streams live", async () => {
+  closeAllSubscribers();
+  const fixture = await setup();
+  const handler = fixture.makeHandler();
+  const first = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "atomic-baseline" }));
+  expect(first.response.status).toBe(200);
+  const before = await json(handler, "/api/v1/history?limit=100");
+  const live = await handler(request("/api/v1/stream"));
+  const liveReader = live.body!.getReader();
+  expect(new TextDecoder().decode((await liveReader.read()).value)).toContain("event: hello");
+  expect(hasLiveSubscribers()).toBe(true);
+  const journal = join(fixture.projectRoot, ".pi", "hive", "sessions", pruneSession, "journal");
+  writeFileSync(join(journal, "zzzz-corrupt.json"), "{not-json}\n");
+  const failed = await json(handler, "/api/v1/maintenance/projection/rebuild", write({ operationId: "atomic-corruption" }));
+  expect(failed.response.status).toBe(400);
+  expect(failed.body.error.message).toMatch(/corrupt|journal|chain/i);
+  const after = await json(handler, "/api/v1/history?limit=100");
+  expect(after.body.items).toEqual(before.body.items);
+  expect(hasLiveSubscribers()).toBe(true);
+  broadcastWorkflowEvent({ eventId: "still-live-after-failed-maintenance" }, "failure-live-cursor");
+  const stillLive = await Promise.race([liveReader.read(), new Promise<never>((_, reject) => setTimeout(() => reject(new Error("failed maintenance closed the live stream")), 250))]);
+  expect(new TextDecoder().decode(stillLive.value)).toContain("still-live-after-failed-maintenance");
+  await liveReader.cancel();
+  handler.dispose();
+  fixture.approvalLease.release();
+  closeAllSubscribers();
+});
+
+test("production workflow synchronizer broadcasts live events with bounded subscriber lifecycle", async () => {
+  closeAllSubscribers();
+  const fixture = await setup();
+  const synchronizer = createConfiguredWorkflowProjectionSynchronizer({
+    databasePath: fixture.databasePath,
+    onEvent: (event) => broadcastWorkflowEvent(event, encodeWorkflowHistoryCursor(event)),
+  });
+  expect(synchronizer.sync([fixture.projectRoot]).active).toBe(true);
+
+  let handler = fixture.makeHandler();
+  const live = await handler(request("/api/v1/stream"));
+  const liveReader = live.body!.getReader();
+  const hello = await liveReader.read();
+  expect(new TextDecoder().decode(hello.value)).toContain("event: hello");
+  const appended = appendWorkflowEvent(fixture.projectRoot, createWorkflowEvent({ eventId: "live-production-event", projectId, sessionId: pruneSession, runId: "run-prune", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1, nodeId: "root" } }));
+  expect(synchronizer.sync([fixture.projectRoot]).events).toBe(1);
+  const liveEvent = await Promise.race([liveReader.read(), new Promise<never>((_, reject) => setTimeout(() => reject(new Error("live workflow event was not broadcast")), 250))]);
+  const liveText = new TextDecoder().decode(liveEvent.value);
+  expect(liveText).toContain("event: workflow");
+  expect(liveText).toContain(appended.eventId);
+  expect(hasLiveSubscribers()).toBe(true);
+  await liveReader.cancel();
+  expect(hasLiveSubscribers()).toBe(false);
+  handler.dispose();
+
+  handler = fixture.makeHandler({ streamLimits: { maxSubscribers: 1 } });
+  const first = await handler(request("/api/v1/stream"));
+  const firstReader = first.body!.getReader();
+  const capped = await handler(request("/api/v1/stream"));
+  expect(await capped.text()).toContain("subscriber-capacity");
+  await firstReader.cancel();
+  expect(hasLiveSubscribers()).toBe(false);
+  handler.dispose();
+
+  handler = fixture.makeHandler({ streamLimits: { bufferBytes: 512 } });
+  const slow = await handler(request("/api/v1/stream"));
+  const slowReader = slow.body!.getReader();
+  appendWorkflowEvent(fixture.projectRoot, createWorkflowEvent({ eventId: "backpressure-production-event", projectId, sessionId: pruneSession, runId: "run-prune", type: "artifact.recorded", producer: "harness", payload: { formatVersion: 1, nodeId: "root" } }));
+  expect(synchronizer.sync([fixture.projectRoot]).events).toBe(1);
+  expect(hasLiveSubscribers()).toBe(false);
+  expect(new TextDecoder().decode((await slowReader.read()).value)).toContain("event: hello");
+  expect((await slowReader.read()).done).toBe(true);
+  handler.dispose();
+
+  const timers = new Map<symbol, Readonly<{ callback: () => void; delayMs: number }>>();
+  const scheduler = {
+    setTimeout(callback: () => void, delayMs: number) { const id = Symbol("timer"); timers.set(id, { callback, delayMs }); return id; },
+    clearTimeout(timer: unknown) { timers.delete(timer as symbol); },
+  };
+  handler = fixture.makeHandler({ streamLimits: { idleMs: 100, lifetimeMs: 50, scheduler } });
+  const expiring = await handler(request("/api/v1/stream"));
+  const expiringReader = expiring.body!.getReader();
+  expect(hasLiveSubscribers()).toBe(true);
+  const lifetime = [...timers.values()].find((timer) => timer.delayMs === 50);
+  expect(lifetime).toBeDefined();
+  lifetime!.callback();
+  expect(hasLiveSubscribers()).toBe(false);
+  expect(new TextDecoder().decode((await expiringReader.read()).value)).toContain("event: hello");
+  expect((await expiringReader.read()).done).toBe(true);
+
+  handler.dispose();
+
+  // Exercise the production legacy stream's shared global cap as well; both
+  // channels participate in the daemon's idle/live-handle decision.
+  handler = fixture.makeHandler();
+  const legacyStreams: Response[] = [];
+  for (let index = 0; index < 64; index += 1) legacyStreams.push(await handler(request("/stream")));
+  const legacyCapped = await handler(request("/stream"));
+  expect(await legacyCapped.text()).toContain("subscriber-capacity");
+  await Promise.all(legacyStreams.map((response) => response.body!.cancel()));
+  expect(hasLiveSubscribers()).toBe(false);
+
+  handler.dispose();
+  synchronizer.close();
+  fixture.approvalLease.release();
+  closeAllSubscribers();
+});

--- a/tests/observability/workflow-server-db.spec.ts
+++ b/tests/observability/workflow-server-db.spec.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { toWorkflowTelemetryEvent } from "../../src/observability/events";
+import { encodeWorkflowHistoryCursor } from "../../src/observability/projection";
+import { openWorkflowProjectionDatabase } from "../../src/observability/server/workflow-db";
+import { createWorkflowEvent, sealWorkflowEvent } from "../../src/workflows/events";
+
+function stream(count: number) {
+  const events = [];
+  let previous: string | null = null;
+  for (let index = 1; index <= count; index++) {
+    const source = sealWorkflowEvent(createWorkflowEvent({
+      eventId: `event-${index}`, projectId: "project-1", sessionId: "session-1", runId: `run-${String(index).padStart(4, "0")}`,
+      type: "run.started", producer: "runtime", timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+      payload: { workflowId: index % 2 ? "build" : "review", status: "running" },
+    }), index, previous);
+    previous = source.eventHash;
+    events.push(toWorkflowTelemetryEvent(source, { projectRoot: "/project", workflowId: index % 2 ? "build" : "review" }));
+  }
+  return events;
+}
+
+test("workflow server DB pages large filtered resources stably across restart", () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-server-db-")), "workflow.db");
+  let database = openWorkflowProjectionDatabase({ path });
+  for (const event of stream(701)) database.ingest(event);
+
+  const ids: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = database.currentPage({ kind: "runs", limit: 137, cursor, projectId: "project-1", sessionId: "session-1", workflowId: "build", status: "running" });
+    ids.push(...page.items.map((row) => row.runId!));
+    cursor = page.nextCursor;
+  } while (cursor);
+  expect(ids).toHaveLength(351);
+  expect(new Set(ids).size).toBe(351);
+  expect(ids).toEqual([...ids].sort());
+
+  const history = database.history({ limit: 300, workflowId: "review", eventType: "run.started" });
+  expect(history.items).toHaveLength(300);
+  expect(history.hasMore).toBe(true);
+  database.close();
+
+  database = openWorkflowProjectionDatabase({ path });
+  const afterRestart = database.currentPage({ kind: "runs", limit: 10, workflowId: "build" });
+  expect(afterRestart.items.map((row) => row.runId)).toEqual(ids.slice(0, 10));
+  database.close();
+}, 10_000);
+
+test("workflow operation receipts atomically claim, finalize, replay after restart, and fail closed", async () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-receipts-")), "workflow.db");
+  let database = openWorkflowProjectionDatabase({ path });
+  let invocations = 0;
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  const invoke = async () => { invocations += 1; await held; return { durable: true, value: 7 }; };
+  const first = database.runOperation("projection-prune", "operation-1", "a".repeat(64), invoke);
+  const concurrent = database.runOperation("projection-prune", "operation-1", "a".repeat(64), invoke);
+  release();
+  expect(await first).toEqual({ durable: true, value: 7 });
+  expect(await concurrent).toEqual({ durable: true, value: 7 });
+  expect(invocations).toBe(1);
+  database.close();
+
+  database = openWorkflowProjectionDatabase({ path });
+  expect(await database.runOperation<{ durable: boolean; value: number }>("projection-prune", "operation-1", "a".repeat(64), async () => {
+    throw new Error("must not invoke after restart");
+  })).toEqual({ durable: true, value: 7 });
+  await expect(database.runOperation("projection-prune", "operation-1", "b".repeat(64), async () => null)).rejects.toThrow(/reuse|conflict/i);
+
+  database.database.query(`INSERT INTO workflow_operation_receipts
+    (scope, operation_id, request_hash, state, claimed_at, updated_at, response_json, response_hash)
+    VALUES (?, ?, ?, 'in_progress', ?, ?, NULL, NULL)`).run("journal-prune", "abandoned", "c".repeat(64), "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z");
+  await expect(database.runOperation("journal-prune", "abandoned", "c".repeat(64), async () => ({ unsafe: true }))).rejects.toThrow(/unknown|recovery|in.progress/i);
+  expect(database.database.query(`SELECT state FROM workflow_operation_receipts WHERE scope = ? AND operation_id = ?`).get("journal-prune", "abandoned")).toEqual({ state: "unknown" });
+  database.close();
+});
+
+test("workflow operation leases heartbeat under an injected clock and coordinate the active in-process promise", async () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-heartbeat-")), "workflow.db");
+  let clock = 0;
+  const timers = new Map<symbol, () => void>();
+  const database = openWorkflowProjectionDatabase({
+    path,
+    operationLimits: { leaseMs: 30_000, heartbeatMs: 10_000 },
+    operationRuntime: {
+      now: () => clock,
+      setInterval(callback) { const id = Symbol("heartbeat"); timers.set(id, callback); return id; },
+      clearInterval(timer) { timers.delete(timer as symbol); },
+    },
+  });
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  let invocations = 0;
+  const first = database.runOperation("projection-rebuild", "long-running", "d".repeat(64), async () => { invocations += 1; await held; return { ok: true }; });
+  clock = 31_000;
+  for (const heartbeat of timers.values()) heartbeat();
+  const duplicate = database.runOperation<{ ok: boolean }>("projection-rebuild", "long-running", "d".repeat(64), async () => { invocations += 1; return { ok: false }; });
+  expect(database.database.query(`SELECT state, owner_token IS NOT NULL AS owned, lease_expires_at FROM workflow_operation_receipts WHERE operation_id = 'long-running'`).get()).toEqual({ state: "in_progress", owned: 1, lease_expires_at: "1970-01-01T00:01:01.000Z" });
+  release();
+  expect(await first).toEqual({ ok: true });
+  expect(await duplicate).toEqual({ ok: true });
+  expect(invocations).toBe(1);
+  expect(timers.size).toBe(0);
+  database.close();
+});
+
+test("workflow operation receipts enforce count, response-byte, retention, and unknown fail-closed bounds", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-hive-workflow-receipt-bounds-"));
+  let clock = 0;
+  const path = join(root, "workflow.db");
+  let database = openWorkflowProjectionDatabase({ path, operationLimits: { count: 2, retentionMs: 100 }, operationRuntime: { now: () => clock } });
+  await database.runOperation("question", "old-a", "a".repeat(64), async () => ({ value: "a" }));
+  await database.runOperation("question", "old-b", "b".repeat(64), async () => ({ value: "b" }));
+  clock = 50;
+  await expect(database.runOperation("question", "at-capacity", "c".repeat(64), async () => null)).rejects.toMatchObject({ code: "OPERATION_RECEIPT_CAPACITY" });
+  clock = 200;
+  expect(await database.runOperation("question", "after-retention", "d".repeat(64), async () => ({ retained: true }))).toEqual({ retained: true });
+  expect(database.database.query(`SELECT COUNT(*) AS count FROM workflow_operation_receipts`).get()).toEqual({ count: 1 });
+  database.close();
+
+  database = openWorkflowProjectionDatabase({ path: join(root, "unknown.db"), operationLimits: { count: 1 }, operationRuntime: { now: () => clock } });
+  await expect(database.runOperation("approval", "unknown", "e".repeat(64), async () => { throw new Error("side effect failed"); })).rejects.toThrow(/side effect failed/i);
+  await expect(database.runOperation("approval", "new", "f".repeat(64), async () => null)).rejects.toMatchObject({ code: "OPERATION_RECEIPT_CAPACITY" });
+  database.close();
+
+  database = openWorkflowProjectionDatabase({ path: join(root, "bytes.db"), operationLimits: { responseBytes: 16, totalResponseBytes: 16 }, operationRuntime: { now: () => clock } });
+  await expect(database.runOperation("knowledge", "too-large", "1".repeat(64), async () => ({ value: "response exceeds sixteen bytes" }))).rejects.toThrow(/bounded JSON/i);
+  expect(database.database.query(`SELECT state FROM workflow_operation_receipts WHERE operation_id = 'too-large'`).get()).toEqual({ state: "unknown" });
+  database.close();
+});
+
+test("atomic projection replacement hides partial rows from concurrent readers and rolls back a mid-rebuild failure", () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-atomic-rebuild-")), "workflow.db");
+  const writer = openWorkflowProjectionDatabase({ path });
+  const old = stream(1)[0];
+  writer.ingest(old);
+  const reader = openWorkflowProjectionDatabase({ path });
+  const replacement = toWorkflowTelemetryEvent(sealWorkflowEvent(createWorkflowEvent({ eventId: "replacement", projectId: "project-new", sessionId: "session-new", runId: "run-new", type: "run.started", producer: "runtime", payload: { formatVersion: 1, status: "running" } }), 1, null), { workflowId: "new" });
+  expect(() => writer.replaceProjectionAtomically(() => {
+    writer.ingest(replacement);
+    expect(reader.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual([old.eventId]);
+    throw new Error("injected mid-rebuild failure");
+  })).toThrow(/injected mid-rebuild failure/i);
+  expect(writer.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual([old.eventId]);
+  expect(reader.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual([old.eventId]);
+  writer.replaceProjectionAtomically(() => { writer.ingest(replacement); });
+  expect(reader.history({ limit: 10 }).items.map((event) => event.eventId)).toEqual([replacement.eventId]);
+  reader.close(); writer.close();
+});
+
+test("aggregate project and workflow rows choose the deterministic latest authoritative session", () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-aggregate-latest-")), "workflow.db");
+  const database = openWorkflowProjectionDatabase({ path });
+  const event = (sessionId: string, eventId: string, timestamp: string, status: string) => toWorkflowTelemetryEvent(sealWorkflowEvent(createWorkflowEvent({
+    eventId, projectId: "project-aggregate", sessionId, runId: `run-${sessionId}`, type: "session.selected", producer: "runtime", timestamp,
+    payload: { formatVersion: 1, workflowId: "delivery", status },
+  }), 1, null), { projectRoot: "/project", workflowId: "delivery" });
+  const oldest = event("session-a", "aggregate-old", "2026-01-01T00:00:01.000Z", "running");
+  const newest = event("session-z", "aggregate-new", "2026-01-01T00:00:09.000Z", "completed");
+  database.ingest(oldest);
+  database.ingest(newest);
+  expect(database.aggregateCurrentPage("projects", { limit: 10 }).items.map((row) => row.eventId)).toEqual([newest.eventId]);
+  expect(database.aggregateCurrentPage("workflows", { limit: 10 }).items.map((row) => row.eventId)).toEqual([newest.eventId]);
+  expect(database.aggregateCurrentPage("projects", { limit: 10, status: "running" }).items).toEqual([]);
+  expect(database.aggregateCurrentPage("workflows", { limit: 10, status: "running" }).items).toEqual([]);
+  expect(database.aggregateCurrentPage("projects", { limit: 10, status: "completed" }).items.map((row) => row.eventId)).toEqual([newest.eventId]);
+  expect(database.aggregateCurrentPage("workflows", { limit: 10, status: "completed" }).items.map((row) => row.eventId)).toEqual([newest.eventId]);
+  database.close();
+});
+
+test("workflow SSE catch-up validates retained cursors, preserves order, and requires bounded resync", () => {
+  const path = join(mkdtempSync(join(tmpdir(), "pi-hive-workflow-sse-history-")), "workflow.db");
+  const database = openWorkflowProjectionDatabase({ path });
+  const events = stream(4);
+  for (const event of events) database.ingest(event);
+  expect(database.streamCatchUp(encodeWorkflowHistoryCursor(events[0]), 2)).toEqual({ state: "resync-required", reason: "catch-up-limit-exceeded" });
+  expect(database.streamCatchUp(encodeWorkflowHistoryCursor(events[1]), 2)).toEqual({ state: "ready", events: events.slice(2) });
+  database.pruneProjection("2026-01-01T00:00:02.500Z");
+  expect(database.streamCatchUp(encodeWorkflowHistoryCursor(events[0]), 2)).toEqual({ state: "resync-required", reason: "cursor-expired" });
+  expect(database.streamCatchUp("not-a-cursor", 2)).toEqual({ state: "resync-required", reason: "cursor-invalid" });
+  database.close();
+});

--- a/tests/observability/workflow-server.spec.ts
+++ b/tests/observability/workflow-server.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import type { WorkflowProjectionCurrentRow } from "../../src/observability/projection";
+import { createWorkflowApi } from "../../src/observability/server/workflow-routes";
+
+const token = "w".repeat(64);
+const origin = "http://127.0.0.1:43191";
+const row: WorkflowProjectionCurrentRow = Object.freeze({
+  projectId: "project-1", projectRoot: "/project", sessionId: "session-1", workflowId: "build", runId: "run-1",
+  eventId: "event-1", eventType: "run.started", timestamp: "2026-01-01T00:00:00.000Z", sequence: 1, status: "running",
+});
+
+function request(path: string, init: RequestInit = {}, auth = true): Request {
+  const headers = new Headers(init.headers);
+  headers.set("host", "127.0.0.1:43191");
+  if (!headers.has("x-pi-hive-api-version")) headers.set("x-pi-hive-api-version", "1");
+  if (auth) headers.set("authorization", `Bearer ${token}`);
+  return new Request(`${origin}${path}`, { ...init, headers });
+}
+
+function fixture(limits: { maxRequestsPerWindow?: number; rateWindowMs?: number; now?: () => number } = {}) {
+  const calls: Array<{ name: string; value: unknown }> = [];
+  const operations = new Map<string, { hash: string; result: unknown }>();
+  const api = createWorkflowApi({
+    token,
+    projection: {
+      currentPage(query) { calls.push({ name: "current", value: query }); return { items: [row], hasMore: false }; },
+      history(query) { calls.push({ name: "history", value: query }); return { items: [], hasMore: false }; },
+      usage(query) { calls.push({ name: "usage", value: query }); return { estimated: { inputTokens: 1, outputTokens: 2, costMicroUsd: 3 }, providerConfirmed: { inputTokens: 4, outputTokens: 5, costMicroUsd: 6 } }; },
+      status() { return { streams: [], diagnostics: [] }; },
+      stream(lastEventId) { calls.push({ name: "stream", value: lastEventId }); return new Response("event: hello\ndata: {\"apiVersion\":1}\n\n", { headers: { "content-type": "text/event-stream" } }); },
+      async runOperation(scope, id, hash, invoke) {
+        const key = `${scope}\0${id}`;
+        const prior = operations.get(key);
+        if (prior) {
+          if (prior.hash !== hash) throw new Error("operation ID reuse conflict");
+          return structuredClone(prior.result) as never;
+        }
+        const result = await invoke();
+        operations.set(key, { hash, result: structuredClone(result) });
+        return result;
+      },
+      close() {},
+    },
+    ...limits,
+    controls: {
+      readQuestion(input) { calls.push({ name: "question-detail", value: input }); return { questionId: "question-1", state: "pending", definition: { kind: "confirm", prompt: "Continue?" } }; },
+      readCheckpoint(input) { calls.push({ name: "approval-detail", value: input }); return { requestId: "approval-1", digest: `sha256:${"a".repeat(64)}` }; },
+      readKnowledge(input) { calls.push({ name: "knowledge-detail", value: input }); return { proposalId: "proposal-1", state: "pending" }; },
+      answerQuestion(input) { calls.push({ name: "question", value: input }); return { state: "answered" }; },
+      decideCheckpoint(input) { calls.push({ name: "approval", value: input }); return { decision: "approved" }; },
+      decideKnowledge(input) { calls.push({ name: "knowledge", value: input }); return { state: "approved" }; },
+      rebuildProjection(input) { calls.push({ name: "rebuild", value: input }); return { events: 10, streams: 2 }; },
+      pruneProjection(input) { calls.push({ name: "prune", value: input }); return { removed: 8, retained: 2 }; },
+      pruneJournal(input) { calls.push({ name: "journal", value: input }); return { deletedEvents: 5 }; },
+    },
+  });
+  return { api, calls };
+}
+
+async function handle(api: ReturnType<typeof createWorkflowApi>, path: string, init: RequestInit = {}, auth = true) {
+  const req = request(path, init, auth);
+  return api.handle(req, new URL(req.url));
+}
+
+function write(body: unknown, extra: HeadersInit = {}): RequestInit {
+  return { method: "POST", headers: { "content-type": "application/json", origin, "x-pi-hive-csrf": token, ...extra }, body: JSON.stringify(body) };
+}
+
+describe("workflow dashboard API v1", () => {
+  test("protects every read, rejects incompatible clients, and exposes deterministic resource pages", async () => {
+    const { api, calls } = fixture();
+    expect((await handle(api, "/api/v1/runs", {}, false))?.status).toBe(401);
+    expect((await handle(api, "/api/v1/runs", { headers: { "x-pi-hive-api-version": "2" } }))?.status).toBe(426);
+    const response = await handle(api, "/api/v1/runs?limit=500&projectId=project-1&sessionId=session-1&runId=run-1&status=running");
+    expect(response?.status).toBe(200);
+    expect(await response!.json()).toEqual({ apiVersion: 1, resource: "runs", items: [row], hasMore: false });
+    expect(calls[0].value).toMatchObject({ kind: "runs", limit: 500, projectId: "project-1", sessionId: "session-1", runId: "run-1", status: "running" });
+  });
+
+  test("serves an authenticated bounded workflow stream for cursor catch-up", async () => {
+    const { api, calls } = fixture();
+    expect((await handle(api, "/api/v1/stream", {}, false))?.status).toBe(401);
+    const response = await handle(api, "/api/v1/stream", { headers: { "last-event-id": "cursor-1" } });
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe("text/event-stream");
+    expect(calls.at(-1)).toEqual({ name: "stream", value: "cursor-1" });
+  });
+
+  test("maps all generic views and bounded activity/usage filters without plan semantics", async () => {
+    const { api, calls } = fixture();
+    for (const name of ["projects", "workflows", "sessions", "runs", "nodes", "tasks", "artifacts", "checkpoints", "questions", "approvals", "knowledge"]) {
+      expect((await handle(api, `/api/v1/${name}?limit=999999`))?.status, name).toBe(400);
+      expect((await handle(api, `/api/v1/${name}?limit=1`))?.status, name).toBe(200);
+    }
+    expect((await handle(api, "/api/v1/activity?limit=2&workflowId=build&eventType=task.started"))?.status).toBe(200);
+    expect((await handle(api, "/api/v1/usage?projectId=project-1&workflowId=build&runId=run-1&nodeId=node-1"))?.status).toBe(200);
+    expect(calls.find((call) => call.name === "history")?.value).toMatchObject({ workflowId: "build", eventType: "task.started", limit: 2 });
+    expect(calls.find((call) => call.name === "usage")?.value).toMatchObject({ projectId: "project-1", workflowId: "build", runId: "run-1", nodeId: "node-1" });
+  });
+
+  test("rejects route-specific unsupported, duplicate, excessive, and ambiguous query filters", async () => {
+    const { api, calls } = fixture();
+    expect((await handle(api, "/api/v1/runs?eventType=run.started"))?.status).toBe(400);
+    expect((await handle(api, "/api/v1/projects?nodeId=node-1"))?.status).toBe(400);
+    expect((await handle(api, "/api/v1/usage?taskId=task-1"))?.status).toBe(400);
+    expect((await handle(api, "/api/v1/runs?runId=one&runId=two"))?.status).toBe(400);
+    expect((await handle(api, `/api/v1/runs?${Array.from({ length: 17 }, (_, index) => `status=s${index}`).join("&")}`))?.status).toBe(400);
+    expect((await handle(api, `/api/v1/runs?cursor=${"x".repeat(8_193)}`))?.status).toBe(400);
+    expect((await handle(api, "/api/v1/tasks?runId=run-1&nodeId=node-1&taskId=task-1"))?.status).toBe(200);
+    expect(calls.at(-1)?.value).toMatchObject({ runId: "run-1", nodeId: "node-1", taskId: "task-1" });
+  });
+
+  test("reads exact pending control objects from authoritative validators", async () => {
+    const { api, calls } = fixture();
+    const cases = [
+      "/api/v1/questions/question-1?projectId=project-1&sessionId=session-1&runId=run-1",
+      "/api/v1/approvals/approval-1?projectId=project-1&sessionId=session-1&runId=run-1",
+      "/api/v1/knowledge/proposal-1?projectId=project-1&sessionId=session-1&runId=run-1",
+    ];
+    for (const path of cases) expect((await handle(api, path))?.status).toBe(200);
+    expect((await handle(api, "/api/v1/knowledge/proposal-1?projectId=project-1&sessionId=session-1"))?.status).toBe(400);
+    expect(calls.map((call) => call.name)).toEqual(["question-detail", "approval-detail", "knowledge-detail"]);
+  });
+
+  test("requires origin, bearer, CSRF, JSON content type, and bounded exact write DTOs", async () => {
+    const { api, calls } = fixture();
+    const body = { projectId: "project-1", sessionId: "session-1", runId: "run-1", questionId: "question-1", expectedState: "pending", value: true, operationId: "op-1", claimedIdentity: "local-user" };
+    expect((await handle(api, "/api/v1/controls/questions/answer", { ...write(body), headers: { "content-type": "application/json", origin } }))?.status).toBe(403);
+    expect((await handle(api, "/api/v1/controls/questions/answer", { ...write(body), headers: { origin, "x-pi-hive-csrf": token, "content-type": "text/plain" } }))?.status).toBe(415);
+    expect((await handle(api, "/api/v1/controls/questions/answer", { ...write({ ...body, extra: true }) }))?.status).toBe(400);
+    const response = await handle(api, "/api/v1/controls/questions/answer", write(body));
+    expect(response?.status).toBe(200);
+    expect(calls.at(-1)?.value).toMatchObject({ ...body, credential: token, channel: "dashboard" });
+    expect(JSON.stringify(calls)).not.toContain("plan");
+  });
+
+  test("routes exact checkpoint and knowledge CAS plus maintenance and journal prune", async () => {
+    const { api, calls } = fixture();
+    const cases: Array<[string, unknown, string]> = [
+      ["/api/v1/controls/approvals/decide", { projectId: "project-1", sessionId: "session-1", runId: "run-1", requestId: "approval-1", expectedRequestSequence: 4, digest: `sha256:${"a".repeat(64)}`, expectedWorkspaceHash: `sha256:${"b".repeat(64)}`, decision: "approved", operationId: "op-a" }, "approval"],
+      ["/api/v1/controls/knowledge/decide", { projectId: "project-1", sessionId: "session-1", runId: "run-1", proposalId: "proposal-1", expectedState: "pending", decision: "approve", operationId: "op-k", claimedIdentity: "local-user" }, "knowledge"],
+      ["/api/v1/maintenance/projection/rebuild", { operationId: "op-r" }, "rebuild"],
+      ["/api/v1/maintenance/projection/prune", { operationId: "op-p", cutoff: "2026-01-01T00:00:00.000Z" }, "prune"],
+      ["/api/v1/maintenance/journals/prune", { projectId: "project-1", sessionId: "session-1", operationId: "op-j", confirmIrrecoverable: true }, "journal"],
+    ];
+    for (const [path, body, call] of cases) {
+      const response = await handle(api, path, write(body));
+      expect(response?.status, path).toBe(200);
+      expect(calls.at(-1)?.name).toBe(call);
+    }
+    expect((await handle(api, "/api/v1/controls/knowledge/decide", write({ projectId: "project-1", sessionId: "session-1", proposalId: "proposal-1", expectedState: "pending", decision: "approve", operationId: "missing-run", claimedIdentity: "local-user" })))?.status).toBe(400);
+  });
+
+  test("streams request bodies with a hard cap and cancels overflow before full allocation", async () => {
+    const { api, calls } = fixture();
+    let cancelled = false;
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(40_000));
+        if (pulls > 2) controller.close();
+      },
+      cancel() { cancelled = true; },
+    });
+    const response = await handle(api, "/api/v1/controls/questions/answer", {
+      method: "POST", duplex: "half", headers: { "content-type": "application/json", origin, "x-pi-hive-csrf": token }, body: stream,
+    } as RequestInit);
+    expect(response?.status).toBe(413);
+    expect(cancelled).toBe(true);
+    expect(calls.some((call) => call.name === "question")).toBe(false);
+  });
+
+  test("bounds authenticated request rate with deterministic retry metadata", async () => {
+    const { api } = fixture({ maxRequestsPerWindow: 2, rateWindowMs: 1_000, now: () => 100 });
+    expect((await handle(api, "/api/v1/runs?limit=1"))?.status).toBe(200);
+    expect((await handle(api, "/api/v1/runs?limit=1"))?.status).toBe(200);
+    const limited = await handle(api, "/api/v1/runs?limit=1");
+    expect(limited?.status).toBe(429);
+    expect(limited?.headers.get("retry-after")).toBe("1");
+  });
+
+  test("replays identical operation IDs and rejects conflicting reuse", async () => {
+    const { api, calls } = fixture();
+    const first = { operationId: "stable-op", cutoff: "2026-01-01T00:00:00.000Z" };
+    expect((await handle(api, "/api/v1/maintenance/projection/prune", write(first)))?.status).toBe(200);
+    expect((await handle(api, "/api/v1/maintenance/projection/prune", write(first)))?.status).toBe(200);
+    expect(calls.filter((call) => call.name === "prune")).toHaveLength(1);
+    expect((await handle(api, "/api/v1/maintenance/projection/prune", write({ ...first, cutoff: "2026-02-01T00:00:00.000Z" })))?.status).toBe(409);
+  });
+});

--- a/tests/observability/workflow-telemetry.test.ts
+++ b/tests/observability/workflow-telemetry.test.ts
@@ -805,5 +805,5 @@ test("projection query cursors and in-memory limits reject each malformed bounda
   for (const limit of [0, 1.5, WORKFLOW_PROJECTION_IN_MEMORY_EVENT_LIMIT + 1]) assert.throws(() => new WorkflowTelemetryProjection({ eventLimit: limit }), /event limit is invalid/i);
   for (const limit of [0, 1.5, 501]) assert.throws(() => projection.currentPage({ kind: "sessions", limit }), /current limit/i);
   assert.throws(() => projection.currentPage({ kind: "invalid" as never, limit: 1 }), /kind is invalid/i);
-  assert.throws(() => projection.currentPage({ kind: "sessions", limit: 1, cursor: "x".repeat(8_193) }), /cursor exceeds/i);
+  assert.throws(() => projection.currentPage({ kind: "sessions", limit: 1, cursor: "x".repeat(8_193) }), /byte limit|cursor exceeds/i);
 });

--- a/tests/policy/security.test.ts
+++ b/tests/policy/security.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { applyBrowserSecurityHeaders, hasExpectedHost, isAuthorizedWrite, isSameOriginRequest, isSameOriginWrite, writeGateResponse } from "../../src/observability/security.ts";
+import { applyBrowserSecurityHeaders, hasExpectedHost, isAuthorizedCsrf, isAuthorizedWrite, isSameOriginRequest, isSameOriginWrite, writeGateResponse } from "../../src/observability/security.ts";
 
 function req(headers: Record<string, string> = {}): Request {
   return new Request("http://127.0.0.1:43191/events", { headers });
@@ -31,6 +31,14 @@ test("dashboard same-origin guard blocks cross-origin browser requests", () => {
   assert.equal(isSameOriginRequest(req({ origin: "https://evil.example" }), url), false);
   assert.equal(isSameOriginRequest(req({ "sec-fetch-site": "cross-site" }), url), false);
   assert.equal(isSameOriginWrite(req({ origin: "https://evil.example" }), url), false);
+});
+
+test("browser CSRF proof uses the daemon secret and fails closed", () => {
+  const token = "a".repeat(64);
+  assert.equal(isAuthorizedCsrf(req({ "x-pi-hive-csrf": token }), token), true);
+  assert.equal(isAuthorizedCsrf(req({ "x-pi-hive-csrf": "wrong" }), token), false);
+  assert.equal(isAuthorizedCsrf(req(), token), false);
+  assert.equal(isAuthorizedCsrf(req({ "x-pi-hive-csrf": token }), ""), false);
 });
 
 test("write auth requires the daemon token (Phase D)", () => {


### PR DESCRIPTION
## Summary
- add authenticated workflow API v1 routes and exact control operations
- add durable operation receipts, bounded maintenance, pagination, and live SSE catch-up
- integrate production question/checkpoint/knowledge controls and daemon lifecycle
- preserve legacy routes until W27 cutover

## Validation
- strict RED → GREEN → REFACTOR and five adversarial review rounds
- `just verify`: 1,154 Node tests and 119 Bun tests, all gates passed
- coverage, package, security, compatibility, and production integration gates passed

Rebase merge only.